### PR TITLE
Moving iOS React Native code and tests out of main repo

### DIFF
--- a/ReactNativeTemplate/installios.js
+++ b/ReactNativeTemplate/installios.js
@@ -8,8 +8,6 @@ var fs = require('fs');
 console.log('Installing npm dependencies');
 execSync('npm install', {stdio:[0,1,2]});
 
-var rimraf = require('rimraf');
-
 console.log('Installing sdk dependencies');
 var sdkDependency = 'SalesforceMobileSDK-iOS';
 var repoUrlWithBranch = packageJson.sdkDependencies[sdkDependency];
@@ -19,7 +17,6 @@ if (fs.existsSync(targetDir)) {
     console.log(targetDir + ' already exists - if you want to refresh it, please remove it and re-run install.js');
 } else {
     execSync('git clone --branch ' + branch + ' --single-branch --depth 1 ' + repoUrl + ' ' + targetDir, {stdio:[0,1,2]});
-    rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-iOS', 'libs', 'SalesforceReact', 'package.json')); // confuses metro bundler
 }
 
 console.log('Installing pod dependencies');

--- a/ReactNativeTemplate/ios/Podfile
+++ b/ReactNativeTemplate/ios/Podfile
@@ -33,7 +33,7 @@ pod 'SalesforceAnalytics', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceSDKCore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
-pod 'SalesforceReact', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
+pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 
 end
 

--- a/SmartSyncExplorerReactNative/installios.js
+++ b/SmartSyncExplorerReactNative/installios.js
@@ -8,8 +8,6 @@ var fs = require('fs');
 console.log('Installing npm dependencies');
 execSync('npm install', {stdio:[0,1,2]});
 
-var rimraf = require('rimraf');
-
 console.log('Installing sdk dependencies');
 var sdkDependency = 'SalesforceMobileSDK-iOS';
 var repoUrlWithBranch = packageJson.sdkDependencies[sdkDependency];
@@ -19,7 +17,6 @@ if (fs.existsSync(targetDir)) {
     console.log(targetDir + ' already exists - if you want to refresh it, please remove it and re-run install.js');
 } else {
     execSync('git clone --branch ' + branch + ' --single-branch --depth 1 ' + repoUrl + ' ' + targetDir, {stdio:[0,1,2]});
-    rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-iOS', 'libs', 'SalesforceReact', 'package.json')); // confuses metro bundler
 }
 
 console.log('Installing pod dependencies');

--- a/SmartSyncExplorerReactNative/ios/Podfile
+++ b/SmartSyncExplorerReactNative/ios/Podfile
@@ -34,7 +34,7 @@ pod 'SalesforceAnalytics', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceSDKCore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
-pod 'SalesforceReact', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
+pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 
 end
 


### PR DESCRIPTION
Related PRs:
- removal from main repo: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/2657
- addition to React Native repo: https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/pull/88
