### PR TITLE
Limit commented out code

### DIFF
--- a/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/AppDelegate.m
+++ b/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/AppDelegate.m
@@ -60,38 +60,49 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    self.launchOptions = launchOptions;
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     [self initializeAppViewState];
-
-    //Uncomment the code below to see how you can customize the color, textcolor, font and   fontsize of the navigation bar
-    //SFSDKLoginViewControllerConfig *loginViewConfig = [[SFSDKLoginViewControllerConfig  alloc] init];
-    //Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar
-    //loginViewConfig.showSettingsIcon = YES;
-    //Set showNavBar to NO if you want to hide the top bar
-    //loginViewConfig.showNavbar = YES;
-    //loginViewConfig.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
-    //loginViewConfig.navBarTextColor = [UIColor whiteColor];
-    //loginViewConfig.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
-    //[SFUserAccountManager sharedInstance].loginViewControllerConfig = loginViewConfig;
-
-    __weak typeof (self) weakSelf = self;
+    
+    // If you wish to register for push notifications, uncomment the line below.  Note that,
+    // if you want to receive push notifications from Salesforce, you will also need to
+    // implement the application:didRegisterForRemoteNotificationsWithDeviceToken: method (below).
+//    [self registerForRemotePushNotifications];
+    
+    //Uncomment the code below to see how you can customize the color, textcolor, font and fontsize of the navigation bar
+//    [self customizeLoginView];
+    
     [SFSDKAuthHelper loginIfRequired:^{
-      [weakSelf setupRootViewController];
+        [self setupRootViewController];
     }];
     return YES;
+}
+- (void)registerForRemotePushNotifications {
+    [[SFPushNotificationManager sharedInstance] registerForRemoteNotifications];
+}
+
+- (void)customizeLoginView {
+    SFSDKLoginViewControllerConfig *loginViewConfig = [[SFSDKLoginViewControllerConfig  alloc] init];
+    // Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar
+    loginViewConfig.showSettingsIcon = YES;
+    // Set showNavBar to NO if you want to hide the top bar
+    loginViewConfig.showNavbar = YES;
+    loginViewConfig.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
+    loginViewConfig.navBarTitleColor = [UIColor whiteColor];
+    loginViewConfig.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
+    [SFUserAccountManager sharedInstance].loginViewControllerConfig = loginViewConfig;
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-    //
     // Uncomment the code below to register your device token with the push notification manager
-    //
-    // [[SFPushNotificationManager sharedInstance] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-    // if ([SFUserAccountManager sharedInstance].currentUser.credentials.accessToken != nil) {
-    //     [[SFPushNotificationManager sharedInstance] registerSalesforceNotificationsWithCompletionBlock:nil failBlock:nil];
-    // }
-    //
+//    [self didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+- (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    [[SFPushNotificationManager sharedInstance] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+    if ([SFUserAccountManager sharedInstance].currentUser.credentials.accessToken != nil) {
+     [[SFPushNotificationManager sharedInstance] registerSalesforceNotificationsWithCompletionBlock:nil failBlock:nil];
+    }
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
@@ -99,15 +110,16 @@
     // Respond to any push notification registration errors here.
 }
 
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options{
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+    // Uncomment following block to enable IDP Login flow
+//    return [self enableIDPLoginFlowForURL:url options:options];
+    
+    return NO;
+}
 
-    // If you're using advanced authentication:
-    // --Configure your app to handle incoming requests to your
-    //   OAuth Redirect URI custom URL scheme.
-    // --Uncomment the following line and delete the original return statement:
-
-    // return [[SFUserAccountManager sharedInstance] handleAdvancedAuthenticationResponse:url options:options];
-  return NO;
+- (BOOL)enableIDPLoginFlowForURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+     return [[SFUserAccountManager sharedInstance] handleIDPAuthenticationResponse:url options:options];
 }
 
 #pragma mark - Private methods

