### PR TITLE
Modernizing SmartSyncExplorerReactNative

### DIFF
--- a/ReactNativeTemplate/app.js
+++ b/ReactNativeTemplate/app.js
@@ -95,4 +95,3 @@ export const App = createStackNavigator({
         screen: ContactListScreen
     }
 });
-

--- a/SmartSyncExplorerReactNative/.babelrc
+++ b/SmartSyncExplorerReactNative/.babelrc
@@ -1,3 +1,3 @@
 {
-"presets": ["react-native"]
+    "presets": ["module:metro-react-native-babel-preset"]
 }

--- a/SmartSyncExplorerReactNative/android/app/build.gradle
+++ b/SmartSyncExplorerReactNative/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
 
 dependencies {
     api fileTree(dir: "libs", include: ["*.jar"])
-    api "com.android.support:appcompat-v7:27.1.1"
+    api 'androidx.appcompat:appcompat:1.0.0'
     api "com.facebook.react:react-native:+"  // From node_modules
     api project(':libs:SalesforceReact') // From node_modules
 }

--- a/SmartSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
+++ b/SmartSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 		<!-- Launcher screen -->
 		<activity android:name=".MainActivity"
 		    android:label="@string/app_name"
-			android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+			android:theme="@style/Theme.AppCompat.Light.NoActionBar">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
@@ -43,7 +43,7 @@
         -->
         <!--
         <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-            android:theme="@style/SalesforceSDK.ActionBarTheme"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"
             android:launchMode="singleInstance">
 
             <intent-filter>
@@ -72,7 +72,8 @@
 		<!--
         <activity android:name="com.salesforce.androidsdk.auth.idp.IDPAccountPickerActivity"
             android:excludeFromRecents="true"
-            android:theme="@style/SalesforceSDK.ActionBarTheme">
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+
 
             <intent-filter>
                 <data android:scheme="com.salesforce.samples.smartsyncexplorerreactnative"

