### PR TITLE
Fixing bug with assembleRelease

### DIFF
--- a/ReactNativeTemplate/android/app/build.gradle
+++ b/ReactNativeTemplate/android/app/build.gradle
@@ -65,6 +65,10 @@ import com.android.build.OutputFile
  * ]
  */
 
+project.ext.react = [
+    entryFile: "index.js"
+]
+
 apply from: "../../node_modules/react-native/react.gradle"
 
 /**

--- a/ReactNativeTemplate/android/gradle.properties
+++ b/ReactNativeTemplate/android/gradle.properties
@@ -18,3 +18,4 @@
 # org.gradle.parallel=true
 
 android.useDeprecatedNdk=true
+android.enableAapt2=false

--- a/ReactNativeTemplate/installandroid.js
+++ b/ReactNativeTemplate/installandroid.js
@@ -4,17 +4,18 @@ var packageJson = require('./package.json')
 var execSync = require('child_process').execSync;
 var path = require('path');
 var fs = require('fs');
-
+var rimraf = require('rimraf');
 console.log('Installing sdk dependencies');
 var sdkDependency = 'SalesforceMobileSDK-Android';
 var repoUrlWithBranch = packageJson.sdkDependencies[sdkDependency];
 var parts = repoUrlWithBranch.split('#'), repoUrl = parts[0], branch = parts.length > 1 ? parts[1] : 'master';
 var targetDir = path.join('mobile_sdk', sdkDependency);
-if (fs.existsSync(targetDir))
+if (fs.existsSync(targetDir)) {
     console.log(targetDir + ' already exists - if you want to refresh it, please remove it and re-run install.js');
-else
+} else {
     execSync('git clone --branch ' + branch + ' --single-branch --depth 1 ' + repoUrl + ' ' + targetDir, {stdio:[0,1,2]});
-
+    rimraf.sync(path.join('mobile_sdk', 'salesforcemobilesdk-android', 'hybrid'));
+    rimraf.sync(path.join('mobile_sdk', 'salesforcemobilesdk-android', 'libs', 'test'));
+}
 console.log('Installing npm dependencies');
 execSync('npm install', {stdio:[0,1,2]});
-

--- a/ReactNativeTemplate/installandroid.js
+++ b/ReactNativeTemplate/installandroid.js
@@ -4,9 +4,9 @@ var packageJson = require('./package.json')
 var execSync = require('child_process').execSync;
 var path = require('path');
 var fs = require('fs');
-var rimraf = require('rimraf');
 console.log('Installing npm dependencies');
 execSync('npm install', {stdio:[0,1,2]});
+var rimraf = require('rimraf');
 console.log('Installing sdk dependencies');
 var sdkDependency = 'SalesforceMobileSDK-Android';
 var repoUrlWithBranch = packageJson.sdkDependencies[sdkDependency];

--- a/ReactNativeTemplate/installandroid.js
+++ b/ReactNativeTemplate/installandroid.js
@@ -5,6 +5,8 @@ var execSync = require('child_process').execSync;
 var path = require('path');
 var fs = require('fs');
 var rimraf = require('rimraf');
+console.log('Installing npm dependencies');
+execSync('npm install', {stdio:[0,1,2]});
 console.log('Installing sdk dependencies');
 var sdkDependency = 'SalesforceMobileSDK-Android';
 var repoUrlWithBranch = packageJson.sdkDependencies[sdkDependency];
@@ -17,5 +19,3 @@ if (fs.existsSync(targetDir)) {
     rimraf.sync(path.join('mobile_sdk', 'salesforcemobilesdk-android', 'hybrid'));
     rimraf.sync(path.join('mobile_sdk', 'salesforcemobilesdk-android', 'libs', 'test'));
 }
-console.log('Installing npm dependencies');
-execSync('npm install', {stdio:[0,1,2]});

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -20,6 +20,7 @@
         "preset": "jest-react-native"
     },
     "devDependencies": {
+        "rimraf": "2.6.2",
         "babel-jest": "16.0.0",
         "babel-preset-react-native": "1.9.1",
         "jest": "19.0.2",


### PR DESCRIPTION
- We need to explicitly override the value of `entryFile` in `react.gradle` -> it defaults to `index.android.js`, but we use a unified `index.js`.
- Removing the directories with rogue symlinks that break `assembleRelease` with `rimraf`.