### PR TITLE
template.js is looking for HybridRemotePage not HybridRemoteTemplate

### DIFF
--- a/HybridRemoteTemplate/bootconfig.json
+++ b/HybridRemoteTemplate/bootconfig.json
@@ -3,7 +3,7 @@
     "oauthRedirectURI": "testsfdc:///mobilesdk/detect/oauth/done",
     "oauthScopes": ["web", "api"],
     "isLocal": false,
-    "startPage": "apex/HybridRemoteTemplate",
+    "startPage": "apex/HybridRemotePage",
     "errorPage": "error.html",
     "shouldAuthenticate": true,
     "attemptOfflineLoad": false,


### PR DESCRIPTION
As a result the start page chosen by user was not put into bootconfig.json

See https://github.com/forcedotcom/SalesforceMobileSDK-Templates/blob/master/HybridRemoteTemplate/template.js#L49