--- a/SmartSyncExplorerReactNative/android/gradle.properties
+++ b/SmartSyncExplorerReactNative/android/gradle.properties
@@ -17,7 +17,6 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.useDeprecatedNdk=true
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/SmartSyncExplorerReactNative/ios/Podfile
+++ b/SmartSyncExplorerReactNative/ios/Podfile
@@ -12,7 +12,6 @@ pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Foll
 pod 'RNVectorIcons', :path => '../node_modules/react-native-vector-icons'  
 pod 'React', :path => '../node_modules/react-native', :subspecs => [
     'DevSupport',
-    'jschelpers',
     'cxxreact',
     'CxxBridge',
     'ART',

--- a/SmartSyncExplorerReactNative/js/App.js
+++ b/SmartSyncExplorerReactNative/js/App.js
@@ -25,167 +25,26 @@
  */
 
 import React from 'react';
-import {
-    Alert,
-    Platform,
-    SafeAreaView,
-    StyleSheet,
-    Text,
-    View
-} from 'react-native';
-
-import {
-    Icon
-} from 'react-native-elements';
-
-import NavigationExperimental from 'react-native-deprecated-custom-components';
-import {oauth} from 'react-native-force';
-import storeMgr from './StoreMgr';
+import { createStackNavigator } from 'react-navigation';
+import styles from './Styles';
 import SearchScreen from './SearchScreen';
 import ContactScreen from './ContactScreen';
-let contactScreenInstance;
 
-class NavImgButton extends React.Component { 
-    render() {
-        return (<View style={styles.navBarButton}>
-                  <Icon size={32} name={this.props.icon} type={this.props.iconType} color="white" underlayColor="red" onPress={() => this.props.onPress()} />
-                </View>);
-    }
-}
-
-
-// Router
-const NavigationBarRouteMapper = {
-    LeftButton(route, navigator, index, navState) {
-        if (route.name === 'Contact') {
-            return (<NavImgButton icon='arrow-back' color='white' onPress={onBack} />);
+export default createStackNavigator(
+    {
+        Contacts: {
+            screen: SearchScreen
+        },
+        Contact: {
+            screen: ContactScreen
         }
     },
-
-    RightButton(route, navigator, index, navState) {
-        if (route.name === 'Contacts') {
-            return (<View style={styles.navButtonsGroup}>
-                      <NavImgButton icon='add' onPress={() => onAdd(navigator)} />
-                      <NavImgButton icon='cloud-sync' iconType='material-community' onPress={onSync} />
-                      <NavImgButton icon='logout' iconType='material-community' onPress={onLogout} />
-                    </View>);
-        }
-        else if (route.name === 'Contact') {
-            return (<View style={styles.navButtonsGroup}>
-                      <NavImgButton icon='save' onPress={onSave} />
-                    </View>);
-        }
-    },
-    
-    Title(route, navigator, index, navState) {
-        return (<Text style={styles.navBarTitleText}> {route.name} </Text>);
-  },
-
-};
-
-// Actions handlers
-var onAdd = navigator => {
-    storeMgr.addContact(
-        (contact) => navigator.push({name: 'Contact', contact})
-    );
-}
-
-var onSync = () => {
-    storeMgr.reSyncData();
-}
-
-var onSave = () => {
-    const contact = contactScreenInstance.state.contact;
-    const navigator = contactScreenInstance.props.navigator;
-    contact.__last_error__ = null;
-    contact.__locally_updated__ = contact.__local__ = true;
-    storeMgr.saveContact(contact, () => navigator.pop());
-}
-
-var onBack = () => {
-    const contact = contactScreenInstance.state.contact;
-    const navigator = contactScreenInstance.props.navigator;
-    if (contact.__locally_created__ && !contact.__locally_modified__) {
-        // Nothing typed in - delete
-        storeMgr.deleteContact(contact, () => navigator.pop());
-    }
-    else {
-        navigator.pop()
-    }
-}
-
-var onLogout = () => {
-    Alert.alert(
-        'Logout',
-        'Are you sure you want to logout',
-        [
-            {text: 'Cancel' },
-            {text: 'OK', onPress: () => oauth.logout()},
-        ],
-        { cancelable: true }
-    )
-}
-
-// App component
-class App extends React.Component {
-    componentDidMount() {
-        storeMgr.syncData();
-    }
-
-    renderScene(route, navigator) {
-        if (route.name === 'Contacts') {
-            return (<SearchScreen style={styles.scene} navigator={navigator} />);
-        }
-        else if (route.name === 'Contact') {
-            return (<ContactScreen style={styles.scene} navigator={navigator} contact={route.contact} ref={(screen) => contactScreenInstance = screen}
-                    />);
+    {
+        initialRouteName: 'Contacts',
+        navigationOptions: {
+            headerStyle: styles.navBar,
+            headerTitleStyle: styles.navBarTitleText,
+            tabBarVisible: false
         }
     }
-
-    render() {
-        const initialRoute = {name: 'Contacts'};
-        return (<SafeAreaView style={styles.safeArea}>
-                  <NavigationExperimental.Navigator
-                    style={styles.container}
-                    initialRoute={initialRoute}
-                    configureScene={() => NavigationExperimental.Navigator.SceneConfigs.PushFromRight}
-                    renderScene={(route, navigator) => this.renderScene(route, navigator)}
-                    navigationBar={<NavigationExperimental.Navigator.NavigationBar routeMapper={NavigationBarRouteMapper} style={styles.navBar} />} />
-                </SafeAreaView>
-        );
-    }
-}
-
-var styles = StyleSheet.create({
-    safeArea: {
-        flex: 1,
-        backgroundColor: 'red'
-    },
-    container: {
-        backgroundColor: 'white',
-    },
-    navBar: {
-        backgroundColor: 'red',
-        height: Platform.OS === 'ios' ? 56 : 38,
-    },
-    navBarButton: {
-        paddingLeft: 6,
-    },
-    navButtonsGroup: {
-        flexDirection: 'row',
-    },
-    navBarTitleText: {
-        paddingTop: Platform.OS === 'ios' ? 0 : 18,
-        fontSize: 26,
-        color: 'white',
-        fontWeight: 'bold',
-    },
-    scene: {
-        paddingTop: Platform.OS === 'ios' ? 56 : 38,
-        backgroundColor: 'white',
-        flex: 1,
-    }
-});
-
-export default App;
-
+);

--- a/SmartSyncExplorerReactNative/js/ContactScreen.js
+++ b/SmartSyncExplorerReactNative/js/ContactScreen.js
@@ -34,33 +34,77 @@ import {
     Text
 } from 'react-native';
 
+import styles from './Styles';
+import NavImgButton from './NavImgButton';
 import Field from './Field';
 import storeMgr from './StoreMgr';
 import { Card, Button } from 'react-native-elements';
 
 // State: contact
 // Props: contact
-var createReactClass = require('create-react-class');
-const ContactScreen = createReactClass({
-    getInitialState() {
+class ContactScreen extends React.Component {
+    static navigationOptions = ({ navigation }) => {
+        const { params = {} } = navigation.state;
         return {
-            contact: this.props.contact
+            title: 'Contact',
+            headerLeft: (<NavImgButton icon='arrow-back' color='white' onPress={() => params.onBack()} />),
+            headerRight: (
+                    <View style={styles.navButtonsGroup}>
+                    <NavImgButton icon='save' onPress={() => params.onSave()} />
+                    </View>
+            )
         };
-    },
+    }
 
+    constructor(props) {
+        super(props);
+        this.state = { contact: this.props.navigation.getParam('contact', {}) };
+        this.onBack = this.onBack.bind(this);
+        this.onSave = this.onSave.bind(this);
+        this.onChange = this.onChange.bind(this);
+        this.onDeleteUndeleteContact = this.onDeleteUndeleteContact.bind(this);
+    }
+
+    componentDidMount() {
+        this.props.navigation.setParams({
+            onBack: this.onBack,
+            onSave: this.onSave
+        });
+    }
+    
+    onBack() {
+        const contact = this.state.contact;
+        const navigation = this.props.navigation;
+        if (contact.__locally_created__ && !contact.__locally_modified__) {
+            // Nothing typed in - delete
+            storeMgr.deleteContact(contact, () => navigation.pop());
+        }
+        else {
+            navigation.pop()
+        }
+    }
+
+    onSave() {
+        const contact = this.state.contact;
+        const navigation = this.props.navigation;
+        contact.__last_error__ = null;
+        contact.__locally_updated__ = contact.__local__ = true;
+        storeMgr.saveContact(contact, () => navigation.pop());
+    }
+    
     onChange(fieldKey, fieldValue) {
         const contact = this.state.contact;
         contact[fieldKey] = fieldValue;
         this.setState({contact});
-    },
+    }
 
     onDeleteUndeleteContact() {
         const contact = this.state.contact;
-        const navigator = this.navigator;
+        const navigation = this.props.navigation;
         contact.__locally_deleted__ = !contact.__locally_deleted__;
         contact.__local__ = contact.__locally_deleted__ || contact.__locally_updated__ || contact.__locally_created__;
-        storeMgr.saveContact(contact, () => {this.props.navigator.pop()});
-    },
+        storeMgr.saveContact(contact, () => {navigation.pop()});
+    }
 
     renderErrorIfAny() {
         var errorMessage = null;
@@ -92,7 +136,7 @@ const ContactScreen = createReactClass({
                     </View>
             );
         }
-    },
+    }
 
     renderDeleteUndeleteButton() {
         var iconName = 'delete';
@@ -115,7 +159,7 @@ const ContactScreen = createReactClass({
                 />
                 </View>
         );
-    },
+    }
 
     render() {
         return (
@@ -134,6 +178,6 @@ const ContactScreen = createReactClass({
                 </ScrollView>
                );
     }
-});
+}
 
 export default ContactScreen;

--- a/SmartSyncExplorerReactNative/js/ContactScreen.js
+++ b/SmartSyncExplorerReactNative/js/ContactScreen.js
@@ -45,12 +45,17 @@ import { Card, Button } from 'react-native-elements';
 class ContactScreen extends React.Component {
     static navigationOptions = ({ navigation }) => {
         const { params = {} } = navigation.state;
+        var deleteUndeleteIconName = 'delete';
+        if (params.contact.__locally_deleted__) {
+            deleteUndeleteIconName = 'delete-restore';
+        } 
+        
         return {
             title: 'Contact',
             headerLeft: (<NavImgButton icon='arrow-back' color='white' onPress={() => params.onBack()} />),
             headerRight: (
                     <View style={styles.navButtonsGroup}>
-                    <NavImgButton icon='save' onPress={() => params.onSave()} />
+                        <NavImgButton icon={deleteUndeleteIconName} iconType='material-community' onPress={() => params.onDeleteUndeleteContact()} />
                     </View>
             )
         };
@@ -68,7 +73,8 @@ class ContactScreen extends React.Component {
     componentDidMount() {
         this.props.navigation.setParams({
             onBack: this.onBack,
-            onSave: this.onSave
+            onDeleteUndeleteContact: this.onDeleteUndeleteContact,
+            contact: this.state.contact
         });
     }
     
@@ -99,7 +105,7 @@ class ContactScreen extends React.Component {
     }
 
     onDeleteUndeleteContact() {
-        const contact = this.state.contact;
+        var contact = this.state.contact;
         const navigation = this.props.navigation;
         contact.__locally_deleted__ = !contact.__locally_deleted__;
         contact.__local__ = contact.__locally_deleted__ || contact.__locally_updated__ || contact.__locally_created__;
@@ -138,29 +144,20 @@ class ContactScreen extends React.Component {
         }
     }
 
-    renderDeleteUndeleteButton() {
-        var iconName = 'delete';
-        var title = 'Delete';
-        var bgColor = 'red';
-        if (this.state.contact.__locally_deleted__) {
-            iconName = 'delete-restore';
-            title = 'Undelete';
-            bgColor = 'blue';
-        } 
-
+    renderSaveButton() {
         return (
                 <View style={{marginTop:10}}>
                 <Button
-                  backgroundColor={bgColor}
+                  backgroundColor='blue'
                   containerStyle={{alignItems:'stretch'}}
-                  icon={{name: iconName, type: 'material-community'}}
-                  title={title}
-                  onPress={this.onDeleteUndeleteContact}
+                  icon={{name: 'save'}}
+                  title='Save'
+                  onPress={this.onSave}
                 />
                 </View>
         );
     }
-
+    
     render() {
         return (
                 <ScrollView>
@@ -172,7 +169,7 @@ class ContactScreen extends React.Component {
                     <Field fieldLabel="Mobile phone" fieldValue={this.state.contact.MobilePhone} onChange={(text) => this.onChange("MobilePhone", text)}/>
                     <Field fieldLabel="Email address" fieldValue={this.state.contact.Email} onChange={(text) => this.onChange("Email", text)}/>
                     <Field fieldLabel="Department" fieldValue={this.state.contact.Department} onChange={(text) => this.onChange("Department", text)}/>
-                    {this.renderDeleteUndeleteButton()}
+                    {this.renderSaveButton()}
                   </View>
                 </ScrollView>
                );

--- a/SmartSyncExplorerReactNative/js/ContactScreen.js
+++ b/SmartSyncExplorerReactNative/js/ContactScreen.js
@@ -172,7 +172,6 @@ class ContactScreen extends React.Component {
                     <Field fieldLabel="Mobile phone" fieldValue={this.state.contact.MobilePhone} onChange={(text) => this.onChange("MobilePhone", text)}/>
                     <Field fieldLabel="Email address" fieldValue={this.state.contact.Email} onChange={(text) => this.onChange("Email", text)}/>
                     <Field fieldLabel="Department" fieldValue={this.state.contact.Department} onChange={(text) => this.onChange("Department", text)}/>
-                    <Field fieldLabel="Home phone" fieldValue={this.state.contact.HomePhone} onChange={(text) => this.onChange("HomePhone", text)}/>
                     {this.renderDeleteUndeleteButton()}
                   </View>
                 </ScrollView>

--- a/SmartSyncExplorerReactNative/js/Field.js
+++ b/SmartSyncExplorerReactNative/js/Field.js
@@ -25,9 +25,7 @@
  */
 
 import React from 'react';
-import {
-    View
-} from 'react-native';
+import { View } from 'react-native';
 import {
     FormLabel,
     FormInput

--- a/SmartSyncExplorerReactNative/js/NavImgButton.js
+++ b/SmartSyncExplorerReactNative/js/NavImgButton.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import { Icon} from 'react-native-elements';
+import styles from './Styles';
+
+class NavImgButton extends React.Component { 
+    render() {
+        return (<View style={styles.navBarButton}>
+                  <Icon size={32} name={this.props.icon} type={this.props.iconType} color='white' underlayColor='red' onPress={() => this.props.onPress()} />
+                </View>);
+    }
+}
+
+export default NavImgButton;

--- a/SmartSyncExplorerReactNative/js/StoreMgr.js
+++ b/SmartSyncExplorerReactNative/js/StoreMgr.js
@@ -53,7 +53,7 @@ function syncDownContacts() {
     
     console.log("Starting syncDown");
     syncInFlight = true;
-    const fieldlist = ["Id", "FirstName", "LastName", "Title", "Email", "MobilePhone","Department","HomePhone", "LastModifiedDate"];
+    const fieldlist = ["Id", "FirstName", "LastName", "Title", "Email", "MobilePhone","Department", "LastModifiedDate"];
     const target = {type:"soql", query:`SELECT ${fieldlist.join(",")} FROM Contact LIMIT 10000`};
     return syncDown(false, target, "contacts", {mergeMode:smartsync.MERGE_MODE.OVERWRITE}, syncName)
         .then(() => {
@@ -87,7 +87,7 @@ function syncUpContacts() {
 
     console.log("Starting syncUp");
     syncInFlight = true;
-    const fieldlist = ["FirstName", "LastName", "Title", "Email", "MobilePhone","Department","HomePhone"];
+    const fieldlist = ["FirstName", "LastName", "Title", "Email", "MobilePhone","Department"];
     return syncUp(false, {}, "contacts", {mergeMode:smartsync.MERGE_MODE.OVERWRITE, fieldlist})
         .then(() => {
             console.log("syncUp completed or failed");
@@ -136,7 +136,7 @@ function saveContact(contact, callback) {
 
 function addContact(successCallback, errorCallback) {
     const contact = {Id: `local_${(new Date()).getTime()}`,
-                   FirstName: null, LastName: null, Title: null, Email: null, MobilePhone: null, HomePhone: null, Department: null, attributes: {type: "Contact"},
+                   FirstName: null, LastName: null, Title: null, Email: null, MobilePhone: null, Department: null, attributes: {type: "Contact"},
                    __locally_created__: true,
                    __locally_updated__: false,
                    __locally_deleted__: false,

--- a/SmartSyncExplorerReactNative/js/Styles.js
+++ b/SmartSyncExplorerReactNative/js/Styles.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import {
+    Platform,
+    StyleSheet
+} from 'react-native';
+
+export default StyleSheet.create({
+    safeArea: {
+        flex: 1,
+        backgroundColor: 'red'
+    },
+    container: {
+        backgroundColor: 'white',
+    },
+    navBar: {
+        backgroundColor: 'red',
+        height: Platform.OS === 'ios' ? 56 : 38,
+    },
+    navBarButton: {
+        paddingLeft: 6,
+    },
+    navButtonsGroup: {
+        flexDirection: 'row',
+    },
+    navBarButton: {
+        paddingLeft: 6,
+    },
+    navBarTitleText: {
+        paddingTop: Platform.OS === 'ios' ? 0 : 18,
+        fontSize: 26,
+        color: 'white',
+        fontWeight: 'bold',
+    },
+    scene: {
+        paddingTop: Platform.OS === 'ios' ? 56 : 38,
+        backgroundColor: 'white',
+        flex: 1,
+    }
+});

--- a/SmartSyncExplorerReactNative/js/Styles.js
+++ b/SmartSyncExplorerReactNative/js/Styles.js
@@ -24,22 +24,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {
-    Platform,
-    StyleSheet
-} from 'react-native';
+import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-    safeArea: {
-        flex: 1,
-        backgroundColor: 'red'
-    },
-    container: {
-        backgroundColor: 'white',
-    },
     navBar: {
         backgroundColor: 'red',
-        height: Platform.OS === 'ios' ? 56 : 38,
     },
     navBarButton: {
         paddingLeft: 6,
@@ -51,14 +40,8 @@ export default StyleSheet.create({
         paddingLeft: 6,
     },
     navBarTitleText: {
-        paddingTop: Platform.OS === 'ios' ? 0 : 18,
         fontSize: 26,
         color: 'white',
         fontWeight: 'bold',
-    },
-    scene: {
-        paddingTop: Platform.OS === 'ios' ? 56 : 38,
-        backgroundColor: 'white',
-        flex: 1,
     }
 });

--- a/SmartSyncExplorerReactNative/package.json
+++ b/SmartSyncExplorerReactNative/package.json
@@ -11,17 +11,16 @@
         "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev"
     },
     "dependencies": {
-        "eslint": "^4.0.0",
-        "react": "16.4.1",
-        "react-native": "0.56.1",
-        "react-native-deprecated-custom-components": "git+https://github.com/facebookarchive/react-native-custom-components.git",
+        "eslint": "^4.17.0",
+        "react": "16.8.3",
+        "react-native": "0.59.9",
+        "react-navigation": "2.18.3",
         "react-native-force": "https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
-        "whatwg-fetch": "1.1.1",
         "react-native-elements": "^0.19.0",
         "react-native-vector-icons": "^4.5.0"
     },
     "devDependencies": {
         "rimraf": "2.6.2",
-        "babel-preset-react-native": "5.0.2"
+        "metro-react-native-babel-preset": "^0.45.0"
     }
 }


### PR DESCRIPTION
- using react-navigation instead of navigation-experimental (nb: using react-navigation 2.x because react-navigation 3.x doesn't work with mobile sdk because of androidx)
- using FlatList instead of the deprecated ListView
- using `class xxx extends React.Component` instead of `createReactClass` for all components
-  moved styles to its own file (also cleaned them)
- moved NavImgButton class to its own file
- made some ui changes in detail screen (big save / small delete buttons as opposed to the opposite)