--- a/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.m
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.m
@@ -57,37 +57,49 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    self.launchOptions = launchOptions;
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     [self initializeAppViewState];
-
-    //Uncomment the code below to see how you can customize the color, textcolor, font and   fontsize of the navigation bar
-    //SFSDKLoginViewControllerConfig *loginViewConfig = [[SFSDKLoginViewControllerConfig  alloc] init];
-    //Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar
-    //loginViewConfig.showSettingsIcon = YES;
-    //Set showNavBar to NO if you want to hide the top bar
-    //loginViewConfig.showNavbar = YES;
-    //loginViewConfig.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
-    //loginViewConfig.navBarTextColor = [UIColor whiteColor];
-    //loginViewConfig.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
-    //[SFUserAccountManager sharedInstance].loginViewControllerConfig = loginViewConfig;
-
+    
+    // If you wish to register for push notifications, uncomment the line below.  Note that,
+    // if you want to receive push notifications from Salesforce, you will also need to
+    // implement the application:didRegisterForRemoteNotificationsWithDeviceToken: method (below).
+//    [self registerForRemotePushNotifications];
+    
+    //Uncomment the code below to see how you can customize the color, textcolor, font and fontsize of the navigation bar
+//    [self customizeLoginView];
+    
     [SFSDKAuthHelper loginIfRequired:^{
-      [self setupRootViewController];
+        [self setupRootViewController];
     }];
     return YES;
+}
+- (void)registerForRemotePushNotifications {
+    [[SFPushNotificationManager sharedInstance] registerForRemoteNotifications];
+}
+
+- (void)customizeLoginView {
+    SFSDKLoginViewControllerConfig *loginViewConfig = [[SFSDKLoginViewControllerConfig  alloc] init];
+    // Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar
+    loginViewConfig.showSettingsIcon = YES;
+    // Set showNavBar to NO if you want to hide the top bar
+    loginViewConfig.showNavbar = YES;
+    loginViewConfig.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
+    loginViewConfig.navBarTitleColor = [UIColor whiteColor];
+    loginViewConfig.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
+    [SFUserAccountManager sharedInstance].loginViewControllerConfig = loginViewConfig;
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-    //
     // Uncomment the code below to register your device token with the push notification manager
-    //
-    // [[SFPushNotificationManager sharedInstance] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-    // if ([SFUserAccountManager sharedInstance].currentUser.credentials.accessToken != nil) {
-    //     [[SFPushNotificationManager sharedInstance] registerSalesforceNotificationsWithCompletionBlock:nil failBlock:nil];
-    // }
-    //
+//    [self didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+- (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    [[SFPushNotificationManager sharedInstance] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+    if ([SFUserAccountManager sharedInstance].currentUser.credentials.accessToken != nil) {
+     [[SFPushNotificationManager sharedInstance] registerSalesforceNotificationsWithCompletionBlock:nil failBlock:nil];
+    }
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
@@ -98,10 +110,14 @@
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
     // Uncomment following block to enable IDP Login flow
-    // return [[SFUserAccountManager sharedInstance] handleIDPAuthenticationResponse:url options:options];
+//    return [self enableIDPLoginFlowForURL:url options:options];
+    
     return NO;
 }
 
+- (BOOL)enableIDPLoginFlowForURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+     return [[SFUserAccountManager sharedInstance] handleIDPAuthenticationResponse:url options:options];
+}
 #pragma mark - Private methods
 
 - (void)initializeAppViewState

--- a/iOS13NativeSwiftTemplate/iOS13NativeSwiftTemplate/AppDelegate.swift
+++ b/iOS13NativeSwiftTemplate/iOS13NativeSwiftTemplate/AppDelegate.swift
@@ -50,29 +50,34 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
 
     // MARK: - App delegate lifecycle
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        // If you wish to register for push notifications, uncomment the line below.  Note that,
+        // if you want to receive push notifications from Salesforce, you will also need to
+        // implement the application(application, didRegisterForRemoteNotificationsWithDeviceToken) method (below).
+//        self.registerForRemotePushNotifications()
         return true
+    }
+
+    func registerForRemotePushNotifications() {        PushNotificationManager.sharedInstance().registerForRemoteNotifications();
     }
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        //
         // Uncomment the code below to register your device token with the push notification manager
