### PR TITLE
Swift template now pulling in SalesforceSwiftSDK

### DIFF
--- a/iOSNativeSwiftTemplate/Podfile
+++ b/iOSNativeSwiftTemplate/Podfile
@@ -11,6 +11,8 @@ pod 'SalesforceAnalytics', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceSDKCore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
+pod 'SalesforceSwiftSDK', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
+pod 'PromiseKit', :git => 'https://github.com/mxcl/PromiseKit', :tag => '5.0.3'
 
 end
 


### PR DESCRIPTION
Note: it compiles and runs but it's not yet using the new rest api wrappers