### PR TITLE
Using promises when synching

### DIFF
--- a/BaristaSwift/Common/Common/Store/FavoritesStore.swift
+++ b/BaristaSwift/Common/Common/Store/FavoritesStore.swift
@@ -31,6 +31,7 @@ import Foundation
 import SalesforceSwiftSDK
 import SmartStore
 import SmartSync
+import PromiseKit
 
 public class FavoritesStore: Store<UserFavorite> {
     public static let instance = FavoritesStore()
@@ -47,11 +48,17 @@ public class FavoritesStore: Store<UserFavorite> {
         return UserFavorite.from(results)
     }
     
-    public func addNewFavorite(_ forProduct:Product, completion:SyncCompletion) {
-        guard let account = AccountStore.instance.myAccount(), let accountId = account.accountId else { return }
+    public func addNewFavorite(_ forProduct:Product) -> Promise<UserFavorite> {
+        guard let account = AccountStore.instance.myAccount(), let accountId = account.accountId else {
+            return Promise(error: FavoritesErrors.noAccount)
+        }
         let fav = UserFavorite()
         fav.productId = forProduct.id
         fav.accountId = accountId
-        self.createEntry(entry: fav, completion: completion)
+        return self.createEntry(entry: fav)
+    }
+    
+    enum FavoritesErrors : Error {
+        case noAccount
     }
 }

--- a/BaristaSwift/Common/Common/Store/OrderItemStore.swift
+++ b/BaristaSwift/Common/Common/Store/OrderItemStore.swift
@@ -31,6 +31,7 @@ import Foundation
 import SalesforceSwiftSDK
 import SmartStore
 import SmartSync
+import PromiseKit
 
 public class OrderItemStore: Store<OrderItem> {
     public static let instance = OrderItemStore()
@@ -63,11 +64,11 @@ public class OrderItemStore: Store<OrderItem> {
         return OrderItem.from(results)
     }
     
-    public func syncDownItems(for order:Order, completion: SyncCompletion = nil) {
+    public func syncDownItems(for order:Order) -> Promise<SFSyncState> {
         let queryString = self.orderItemsQueryString(for: order)
         let target = SFSoqlSyncDownTarget.newSyncTarget(queryString)
         let options = SFSyncOptions.newSyncOptions(forSyncDown: .leaveIfChanged)
-        smartSync.syncDown(with: target, options: options, soupName: OrderItem.objectName, update: completion ?? { _ in return })
+        return smartSync.Promises.syncDown(target: target, options: options, soupName: OrderItem.objectName)
     }
     
     public override func records() -> [OrderItem] {

--- a/BaristaSwift/Common/Common/Store/QuoteLineItemStore.swift
+++ b/BaristaSwift/Common/Common/Store/QuoteLineItemStore.swift
@@ -31,6 +31,7 @@ import Foundation
 import SalesforceSwiftSDK
 import SmartStore
 import SmartSync
+import PromiseKit
 
 public class QuoteLineItemStore: Store<QuoteLineItem> {
     public static let instance = QuoteLineItemStore()
@@ -57,7 +58,7 @@ public class QuoteLineItemStore: Store<QuoteLineItem> {
         return QuoteLineItem.from(results)
     }
     
-    public func create(_ lineItem:QuoteLineItem, completion:SyncCompletion) {
-        self.createEntry(entry: lineItem, completion: completion)
+    public func create(_ lineItem:QuoteLineItem) -> Promise<QuoteLineItem> {
+        return self.createEntry(entry: lineItem)
     }
 }

--- a/BaristaSwift/Common/Common/Store/QuoteStore.swift
+++ b/BaristaSwift/Common/Common/Store/QuoteStore.swift
@@ -31,6 +31,7 @@ import Foundation
 import SalesforceSwiftSDK
 import SmartStore
 import SmartSync
+import PromiseKit
 
 public class QuoteStore: Store<Quote> {
     public static let instance = QuoteStore()
@@ -46,8 +47,8 @@ public class QuoteStore: Store<Quote> {
         return Quote.from(results)
     }
     
-    public func create(_ quote:Quote, completion:SyncCompletion) {
-        self.createEntry(entry: quote, completion: completion)
+    public func create(_ quote:Quote) -> Promise<Quote> {
+        return self.createEntry(entry: quote)
     }
     
     public func quoteFromId(_ quoteId:String) -> Quote? {

--- a/BaristaSwift/Consumer/Consumer/AppDelegate.swift
+++ b/BaristaSwift/Consumer/Consumer/AppDelegate.swift
@@ -35,6 +35,7 @@ import SmartSync
 import Fabric
 import Crashlytics
 import Common
+import PromiseKit
 
 // Fill these in when creating a new Connected Application on Force.com
 // Primary
@@ -54,7 +55,8 @@ class AppDelegate : UIResponder, UIApplicationDelegate
     
     override init() {
         super.init()
-        
+        SalesforceSwiftLogger.setLogLevel(.debug)
+
         SalesforceSwiftSDKManager.initSDK()
             .Builder.configure { (appconfig: SFSDKAppConfig) -> Void in
                 appconfig.oauthScopes = ["web", "api"]
@@ -73,39 +75,22 @@ class AppDelegate : UIResponder, UIApplicationDelegate
             .postLaunch {  [unowned self] (launchActionList: SFSDKLaunchAction) in
                 let launchActionString = SalesforceSwiftSDKManager.launchActionsStringRepresentation(launchActionList)
                 SalesforceSwiftLogger.log(type(of:self), level:.info, message:"Post-launch: launch actions taken: \(launchActionString)")
-                if let currentUserId = SFUserAccountManager.sharedInstance().currentUserIdentity?.userId {
-                    AccountStore.instance.syncDown(completion: { (syncState) in
-                        if let complete = syncState?.isDone(), complete == true {
-                            if let _ = AccountStore.instance.account(currentUserId) {
-                                DispatchQueue.main.async {
-                                    self.beginSyncDown {
-                                        self.setupRootViewController()
-                                    }
-                                }
-                            } else {
-                                guard let user = SFUserAccountManager.sharedInstance().currentUser else {return}
-                                let newAccount = Account()
-                                newAccount.accountNumber = user.accountIdentity.userId
-                                newAccount.name = user.userName
-                                newAccount.ownerId = user.accountIdentity.userId
-                                AccountStore.instance.create(newAccount, completion: { (syncState) in
-                                    if let complete = syncState?.isDone(), complete == true {
-                                        DispatchQueue.main.async {
-                                            self.beginSyncDown {
-                                                self.setupRootViewController()
-                                            }
-                                        }
-                                    }
-                                })
+                if let _ = SFUserAccountManager.sharedInstance().currentUserIdentity?.userId {
+                    _ = AccountStore.instance.syncDown()
+                        .then { _ -> Promise<Account> in
+                            return AccountStore.instance.getOrCreateMyAccount()
+                        }
+                        .then { _ -> Promise<Void> in
+                            return self.beginSyncDown()
+                        }
+                        .done { _ in
+                            DispatchQueue.main.async {
+                                self.setupRootViewController()
                             }
                         }
-                    })
-                    
                 } else {
                     SFUserAccountManager.sharedInstance().logout()
                 }
-                
-                SalesforceSwiftLogger.setLogLevel(.error)
             }.postLogout {  [unowned self] in
                 self.handleSdkManagerLogout()
             }.switchUser{ [unowned self] (fromUser: SFUserAccount?, toUser: SFUserAccount?) -> () in
@@ -204,38 +189,41 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         self.window?.rootViewController = initialViewController
     }
     
-    func beginSyncDown(completion:@escaping () -> Void) {
+    func beginSyncDown() -> Promise<Void> {
         let progressView = SyncProgressViewController()
         self.window?.rootViewController = progressView
         
-        let storeCount = 12
+        let syncFuncs : [() -> Promise<Void>] = [
+            CategoryStore.instance.syncDown,
+            ProductStore.instance.syncDown,
+            ProductOptionStore.instance.syncDown,
+            ProductCategoryAssociationStore.instance.syncDown,
+            OrderStore.instance.syncDown,
+            OrderItemStore.instance.syncDown,
+            QuoteStore.instance.syncDown,
+            QuoteLineItemStore.instance.syncDown,
+            QuoteLineGroupStore.instance.syncDown,
+            OpportunityStore.instance.syncDown,
+            PricebookStore.instance.syncDown,
+            FavoritesStore.instance.syncDown
+        ]
+
         var syncedCount = 0
-        let syncCompletion:((SFSyncState?) -> Void) = { (syncState) in
-            if let complete = syncState?.isDone(), complete == true {
-                syncedCount = syncedCount + 1
-            }
+        let updateProgressView = { () -> Promise<Void> in
+            syncedCount = syncedCount + 1
             
-            let completed = Float(syncedCount)/Float(storeCount)
+            let completed = Float(syncedCount)/Float(syncFuncs.count)
             DispatchQueue.main.async {
                 progressView.updateProgress(completed * 100.0)
-                if syncedCount == storeCount {
-                    completion()
-                }
             }
+            return Promise.value(())
+        }
+                
+        let syncs : [Promise<Void>] = syncFuncs.map { syncFunc in
+            return syncFunc().then { updateProgressView() }
         }
         
-        CategoryStore.instance.syncDown(completion: syncCompletion)
-        ProductStore.instance.syncDown(completion: syncCompletion)
-        ProductOptionStore.instance.syncDown(completion: syncCompletion)
-        ProductCategoryAssociationStore.instance.syncDown(completion: syncCompletion)
-        OrderStore.instance.syncDown(completion: syncCompletion)
-        OrderItemStore.instance.syncDown(completion: syncCompletion)
-        QuoteStore.instance.syncDown(completion: syncCompletion)
-        QuoteLineItemStore.instance.syncDown(completion: syncCompletion)
-        QuoteLineGroupStore.instance.syncDown(completion: syncCompletion)
-        OpportunityStore.instance.syncDown(completion: syncCompletion)
-        PricebookStore.instance.syncDown(completion: syncCompletion)
-        FavoritesStore.instance.syncDown(completion: syncCompletion)
+        return when(fulfilled: syncs)
     }
     
     func resetViewState(_ postResetBlock: @escaping () -> ())

--- a/BaristaSwift/Consumer/Consumer/ViewController/CartViewController.swift
+++ b/BaristaSwift/Consumer/Consumer/ViewController/CartViewController.swift
@@ -29,6 +29,7 @@
 
 import UIKit
 import Common
+import PromiseKit
 
 class CartViewController: BaseViewController {
     
@@ -85,10 +86,11 @@ class CartViewController: BaseViewController {
         let activity = ActivityIndicatorView(frame: .zero)
         activity.showIn(self.view)
         activity.startAnimating()
-        self.cartStore.submitOrder { (completed) in
+        
+        let showAlert = { (successful : Bool) -> Void in
             DispatchQueue.main.async {
                 var alert:UIAlertController!
-                if completed == true {
+                if successful {
                     alert = UIAlertController(title: "Submitted", message: "Your order has been succesfully placed. Thank You.", preferredStyle: .alert)
                 } else {
                     alert = UIAlertController(title: "Error", message: "There was a problem submitting your order, please try again. Thank You.", preferredStyle: .alert)
@@ -100,6 +102,14 @@ class CartViewController: BaseViewController {
                 self.present(alert, animated: true, completion: nil)
             }
         }
+        
+        self.cartStore.submitOrder()
+            .done { _ in
+                showAlert(true)
+            }
+            .catch { _ in
+                showAlert(false)
+            }
     }
 
     override func didReceiveMemoryWarning() {

--- a/BaristaSwift/Consumer/Consumer/ViewController/FavoritesViewController.swift
+++ b/BaristaSwift/Consumer/Consumer/ViewController/FavoritesViewController.swift
@@ -29,6 +29,7 @@
 
 import UIKit
 import Common
+import PromiseKit
 
 class FavoritesViewController: UIViewController {
     
@@ -70,14 +71,13 @@ class FavoritesViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        FavoritesStore.instance.syncDown { (syncState) in
-            if let complete = syncState?.isDone(), complete == true {
+        _ = FavoritesStore.instance.syncDown()
+            .done { _ in
                 DispatchQueue.main.async {
                     self.favorites = FavoritesStore.instance.myFavorites()
                     self.tableView.reloadData()
                 }
             }
-        }
     }
 
     override func didReceiveMemoryWarning() {

--- a/BaristaSwift/Consumer/Consumer/ViewController/FeaturedViewController.swift
+++ b/BaristaSwift/Consumer/Consumer/ViewController/FeaturedViewController.swift
@@ -30,6 +30,7 @@
 import UIKit
 import Common
 import SalesforceSwiftSDK
+import PromiseKit
 
 class FeaturedViewController: UIViewController {
 
@@ -75,19 +76,15 @@ class FeaturedViewController: UIViewController {
     }
 
     @objc func updateFeaturedProducts() {
-        ProductStore.instance.syncDown { (syncState) in
-            SalesforceSwiftLogger.log(type(of:self), level:.info, message:"syncing down")
-            if let complete = syncState?.isDone(), complete == true {
-                SalesforceSwiftLogger.log(type(of:self), level:.info, message:"syncing completed")
+        _ = ProductStore.instance.syncDown()
+            .done { _ in
                 DispatchQueue.main.async {
                     self.refreshControl.endRefreshing()
                     self.featuredProducts = ProductStore.instance.featuredProducts()
                     self.featuredProductTableView.reloadData()
                 }
             }
-        }
     }
-
 }
 
 extension FeaturedViewController: UITableViewDataSource, UITableViewDelegate {

--- a/BaristaSwift/Consumer/Consumer/ViewController/ProductConfigureViewController.swift
+++ b/BaristaSwift/Consumer/Consumer/ViewController/ProductConfigureViewController.swift
@@ -29,6 +29,7 @@
 
 import UIKit
 import Common
+import PromiseKit
 
 class ProductConfigureViewController: UIViewController {
 
@@ -153,31 +154,30 @@ class ProductConfigureViewController: UIViewController {
         activity.centerXAnchor.constraint(equalTo: self.favoriteButton.centerXAnchor).isActive = true
         activity.centerYAnchor.constraint(equalTo: self.favoriteButton.centerYAnchor).isActive = true
         activity.startAnimating()
-        FavoritesStore.instance.addNewFavorite(product) { (syncState) in
-            if let complete = syncState?.isDone(), complete == true {
+        _ = FavoritesStore.instance.addNewFavorite(product)
+            .done { _ in
                 DispatchQueue.main.async {
                     activity.stopAnimating()
                     activity.removeFromSuperview()
                     self.favoriteButton.alpha = 1.0
                 }
             }
-        }
     }
     
     @IBAction func didPressAddToCartButton(_ sender: UIButton) {
         let activity = ActivityIndicatorView(frame: .zero)
         activity.showIn(self.view)
         activity.startAnimating()
-        LocalCartStore.instance.commitToCart { (completedSuccessfully) in
-            DispatchQueue.main.async {
-                if completedSuccessfully {
-                    self.close()
-                } else {
+        LocalCartStore.instance.commitToCart()
+            .done { _ in
+                self.close()
+            }
+            .catch { _ in
+                DispatchQueue.main.async {
                     let alert = UIAlertController(title: "Error", message: "Could not add items to cart, please verify your selections and try again.", preferredStyle: .alert)
                     self.present(alert, animated: true, completion: nil)
                 }
             }
-        }
     }
     
     @IBAction func didPressCancelButton(_ sender: UIButton) {

--- a/BaristaSwift/Provider/Provider/AppDelegate.swift
+++ b/BaristaSwift/Provider/Provider/AppDelegate.swift
@@ -34,6 +34,7 @@ import SmartSync
 import Fabric
 import Crashlytics
 import Common
+import PromiseKit
 
 // Primary
 // SFDCOAuthLoginHost - app-data-4945-dev-ed.cs62.my.salesforce.com
@@ -51,6 +52,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     override init() {
         super.init()
+        
+        SalesforceSwiftLogger.setLogLevel(.debug)
         
         SalesforceSwiftSDKManager.initSDK()
             .Builder.configure { (appconfig: SFSDKAppConfig) -> Void in
@@ -70,39 +73,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .postLaunch {  [unowned self] (launchActionList: SFSDKLaunchAction) in
                 let launchActionString = SalesforceSwiftSDKManager.launchActionsStringRepresentation(launchActionList)
                 SalesforceSwiftLogger.log(type(of:self), level:.info, message:"Post-launch: launch actions taken: \(launchActionString)")
-                if let currentUserId = SFUserAccountManager.sharedInstance().currentUserIdentity?.userId {
-                    AccountStore.instance.syncDown(completion: { (syncState) in
-                        if let complete = syncState?.isDone(), complete == true {
-                            if let _ = AccountStore.instance.account(currentUserId) {
-                                DispatchQueue.main.async {
-                                    self.beginSyncDown {
-                                        self.setupRootViewController()
-                                    }
-                                }
-                            } else {
-                                guard let user = SFUserAccountManager.sharedInstance().currentUser else {return}
-                                let newAccount = Account()
-                                newAccount.accountNumber = user.accountIdentity.userId
-                                newAccount.name = user.userName
-                                newAccount.ownerId = user.accountIdentity.userId
-                                AccountStore.instance.create(newAccount, completion: { (syncState) in
-                                    if let complete = syncState?.isDone(), complete == true {
-                                        DispatchQueue.main.async {
-                                            self.beginSyncDown {
-                                                self.setupRootViewController()
-                                            }
-                                        }
-                                    }
-                                })
+                if let _ = SFUserAccountManager.sharedInstance().currentUserIdentity?.userId {
+                    _ = AccountStore.instance.syncDown()
+                        .then { _ -> Promise<Account> in
+                            return AccountStore.instance.getOrCreateMyAccount()
+                        }
+                        .then { _ -> Promise<Void> in
+                            return self.beginSyncDown()
+                        }
+                        .done { _ in
+                            DispatchQueue.main.async {
+                                self.setupRootViewController()
                             }
                         }
-                    })
-                    
                 } else {
                     SFUserAccountManager.sharedInstance().logout()
                 }
-                
-                SalesforceSwiftLogger.setLogLevel(.error)
             }.postLogout {  [unowned self] in
                 self.handleSdkManagerLogout()
             }.switchUser{ [unowned self] (fromUser: SFUserAccount?, toUser: SFUserAccount?) -> () in
@@ -185,8 +171,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window?.rootViewController = ViewController(nibName: nil, bundle: nil)
     }
     
-    func beginSyncDown(completion:@escaping () -> Void) {
-        LocalOrderStore.instance.fullSyncDown(completion: completion)
+    func beginSyncDown() -> Promise<Void> {
+        let syncs : [Promise<Void>] = [
+            UserStore.instance.syncDown(),
+            AccountStore.instance.syncDown(),
+            ProductStore.instance.syncDown(),
+            ProductOptionStore.instance.syncDown(),
+            QuoteStore.instance.syncDown(),
+            QuoteLineItemStore.instance.syncDown(),
+            QuoteLineGroupStore.instance.syncDown(),
+            OpportunityStore.instance.syncDown(),
+            PricebookStore.instance.syncDown()
+        ]
+        
+        return when(fulfilled: syncs)
     }
     
     func resetViewState(_ postResetBlock: @escaping () -> ()) {


### PR DESCRIPTION
Refactored Store.swift (base class for all Store objects) to use promises when synching.
As a result, had to refactor the callers (and their callers etc) as well.
That caused error handling to be simplified (if any error happens, the promise is "failed" - so in case of success the promise resolves with the expected object).

See comments in PR for more details.