### PR TITLE
Fix for xcode9/fmdb/sqlcipher/cocoapod issue

### DIFF
--- a/ReactNativeTemplate/ios/Podfile
+++ b/ReactNativeTemplate/ios/Podfile
@@ -27,13 +27,16 @@ pod 'React', :path => '../node_modules/react-native', :subspecs => [
     'RCTLinkingIOS'
 ]
 
-# NB: get rid of next line once FMDB works with xcode 9
-pod 'FMDB', :git => 'https://github.com/forcedotcom/fmdb', :branch => '2.7.2_xcode9' 
-
 pod 'SalesforceAnalytics', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceSDKCore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceReact', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 
+end
+
+# Fix for xcode9/fmdb/sqlcipher/cocoapod issue - see https://discuss.zetetic.net/t/ios-11-xcode-issue-implicit-declaration-of-function-sqlite3-key-is-invalid-in-c99/2198/27
+post_install do | installer |
+  print "SQLCipher: link Pods/Headers/sqlite3.h"
+  system "mkdir -p Pods/Headers/Private && ln -s ../../SQLCipher/sqlite3.h Pods/Headers/Private"
 end

--- a/iOSNativeSwiftTemplate/Podfile
+++ b/iOSNativeSwiftTemplate/Podfile
@@ -7,12 +7,15 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 use_frameworks!
 
-# NB: get rid of next line once FMDB works with xcode 9
-pod 'FMDB', :git => 'https://github.com/forcedotcom/fmdb', :branch => '2.7.2_xcode9' 
-
 pod 'SalesforceAnalytics', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceSDKCore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 
+end
+
+# Fix for xcode9/fmdb/sqlcipher/cocoapod issue - see https://discuss.zetetic.net/t/ios-11-xcode-issue-implicit-declaration-of-function-sqlite3-key-is-invalid-in-c99/2198/27
+post_install do | installer |
+  print "SQLCipher: link Pods/Headers/sqlite3.h"
+  system "mkdir -p Pods/Headers/Private && ln -s ../../SQLCipher/sqlite3.h Pods/Headers/Private"
 end

--- a/iOSNativeTemplate/Podfile
+++ b/iOSNativeTemplate/Podfile
@@ -7,12 +7,15 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 use_frameworks!
 
-# NB: get rid of next line once FMDB works with xcode 9
-pod 'FMDB', :git => 'https://github.com/forcedotcom/fmdb', :branch => '2.7.2_xcode9' 
-
 pod 'SalesforceAnalytics', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceSDKCore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 
+end
+
+# Fix for xcode9/fmdb/sqlcipher/cocoapod issue - see https://discuss.zetetic.net/t/ios-11-xcode-issue-implicit-declaration-of-function-sqlite3-key-is-invalid-in-c99/2198/27
+post_install do | installer |
+  print "SQLCipher: link Pods/Headers/sqlite3.h"
+  system "mkdir -p Pods/Headers/Private && ln -s ../../SQLCipher/sqlite3.h Pods/Headers/Private"
 end


### PR DESCRIPTION
See https://discuss.zetetic.net/t/ios-11-xcode-issue-implicit-declaration-of-function-sqlite3-key-is-invalid-in-c99/2198/27