### PR TITLE
Update RN Vector Icons version

### DIFF
--- a/MobileSyncExplorerReactNative/package.json
+++ b/MobileSyncExplorerReactNative/package.json
@@ -18,7 +18,7 @@
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
         "react-navigation": "2.18.3",
         "react-native-elements": "^0.19.0",
-        "react-native-vector-icons": "^4.2.0"
+        "react-native-vector-icons": "^6.6.0"
     },
     "devDependencies": {
         "rimraf": "2.6.2",


### PR DESCRIPTION
This fixes Android release compilation for the MobileSyncExplorerReactNative project. 