### PR TITLE
Templates changes for SFAuthenticationSession

### DIFF
--- a/BaristaSwift/Consumer/Consumer/AppDelegate.swift
+++ b/BaristaSwift/Consumer/Consumer/AppDelegate.swift
@@ -133,14 +133,10 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         // Respond to any push notification registration errors here.
     }
     
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-        
-        // If you're using advanced authentication:
-        // --Configure your app to handle incoming requests to your
-        //   OAuth Redirect URI custom URL scheme.
-        // --Uncomment the following line and delete the original return statement:
-        
-        // return  SFUserAccountManager.sharedInstance().handleAdvancedAuthenticationResponse(url, options: options)
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool
+    {
+        // Uncomment following block to enable IDP Login flow
+        // return  SFUserAccountManager.sharedInstance().handleIDPAuthenticationResponse(url, options: options)
         return false;
     }
     

--- a/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.m
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.m
@@ -98,15 +98,11 @@
     // Respond to any push notification registration errors here.
 }
 
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options{
-
-    // If you're using advanced authentication:
-    // --Configure your app to handle incoming requests to your
-    //   OAuth Redirect URI custom URL scheme.
-    // --Uncomment the following line and delete the original return statement:
-
-    // return [[SFUserAccountManager sharedInstance] handleAdvancedAuthenticationResponse:url options:options];
-  return NO;
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+    // Uncomment following block to enable IDP Login flow
+    // return [[SFUserAccountManager sharedInstance] handleIDPAuthenticationResponse:url options:options];
+    return NO;
 }
 
 #pragma mark - Private methods

--- a/SmartSyncExplorerSwift/SmartSyncExplorerSwift/AppDelegate.swift
+++ b/SmartSyncExplorerSwift/SmartSyncExplorerSwift/AppDelegate.swift
@@ -92,14 +92,10 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         // Respond to any push notification registration errors here.
     }
 
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-
-        // If you're using advanced authentication:
-        // --Configure your app to handle incoming requests to your
-        //   OAuth Redirect URI custom URL scheme.
-        // --Uncomment the following line and delete the original return statement:
-
-        // return  SFUserAccountManager.sharedInstance().handleAdvancedAuthenticationResponse(url, options: options)
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool
+    {
+        // Uncomment following block to enable IDP Login flow
+        // return  SFUserAccountManager.sharedInstance().handleIDPAuthenticationResponse(url, options: options)
         return false;
     }
 

--- a/iOSIDPTemplate/Authenticator/AppDelegate.swift
+++ b/iOSIDPTemplate/Authenticator/AppDelegate.swift
@@ -95,8 +95,9 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         // Respond to any push notification registration errors here.
     }
     
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-       return SFUserAccountManager.sharedInstance().handleAdvancedAuthenticationResponse(url, options: options)
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool
+    {
+        return  SFUserAccountManager.sharedInstance().handleIDPAuthenticationResponse(url, options: options)
     }
     
     // MARK: - Private methods

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
@@ -95,14 +95,10 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         // Respond to any push notification registration errors here.
     }
 
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-
-        // If you're using advanced authentication:
-        // --Configure your app to handle incoming requests to your
-        //   OAuth Redirect URI custom URL scheme.
-        // --Uncomment the following line and delete the original return statement:
-
-        // return  SFUserAccountManager.sharedInstance().handleAdvancedAuthenticationResponse(url, options: options)
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool
+    {
+        // Uncomment following block to enable IDP Login flow
+        // return  SFUserAccountManager.sharedInstance().handleIDPAuthenticationResponse(url, options: options)
         return false;
     }
 

--- a/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
+++ b/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
@@ -113,14 +113,10 @@
     // Respond to any push notification registration errors here.
 }
 
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options{
-
-    // If you're using advanced authentication:
-    // --Configure your app to handle incoming requests to your
-    //   OAuth Redirect URI custom URL scheme.
-    // --Uncomment the following line and delete the original return statement:
-
-    // return [[SFUserAccountManager sharedInstance] handleAdvancedAuthenticationResponse:url options:options];
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+    // Uncomment following block to enable IDP Login flow
+    // return [[SFUserAccountManager sharedInstance] handleIDPAuthenticationResponse:url options:options];
     return NO;
 }
 


### PR DESCRIPTION
* No code is needed in AppDelegate
* handleAdvancedAuthenticationResponse renamed to handleIDPAuthenticationResponse

(Accompanies https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/2621)