### PR TITLE
On updates only syncing up

### DIFF
--- a/BaristaSwift/Common/Common/Base/Store.swift
+++ b/BaristaSwift/Common/Common/Base/Store.swift
@@ -113,7 +113,7 @@ public class Store<objectType: StoreProtocol> {
 
     public func createEntry(entry: objectType) -> Promise<objectType> {
         _ = locallyCreateEntry(entry: entry)
-        return syncUpDown()
+        return syncUp()
             .then { _ -> Promise<objectType> in
                 if let record = self.record(forExternalId: entry.externalId) {
                     return Promise.value(record)
@@ -125,7 +125,7 @@ public class Store<objectType: StoreProtocol> {
     
     public func updateEntry(entry: objectType) -> Promise<objectType> {
         _ = locallyUpdateEntry(entry: entry)
-        return syncUpDown()
+        return syncUp()
             .then { _ -> Promise<objectType> in
                 if let record = self.record(forExternalId: entry.externalId) {
                     return Promise.value(record)
@@ -137,14 +137,14 @@ public class Store<objectType: StoreProtocol> {
     
     public func deleteEntry(entry: objectType) -> Promise<Void> {
         locallyDeleteEntry(entry: entry)
-        return syncUpDown()
+        return syncUp()
     }
 
     public func syncEntry(entry: objectType) -> Promise<Void> {
         var record: objectType = entry
         record.objectType = objectType.objectName
         _ = upsertEntries([record.data])
-        return syncUpDown()
+        return syncUp()
     }
 
     private func reSync(syncName: String) -> Promise<Void> {
@@ -168,10 +168,6 @@ public class Store<objectType: StoreProtocol> {
     
     public func syncUp() -> Promise<Void> {
         return reSync(syncName: syncUpName)
-    }
-    
-    public func syncUpDown() -> Promise<Void> {
-        return self.syncUp().then { self.syncDown() }
     }
     
     internal func upsertEntries(_ entries:[Any]) -> [Any] {

--- a/BaristaSwift/Common/Common/Store/LocalCartStore.swift
+++ b/BaristaSwift/Common/Common/Store/LocalCartStore.swift
@@ -174,7 +174,7 @@ public class LocalCartStore {
         }
         let lineGroups = QuoteLineGroupStore.instance.lineGroupsForQuote(quoteId)
         
-        return QuoteLineGroupStore.instance.syncUpDown()
+        return QuoteLineGroupStore.instance.syncUp()
             .then { _ -> Promise<Void> in
                 for lineGroup in lineGroups {
                     guard let lineGroupExternalId = lineGroup.externalId,
@@ -187,7 +187,7 @@ public class LocalCartStore {
                         _ = QuoteLineItemStore.instance.locallyUpdateEntry(entry: line)
                     }
                 }
-                return QuoteLineItemStore.instance.syncUpDown()
+                return QuoteLineItemStore.instance.syncUp()
             }
     }
     

--- a/BaristaSwift/Provider/Provider/View Controller/ViewController.swift
+++ b/BaristaSwift/Provider/Provider/View Controller/ViewController.swift
@@ -226,5 +226,10 @@ extension ViewController: UITableViewDataSource {
         let config = UISwipeActionsConfiguration(actions: [completeAction])
         return config
     }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let config = UISwipeActionsConfiguration(actions: [])
+        return config
+    }
 }
 


### PR DESCRIPTION
Now that we are logging timings around db queries/upserts and syncs, the bulk of the time is spent synching. 

To update server with local changes, there is no point doing a sync up followed by a sync down.
A sync up should suffice.