-        //
-        //
-        //PushNotificationManager.sharedInstance().didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
-        //if let _ = UserAccountManager.shared.currentUserAccount?.credentials.accessToken {
-        //   PushNotificationManager.sharedInstance().registerForSalesforceNotifications { (result) in
-        //       switch (result) {
-        //           case  .success(let successFlag):
-        //               SalesforceLogger.d(AppDelegate.self, message: "Registration for Salesforce notifications status:  \(successFlag)")
-        //           case .failure(let error):
-        //               SalesforceLogger.e(AppDelegate.self, message: "Registration for Salesforce notifications failed \(error)")
-        //       }
-        //   }
-        //}
-        
+//        didRgisterForRemoteNotifications(deviceToken)
     }
     
+    func didRgisterForRemoteNotifications(_ deviceToken: Data) {
+        PushNotificationManager.sharedInstance().didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
+        if let _ = UserAccountManager.shared.currentUserAccount?.credentials.accessToken {
+            PushNotificationManager.sharedInstance().registerForSalesforceNotifications { (result) in
+                switch (result) {
+                    case  .success(let successFlag):
+                        SalesforceLogger.d(AppDelegate.self, message: "Registration for Salesforce notifications status:  \(successFlag)")
+                    case .failure(let error):
+                        SalesforceLogger.e(AppDelegate.self, message: "Registration for Salesforce notifications failed \(error)")
+                }
+            }
+        }
+    }
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error ) {
         // Respond to any push notification registration errors here.
@@ -80,8 +85,11 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         // Uncomment following block to enable IDP Login flow
-        // return  UserAccountManager.shared.handleIdentityProviderResponse(from: url, with: options)
+//        return self.enableIDPLoginFlowForURL(url, options: options)
         return false;
     }
     
+    func enableIDPLoginFlowForURL(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        return  UserAccountManager.shared.handleIdentityProviderResponse(from: url, with: options)
+    }
 }

--- a/iOSIDPTemplate/Authenticator/AppDelegate.swift
+++ b/iOSIDPTemplate/Authenticator/AppDelegate.swift
@@ -43,55 +43,60 @@ class AppDelegate: UIResponder, UIApplicationDelegate
     }
     
     // MARK: - App delegate lifecycle
-    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.main.bounds)
-        self.initializeAppViewState();
+        self.initializeAppViewState()
         
-        //
         // If you wish to register for push notifications, uncomment the line below.  Note that,
         // if you want to receive push notifications from Salesforce, you will also need to
-        // implement the application:didRegisterForRemoteNotificationsWithDeviceToken: method (below).
-        //
-        // PushNotificationManager.sharedInstance().registerForRemoteNotifications()
-        
+        // implement the application(application, didRegisterForRemoteNotificationsWithDeviceToken) method (below).
+//        self.registerForRemotePushNotifications()
+
         //Uncomment the code below to see how you can customize the color, textcolor,
         //font and fontsize of the navigation bar
-        //let loginViewConfig = SalesforceLoginViewControllerConfig()
-        
-        //Set showSettingsIcon to false if you want to hide the settings
-        //icon on the nav bar
-        //loginViewConfig.showsSettingsIcon = false
-
-        //Set showNavBar to false if you want to hide the top bar
-        //loginViewConfig.showsNavigationBar = false
-        //loginViewConfig.navigationBarColor = UIColor(red: 0.051, green: 0.765, blue: 0.733, alpha: 1.0)
-        //loginViewConfig.navigationBarTextColor = UIColor.white
-        //loginViewConfig.navigationBarFont = UIFont(name: "Helvetica", size: 16.0)
-        //UserAccountManager.shared.loginViewControllerConfig = loginViewConfig
-       
+//        self.customizeLoginView()
         AuthHelper.loginIfRequired {
             self.setupRootViewController()
         }
+        
         return true
     }
     
