### PR TITLE
Move LoginIfRequired to Scene's didEnterForeground

### DIFF
--- a/iOS13NativeSwiftTemplate/iOS13NativeSwiftTemplate/SceneDelegate.swift
+++ b/iOS13NativeSwiftTemplate/iOS13NativeSwiftTemplate/SceneDelegate.swift
@@ -65,8 +65,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
         self.initializeAppViewState()
-         AuthHelper.loginIfRequired {
-                   self.setupRootViewController()
+        AuthHelper.loginIfRequired {
+            self.setupRootViewController()
         }
     }
 

--- a/iOS13NativeSwiftTemplate/iOS13NativeSwiftTemplate/SceneDelegate.swift
+++ b/iOS13NativeSwiftTemplate/iOS13NativeSwiftTemplate/SceneDelegate.swift
@@ -54,10 +54,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-        self.initializeAppViewState()
-        AuthHelper.loginIfRequired {
-            self.setupRootViewController()
-        }
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
@@ -68,6 +64,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        self.initializeAppViewState()
+         AuthHelper.loginIfRequired {
+                   self.setupRootViewController()
+        }
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {


### PR DESCRIPTION
This fixes the issue related to faceid.  Subsequently to foregrounding the scene, the screen is activated and deactivated during the flow. It's best to perform the loginIfRequired only when the scene is foregrounded.