### PR TITLE
Added ability for templates to enable signposts

### DIFF
--- a/ReactNativeTemplate/ios/Podfile
+++ b/ReactNativeTemplate/ios/Podfile
@@ -37,3 +37,15 @@ pod 'SmartSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 
 end
+
+# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
+ post_install do |installer_representation|
+       installer_representation.pods_project.targets.each do |target|
+           target.build_configurations.each do |config|
+               if config.name == 'Debug'
+                   config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'DEBUG=1','SIGNPOST_ENABLED=1']
+                   config.build_settings['OTHER_SWIFT_FLAGS'] = ['$(inherited)', '-DDEBUG','-DSIGNPOST_ENABLED']
+               end
+           end
+       end
+  end

--- a/SmartSyncExplorerReactNative/ios/Podfile
+++ b/SmartSyncExplorerReactNative/ios/Podfile
@@ -38,3 +38,15 @@ pod 'SmartSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 
 end
+
+# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
+ post_install do |installer_representation|
+       installer_representation.pods_project.targets.each do |target|
+           target.build_configurations.each do |config|
+               if config.name == 'Debug'
+                   config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'DEBUG=1','SIGNPOST_ENABLED=1']
+                   config.build_settings['OTHER_SWIFT_FLAGS'] = ['$(inherited)', '-DDEBUG','-DSIGNPOST_ENABLED']
+               end
+           end
+       end
+  end

--- a/SmartSyncExplorerReactNative/ios/SmartSyncExplorerReactNative.xcodeproj/project.pbxproj
+++ b/SmartSyncExplorerReactNative/ios/SmartSyncExplorerReactNative.xcodeproj/project.pbxproj
@@ -289,6 +289,13 @@
 				CODE_SIGN_ENTITLEMENTS = SmartSyncExplorerReactNative/SmartSyncExplorerReactNative.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"$(inherited)",
+					"SQLITE_HAS_CODEC=1",
+					"SIGNPOST_ENABLED=1",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,

--- a/SmartSyncExplorerSwift/Podfile
+++ b/SmartSyncExplorerSwift/Podfile
@@ -14,3 +14,15 @@ pod 'SmartStore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 
 end
+
+# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
+ post_install do |installer_representation|
+       installer_representation.pods_project.targets.each do |target|
+           target.build_configurations.each do |config|
+               if config.name == 'Debug'
+                   config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'DEBUG=1','SIGNPOST_ENABLED=1']
+                   config.build_settings['OTHER_SWIFT_FLAGS'] = ['$(inherited)', '-DDEBUG','-DSIGNPOST_ENABLED']
+               end
+           end
+       end
+  end

--- a/SmartSyncExplorerSwift/SmartSyncExplorerSwift.xcodeproj/project.pbxproj
+++ b/SmartSyncExplorerSwift/SmartSyncExplorerSwift.xcodeproj/project.pbxproj
@@ -465,6 +465,7 @@
 				INFOPLIST_FILE = SmartSyncExplorerSwift/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "-DSIGNPOST_ENABLED";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.salesforce.mobilesdk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SmartSyncExplorerSwift/Bridging-Header.h";

--- a/iOSIDPTemplate/Authenticator.xcodeproj/project.pbxproj
+++ b/iOSIDPTemplate/Authenticator.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 				INFOPLIST_FILE = Authenticator/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DSIGNPOST_ENABLED";
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.Authenticator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -454,6 +455,7 @@
 				INFOPLIST_FILE = Authenticator/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DSIGNPOST_ENABLED";
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.Authenticator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/iOSIDPTemplate/Podfile
+++ b/iOSIDPTemplate/Podfile
@@ -15,3 +15,15 @@ pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'WYPopoverController', :git => 'https://github.com/sammcewan/WYPopoverController', :tag => '0.3.8'
 pod 'SwipeCellKit', '2.5.4'
 end
+
+# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
+ post_install do |installer_representation|
+       installer_representation.pods_project.targets.each do |target|
+           target.build_configurations.each do |config|
+               if config.name == 'Debug'
+                   config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'DEBUG=1','SIGNPOST_ENABLED=1']
+                   config.build_settings['OTHER_SWIFT_FLAGS'] = ['$(inherited)', '-DDEBUG','-DSIGNPOST_ENABLED']
+               end
+           end
+       end
+  end

--- a/iOSNativeSwiftTemplate/Podfile
+++ b/iOSNativeSwiftTemplate/Podfile
@@ -14,3 +14,15 @@ pod 'SmartStore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 
 end
+
+# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
+ post_install do |installer_representation|
+       installer_representation.pods_project.targets.each do |target|
+           target.build_configurations.each do |config|
+               if config.name == 'Debug'
+                   config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'DEBUG=1','SIGNPOST_ENABLED=1']
+                   config.build_settings['OTHER_SWIFT_FLAGS'] = ['$(inherited)', '-DDEBUG','-DSIGNPOST_ENABLED']
+               end
+           end
+       end
+  end

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate.xcodeproj/project.pbxproj
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 				INFOPLIST_FILE = iOSNativeSwiftTemplate/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "-DSIGNPOST_ENABLED";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.salesforce.iosnativeswifttemplate.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "iOSNativeSwiftTemplate/Bridging-Header.h";

--- a/iOSNativeTemplate/Podfile
+++ b/iOSNativeTemplate/Podfile
@@ -14,3 +14,15 @@ pod 'SmartStore', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartSync', :path => 'mobile_sdk/SalesforceMobileSDK-iOS'
 
 end
+
+# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
+ post_install do |installer_representation|
+       installer_representation.pods_project.targets.each do |target|
+           target.build_configurations.each do |config|
+               if config.name == 'Debug'
+                   config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'DEBUG=1','SIGNPOST_ENABLED=1']
+                   config.build_settings['OTHER_SWIFT_FLAGS'] = ['$(inherited)', '-DDEBUG','-DSIGNPOST_ENABLED']
+               end
+           end
+       end
+  end

--- a/iOSNativeTemplate/iOSNativeTemplate.xcodeproj/project.pbxproj
+++ b/iOSNativeTemplate/iOSNativeTemplate.xcodeproj/project.pbxproj
@@ -370,6 +370,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_ENTITLEMENTS = iOSNativeTemplate/iOSNativeTemplate.entitlements;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"SQLITE_HAS_CODEC=1",
+					"SIGNPOST_ENABLED=1",
+				);
 				INFOPLIST_FILE = iOSNativeTemplate/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";


### PR DESCRIPTION
Similar change for all iOS templates. 

- Use the pod install hook to enable the flag across SDK
- Enable main preprocessor flag in sample app project. User other swift flags for swift projects.