+    func registerForRemotePushNotifications() {        PushNotificationManager.sharedInstance().registerForRemoteNotifications();
+    }
+    
+    func customizeLoginView() {
+        let loginViewConfig = SalesforceLoginViewControllerConfig()
+        
+        // Set showSettingsIcon to false if you want to hide the settings
+        // icon on the nav bar
+        loginViewConfig.showsSettingsIcon = false
+        
+        // Set showNavBar to false if you want to hide the top bar
+        loginViewConfig.showsNavigationBar = false
+        loginViewConfig.navigationBarColor = UIColor(red: 0.051, green: 0.765, blue: 0.733, alpha: 1.0)
+        loginViewConfig.navigationTitleColor = UIColor.white
+        loginViewConfig.navigationBarFont = UIFont(name: "Helvetica", size: 16.0)
+        UserAccountManager.shared.loginViewControllerConfig = loginViewConfig
+    }
+    
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        //
         // Uncomment the code below to register your device token with the push notification manager
-        //
-        //
-        //PushNotificationManager.sharedInstance().didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
-        //if let _ = UserAccountManager.shared.currentUserAccount?.credentials.accessToken {
-        //   PushNotificationManager.sharedInstance().registerForSalesforceNotifications { (result) in
-        //       switch (result) {
-        //           case  .success(let successFlag):
-        //               SalesforceLogger.d(AppDelegate.self, message: "Registration for Salesforce notifications status:  \(successFlag)")
-        //           case .failure(let error):
-        //               SalesforceLogger.e(AppDelegate.self, message: "Registration for Salesforce notifications failed \(error)")
-        //       }
-        //   }
-        //}
+//        didRgisterForRemoteNotifications(deviceToken)
+    }
+    
+    func didRgisterForRemoteNotifications(_ deviceToken: Data) {
+        PushNotificationManager.sharedInstance().didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
+        if let _ = UserAccountManager.shared.currentUserAccount?.credentials.accessToken {
+            PushNotificationManager.sharedInstance().registerForSalesforceNotifications { (result) in
+                switch (result) {
+                    case  .success(let successFlag):
+                        SalesforceLogger.d(AppDelegate.self, message: "Registration for Salesforce notifications status:  \(successFlag)")
+                    case .failure(let error):
+                        SalesforceLogger.e(AppDelegate.self, message: "Registration for Salesforce notifications failed \(error)")
+                }
+            }
+        }
     }
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error ) {

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
@@ -48,23 +48,12 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
         
         // If you wish to register for push notifications, uncomment the line below.  Note that,
         // if you want to receive push notifications from Salesforce, you will also need to
-        // implement the application:didRegisterForRemoteNotificationsWithDeviceToken: method (below).
-        //
-        //PushNotificationManager.sharedInstance().registerForRemoteNotifications()
+        // implement the application(application, didRegisterForRemoteNotificationsWithDeviceToken) method (below).
+//        self.registerForRemotePushNotifications()
+
         //Uncomment the code below to see how you can customize the color, textcolor,
         //font and fontsize of the navigation bar
-        //let loginViewConfig = SalesforceLoginViewControllerConfig()
-        
-        //Set showSettingsIcon to false if you want to hide the settings
-        //icon on the nav bar
-        //loginViewConfig.showsSettingsIcon = false
-        
-        //Set showNavBar to false if you want to hide the top bar
-        //loginViewConfig.showsNavigationBar = false
-        //loginViewConfig.navigationBarColor = UIColor(red: 0.051, green: 0.765, blue: 0.733, alpha: 1.0)
-        //loginViewConfig.navigationBarTextColor = UIColor.white
-        //loginViewConfig.navigationBarFont = UIFont(name: "Helvetica", size: 16.0)
-        //UserAccountManager.shared.loginViewControllerConfig = loginViewConfig
+//        self.customizeLoginView()
         AuthHelper.loginIfRequired {
             self.setupRootViewController()
         }
@@ -72,22 +61,42 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
         return true
     }
     
+    func registerForRemotePushNotifications() {
+        PushNotificationManager.sharedInstance().registerForRemoteNotifications();
+    }
+    
+    func customizeLoginView() {
+        let loginViewConfig = SalesforceLoginViewControllerConfig()
+        
+        // Set showSettingsIcon to false if you want to hide the settings
+        // icon on the nav bar
+        loginViewConfig.showsSettingsIcon = false
+        
+        // Set showNavBar to false if you want to hide the top bar
+        loginViewConfig.showsNavigationBar = false
+        loginViewConfig.navigationBarColor = UIColor(red: 0.051, green: 0.765, blue: 0.733, alpha: 1.0)
+        loginViewConfig.navigationTitleColor = UIColor.white
+        loginViewConfig.navigationBarFont = UIFont(name: "Helvetica", size: 16.0)
+        UserAccountManager.shared.loginViewControllerConfig = loginViewConfig
+    }
+    
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        //
         // Uncomment the code below to register your device token with the push notification manager
