### PR TITLE
Logout handling

### DIFF
--- a/BaristaSwift/Common/Common/Base/Store.swift
+++ b/BaristaSwift/Common/Common/Base/Store.swift
@@ -50,7 +50,7 @@ public class Store<objectType: StoreProtocol> {
     public let queryString: String = "SELECT \(objectType.selectFieldsString()) FROM {\(objectType.objectName)} WHERE {\(objectType.objectName):\(Record.Field.locallyDeleted.rawValue)} != 1 ORDER BY {\(objectType.objectName):\(objectType.orderPath)} ASC"
     
     public init() {
-        NotificationCenter.default.addObserver(self, selector: #selector(handleUserWillLogout), name: NSNotification.Name(rawValue: "SFNotificationUserWillLogout") /* kSFNotificationUserWillLogout */, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleUserWillLogout), name: NSNotification.Name(kSFNotificationUserWillLogout), object: nil)
     }
     
     private func setupSoup(store: SFSmartStore) {


### PR DESCRIPTION
The application has a bunch of singletons (one per object type).
1) They were holding on to their SmartStore and SmartSync instances.
2) Soups and syncs were only setup at init time.

Now, we don't hold on to SmartStore or SmartSync instances and we setup soups and syncs on first access to store/sync manager following a logout.

NB: the app as it is would not support multiple users logged in