### PR TITLE
Replace Commented code for SFLoginViewController customization

### DIFF
--- a/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.m
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.m
@@ -97,20 +97,17 @@ static NSString * const OAuthRedirectURI        = @"testsfdc:///mobilesdk/detect
     self.launchOptions = launchOptions;
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     [self initializeAppViewState];
-    
-    //
-    //Uncomment the code below to see how you can customize the color, textcolor, font and fontsize of the navigation bar
-    //
-    //SFLoginViewController *loginViewController = [SFLoginViewController sharedInstance];
-    //Set showNavBar to NO if you want to hide the top bar
-    //loginViewController.showNavbar = YES;
+
+    //Uncomment the code below to see how you can customize the color, textcolor, font and   fontsize of the navigation bar
+    //SFSDKLoginViewControllerConfig *loginViewConfig = [[SFSDKLoginViewControllerConfig  alloc] init];
     //Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar
-    //loginViewController.showSettingsIcon = YES;
-    // Set primary color to different color to style the navigation header
-    //loginViewController.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
-    //loginViewController.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
-    //loginViewController.navBarTextColor = [UIColor blackColor];
-    //
+    //loginViewConfig.showSettingsIcon = YES;
+    //Set showNavBar to NO if you want to hide the top bar
+    //loginViewConfig.showNavbar = YES;
+    //loginViewConfig.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
+    //loginViewConfig.navBarTextColor = [UIColor whiteColor];
+    //loginViewConfig.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
+    //[SFUserAccountManager sharedInstance].loginViewControllerConfig = loginViewConfig;
 
     [[SalesforceSDKManager sharedManager] launch];
     return YES;

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
@@ -80,28 +80,24 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.initializeAppViewState();
         
-        //
         // If you wish to register for push notifications, uncomment the line below.  Note that,
         // if you want to receive push notifications from Salesforce, you will also need to
         // implement the application:didRegisterForRemoteNotificationsWithDeviceToken: method (below).
         //
         // SFPushNotificationManager.sharedInstance().registerForRemoteNotifications()
         
-        //
         //Uncomment the code below to see how you can customize the color, textcolor, font and fontsize of the navigation bar
-        //
-        // let loginViewController = SFLoginViewController.sharedInstance();
-        //Set showNavBar to NO if you want to hide the top bar
-        // loginViewController.showNavbar = true;
+        //var loginViewConfig = SFSDKLoginViewControllerConfig()
         //Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar
-        // loginViewController.showSettingsIcon = true;
-        // Set primary color to different color to style the navigation header
-        // loginViewController.navBarColor = UIColor(red: 0.051, green: 0.765, blue: 0.733, alpha: 1.0);
-        // loginViewController.navBarFont = UIFont (name: "Helvetica Neue", size: 16);
-        // loginViewController.navBarTextColor = UIColor.black;
-        //
-        SalesforceSwiftSDKManager.shared().launch()
+        //loginViewConfig.showSettingsIcon = false
+        //Set showNavBar to NO if you want to hide the top bar
+        //loginViewConfig.showNavbar = true
+        //loginViewConfig.navBarColor = UIColor(red: 0.051, green: 0.765, blue: 0.733, alpha: 1.0)
+        //loginViewConfig.navBarTextColor = UIColor.white
+        //loginViewConfig.navBarFont = UIFont(name: "Helvetica", size: 16.0)
+        //SFUserAccountManager.sharedInstance().loginViewControllerConfig = loginViewConfig
         
+        SalesforceSwiftSDKManager.shared().launch()
         return true
     }
     

--- a/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
+++ b/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
@@ -108,20 +108,17 @@ static NSString * const OAuthRedirectURI        = @"testsfdc:///mobilesdk/detect
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     [self initializeAppViewState];
     
-    //
-    //Uncomment the code below to see how you can customize the color, textcolor, font and fontsize of the navigation bar
-    //
-    //SFLoginViewController *loginViewController = [SFLoginViewController sharedInstance];
-    //Set showNavBar to NO if you want to hide the top bar
-    //loginViewController.showNavbar = YES;
+    //Uncomment the code below to see how you can customize the color, textcolor, font and   fontsize of the navigation bar
+    //SFSDKLoginViewControllerConfig *loginViewConfig = [[SFSDKLoginViewControllerConfig  alloc] init];
     //Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar
-    //loginViewController.showSettingsIcon = YES;
-    // Set primary color to different color to style the navigation header
-    //loginViewController.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
-    //loginViewController.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
-    //loginViewController.navBarTextColor = [UIColor blackColor];
-    //
-
+    //loginViewConfig.showSettingsIcon = YES;
+    //Set showNavBar to NO if you want to hide the top bar
+    //loginViewConfig.showNavbar = YES;
+    //loginViewConfig.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
+    //loginViewConfig.navBarTextColor = [UIColor whiteColor];
+    //loginViewConfig.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
+    //[SFUserAccountManager sharedInstance].loginViewControllerConfig = loginViewConfig;
+    
     [[SmartSyncSDKManager sharedManager] launch];
     return YES;
 }

--- a/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
+++ b/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
@@ -33,6 +33,7 @@
 #import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <SmartSync/SmartSyncSDKManager.h>
 #import <SalesforceSDKCore/SFLoginViewController.h>
+#import <SalesforceSDKCore/SFSDKLoginViewControllerConfig.h>
 
 // Fill these in when creating a new Connected Application on Force.com
 static NSString * const RemoteAccessConsumerKey = @"3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa";


### PR DESCRIPTION
Replace Commented code for SFLoginViewController customization. Moved code to use the following instead.

```
SFSDKLoginViewControllerConfig *loginViewConfig = [[SFSDKLoginViewControllerConfig  alloc] init];
loginViewConfig.showSettingsIcon = NO;
loginViewConfig.showNavbar = YES;
loginViewConfig.navBarColor = [UIColor redColor];
loginViewConfig.navBarTextColor = [UIColor whiteColor];
loginViewConfig.navBarFont = [UIFont boldSystemFontOfSize:20.0f];
[SFUserAccountManager sharedInstance].loginViewControllerConfig = loginViewConfig;
```