-        //
-        //
-        //PushNotificationManager.sharedInstance().didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
-        //if let _ = UserAccountManager.shared.currentUserAccount?.credentials.accessToken {
-        //    PushNotificationManager.sharedInstance().registerForSalesforceNotifications { (result) in
-        //        switch (result) {
-        //            case  .success(let successFlag):
-        //                SalesforceLogger.d(AppDelegate.self, message: "Registration for Salesforce notifications status:  \(successFlag)")
-        //            case .failure(let error):
-        //                SalesforceLogger.e(AppDelegate.self, message: "Registration for Salesforce notifications failed \(error)")
-        //        }
-        //    }
-        //}
+//        didRgisterForRemoteNotifications(deviceToken)
+    }
+    
+    func didRgisterForRemoteNotifications(_ deviceToken: Data) {
+        PushNotificationManager.sharedInstance().didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
+        if let _ = UserAccountManager.shared.currentUserAccount?.credentials.accessToken {
+            PushNotificationManager.sharedInstance().registerForSalesforceNotifications { (result) in
+                switch (result) {
+                    case  .success(let successFlag):
+                        SalesforceLogger.d(AppDelegate.self, message: "Registration for Salesforce notifications status:  \(successFlag)")
+                    case .failure(let error):
+                        SalesforceLogger.e(AppDelegate.self, message: "Registration for Salesforce notifications failed \(error)")
+                }
+            }
+        }
     }
     
     

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
@@ -96,8 +96,7 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
                 }
             }
         }
-    }
-    
+    }    
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error ) {
         // Respond to any push notification registration errors here.

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
@@ -61,8 +61,7 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
         return true
     }
     
-    func registerForRemotePushNotifications() {
-        PushNotificationManager.sharedInstance().registerForRemoteNotifications();
+    func registerForRemotePushNotifications() {        PushNotificationManager.sharedInstance().registerForRemoteNotifications();
     }
     
     func customizeLoginView() {
@@ -107,8 +106,12 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey 
  : Any] = [:]) -> Bool {
         // Uncomment following block to enable IDP Login flow
-        // return  UserAccountManager.shared.handleIdentityProviderResponse(from: url, with: options)
+//        return self.enableIDPLoginFlowForURL(url, options: options)
         return false;
+    }
+    
+    func enableIDPLoginFlowForURL(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        return  UserAccountManager.shared.handleIdentityProviderResponse(from: url, with: options)
     }
     
     // MARK: - Private methods

--- a/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
+++ b/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
@@ -77,7 +77,11 @@
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     [self initializeAppViewState];
     
-  
+    // If you wish to register for push notifications, uncomment the line below.  Note that,
+    // if you want to receive push notifications from Salesforce, you will also need to
+    // implement the application:didRegisterForRemoteNotificationsWithDeviceToken: method (below).
+//    [self registerForRemotePushNotifications];
+    
     //Uncomment the code below to see how you can customize the color, textcolor, font and fontsize of the navigation bar
 //    [self customizeLoginView];
     
@@ -85,6 +89,9 @@
         [self setupRootViewController];
     }];
     return YES;
