### PR TITLE
Fixing setversion.sh

### DIFF
--- a/iOSIDPTemplate/package.json
+++ b/iOSIDPTemplate/package.json
@@ -3,6 +3,6 @@
     "version": "0.0.1",
     "private": true,
     "sdkDependencies": {
-        "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS#dev"
+        "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
     }
 }

--- a/setversion.sh
+++ b/setversion.sh
@@ -39,7 +39,7 @@ update_package_json ()
 {
     local file=$1
     local version=$2
-    gsed -i "s/\.git\#[^\"]*\"/\.git\#${version}\"/g" ${file}
+    gsed -i "s/\(SalesforceMobileSDK.*\)\#[^\"]*\"/\1\#${version}\"/g" ${file}
 }
 
 parse_opts "$@"


### PR DESCRIPTION
Was missing iOSIDPTemplate.
Only one of the two commits is needed.
The second one is better than the first IMHO.