### PR TITLE
Removing explicit PromiseKit dependency in Podfile

### DIFF
--- a/SmartSyncExplorerSwift/Podfile
+++ b/SmartSyncExplorerSwift/Podfile
@@ -12,7 +12,6 @@ pod 'SalesforceSDKCore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceSwiftSDK', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
-pod 'PromiseKit', :git => 'https://github.com/mxcl/PromiseKit', :tag => '5.0.3'
 
 end
 

--- a/iOSIDPTemplate/Podfile
+++ b/iOSIDPTemplate/Podfile
@@ -12,7 +12,6 @@ pod 'SalesforceSDKCore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceSwiftSDK', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
-pod 'PromiseKit', :git => 'https://github.com/mxcl/PromiseKit', :tag => '5.0.3'
 pod 'WYPopoverController', :git => 'https://github.com/sammcewan/WYPopoverController', :tag => '0.3.8'
 pod 'SwipeCellKit', :git => 'https://github.com/SwipeCellKit/SwipeCellKit.git', :tag => '2.0.0'
 

--- a/iOSNativeSwiftTemplate/Podfile
+++ b/iOSNativeSwiftTemplate/Podfile
@@ -12,7 +12,6 @@ pod 'SalesforceSDKCore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceSwiftSDK', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
-pod 'PromiseKit', :git => 'https://github.com/mxcl/PromiseKit', :tag => '5.0.3'
 
 end
 


### PR DESCRIPTION
We do not need this dependency in the Podfile. It should be pulled transitively.