+}
+- (void)registerForRemotePushNotifications {
+    [[SFPushNotificationManager sharedInstance] registerForRemoteNotifications];
 }
 
 - (void)customizeLoginView {
@@ -102,10 +109,10 @@
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
     // Uncomment the code below to register your device token with the push notification manager
-//    [self registerForRemoteNotificationWithDeviceToken:deviceToken];
+//    [self didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
-- (void)registerForRemoteNotificationWithDeviceToken:(NSData *)deviceToken {
+- (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
     [[SFPushNotificationManager sharedInstance] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
     if ([SFUserAccountManager sharedInstance].currentUser.credentials.accessToken != nil) {
      [[SFPushNotificationManager sharedInstance] registerSalesforceNotificationsWithCompletionBlock:nil failBlock:nil];

--- a/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
+++ b/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
@@ -127,12 +127,12 @@
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
     // Uncomment following block to enable IDP Login flow
-//    return [self enableIdpLoginFlowForURL:url options:options];
+//    return [self enableIDPLoginFlowForURL:url options:options];
     
     return NO;
 }
 
-- (BOOL)enableIdpLoginFlowForURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+- (BOOL)enableIDPLoginFlowForURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
      return [[SFUserAccountManager sharedInstance] handleIDPAuthenticationResponse:url options:options];
 }
 

--- a/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
+++ b/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
@@ -78,32 +78,38 @@
     [self initializeAppViewState];
     
   
-    //Uncomment the code below to see how you can customize the color, textcolor, font and   fontsize of the navigation bar
-    //SFSDKLoginViewControllerConfig *loginViewConfig = [[SFSDKLoginViewControllerConfig  alloc] init];
-    //Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar
-    //loginViewConfig.showSettingsIcon = YES;
-    //Set showNavBar to NO if you want to hide the top bar
-    //loginViewConfig.showNavbar = YES;
-    //loginViewConfig.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
-    //loginViewConfig.navBarTextColor = [UIColor whiteColor];
-    //loginViewConfig.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
-    //[SFUserAccountManager sharedInstance].loginViewControllerConfig = loginViewConfig;
+    //Uncomment the code below to see how you can customize the color, textcolor, font and fontsize of the navigation bar
+//    [self customizeLoginView];
+    
     [SFSDKAuthHelper loginIfRequired:^{
         [self setupRootViewController];
     }];
     return YES;
 }
 
+- (void)customizeLoginView {
+    SFSDKLoginViewControllerConfig *loginViewConfig = [[SFSDKLoginViewControllerConfig  alloc] init];
+    // Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar
+    loginViewConfig.showSettingsIcon = YES;
+    // Set showNavBar to NO if you want to hide the top bar
+    loginViewConfig.showNavbar = YES;
+    loginViewConfig.navBarColor = [UIColor colorWithRed:0.051 green:0.765 blue:0.733 alpha:1.0];
+    loginViewConfig.navBarTitleColor = [UIColor whiteColor];
+    loginViewConfig.navBarFont = [UIFont fontWithName:@"Helvetica" size:16.0];
+    [SFUserAccountManager sharedInstance].loginViewControllerConfig = loginViewConfig;
+}
+
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-    //
     // Uncomment the code below to register your device token with the push notification manager
-    //
-    // [[SFPushNotificationManager sharedInstance] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-    // if ([SFUserAccountManager sharedInstance].currentUser.credentials.accessToken != nil) {
-    //     [[SFPushNotificationManager sharedInstance] registerSalesforceNotificationsWithCompletionBlock:nil failBlock:nil];
-    // }
-    //
+//    [self registerForRemoteNotificationWithDeviceToken:deviceToken];
+}
+
+- (void)registerForRemoteNotificationWithDeviceToken:(NSData *)deviceToken {
+    [[SFPushNotificationManager sharedInstance] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+    if ([SFUserAccountManager sharedInstance].currentUser.credentials.accessToken != nil) {
+     [[SFPushNotificationManager sharedInstance] registerSalesforceNotificationsWithCompletionBlock:nil failBlock:nil];
+    }
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
@@ -114,8 +120,13 @@
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
     // Uncomment following block to enable IDP Login flow
-    // return [[SFUserAccountManager sharedInstance] handleIDPAuthenticationResponse:url options:options];
+//    return [self enableIdpLoginFlowForURL:url options:options];
+    
     return NO;
+}
+
+- (BOOL)enableIdpLoginFlowForURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+     return [[SFUserAccountManager sharedInstance] handleIDPAuthenticationResponse:url options:options];
 }
 
 #pragma mark - Private methods


### PR DESCRIPTION
Instead of having lines and lines of commented out codes that we often forget to refactor whenever we make changes in the SDK, the example code now lives in small private methods. Only the calls to those privates methods are commented out.

