### PR TITLE
Using more (not most) recent react-navigation in ReactNativeTemplate

### DIFF
--- a/ReactNativeTemplate/android/app/build.gradle
+++ b/ReactNativeTemplate/android/app/build.gradle
@@ -131,7 +131,7 @@ android {
 
 dependencies {
     api fileTree(dir: "libs", include: ["*.jar"])
-    api "com.android.support:appcompat-v7:27.1.1"
+    api 'androidx.appcompat:appcompat:1.0.0'
     api "com.facebook.react:react-native:+"  // From node_modules
     api project(':libs:SalesforceReact') // From node_modules
 }

--- a/ReactNativeTemplate/app.js
+++ b/ReactNativeTemplate/app.js
@@ -32,7 +32,7 @@ import {
     FlatList,
 } from 'react-native';
 
-import {StackNavigator} from 'react-navigation';
+import { createStackNavigator } from "react-navigation";
 import {oauth, net} from 'react-native-force';
 
 class ContactListScreen extends React.Component {
@@ -90,7 +90,9 @@ const styles = StyleSheet.create({
     }
 });
 
-export const App = StackNavigator({
-    ContactList: { screen: ContactListScreen }
+export const App = createStackNavigator({
+    Home: {
+        screen: ContactListScreen
+    }
 });
 

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -15,7 +15,7 @@
         "eslint": "^4.17.0",
         "react": "16.8.3",
         "react-native": "0.59.9",
-        "react-navigation": "^1.0.0-beta.11",
+        "react-navigation": "2.18.3",
         "whatwg-fetch": "1.1.1"
     },
     "devDependencies": {

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -15,8 +15,7 @@
         "eslint": "^4.17.0",
         "react": "16.8.3",
         "react-native": "0.59.9",
-        "react-navigation": "2.18.3",
-        "whatwg-fetch": "1.1.1"
+        "react-navigation": "2.18.3"
     },
     "devDependencies": {
         "rimraf": "2.6.2",


### PR DESCRIPTION
ReactNativeTemplate was using react-navigation@1.0.0-beta.11
Now it uses 2.18.3 (the last 2.x)

Notes:
- Didn't move to react-navigation 3.x because it depends in react-native-gesture-handler which doesn't work with Mobile SDK because we use AndroidX for compat libraries.
- RN 0.60 will bring AndroidX support and we can expect other libraries to support it as well.
- Working on SmartSyncExplorerReactNative next