### PR TITLE
Moving to React Native 0.62.2

### DIFF
--- a/MobileSyncExplorerReactNative/android/settings.gradle
+++ b/MobileSyncExplorerReactNative/android/settings.gradle
@@ -1,4 +1,8 @@
 rootProject.name = 'MobileSyncExplorerReactNative'
+include ':react-native-safe-area-context'
+project(':react-native-safe-area-context').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-safe-area-context/android')
+include ':react-native-gesture-handler'
+project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 
 def libsRootDir = new File( settingsDir, '../mobile_sdk/SalesforceMobileSDK-Android/libs' )

--- a/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative.xcodeproj/project.pbxproj
+++ b/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative.xcodeproj/project.pbxproj
@@ -252,10 +252,10 @@
 				"${BUILT_PRODUCTS_DIR}/Folly/folly.framework",
 				"${BUILT_PRODUCTS_DIR}/MobileSync/MobileSync.framework",
 				"${BUILT_PRODUCTS_DIR}/RCTTypeSafety/RCTTypeSafety.framework",
+				"${BUILT_PRODUCTS_DIR}/RNGestureHandler/RNGestureHandler.framework",
 				"${BUILT_PRODUCTS_DIR}/RNVectorIcons/RNVectorIcons.framework",
 				"${BUILT_PRODUCTS_DIR}/React-Core/React.framework",
 				"${BUILT_PRODUCTS_DIR}/React-CoreModules/CoreModules.framework",
-				"${BUILT_PRODUCTS_DIR}/React-RCTActionSheet/RCTActionSheet.framework",
 				"${BUILT_PRODUCTS_DIR}/React-RCTAnimation/RCTAnimation.framework",
 				"${BUILT_PRODUCTS_DIR}/React-RCTBlob/RCTBlob.framework",
 				"${BUILT_PRODUCTS_DIR}/React-RCTImage/RCTImage.framework",
@@ -277,6 +277,7 @@
 				"${BUILT_PRODUCTS_DIR}/SmartStore/SmartStore.framework",
 				"${BUILT_PRODUCTS_DIR}/Yoga/yoga.framework",
 				"${BUILT_PRODUCTS_DIR}/glog/glog.framework",
+				"${BUILT_PRODUCTS_DIR}/react-native-safe-area-context/react_native_safe_area_context.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -286,10 +287,10 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/folly.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MobileSync.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTTypeSafety.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNGestureHandler.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNVectorIcons.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CoreModules.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTActionSheet.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTAnimation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTBlob.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTImage.framework",
@@ -311,6 +312,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SmartStore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/yoga.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/react_native_safe_area_context.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/MobileSyncExplorerReactNative/ios/Podfile
+++ b/MobileSyncExplorerReactNative/ios/Podfile
@@ -30,15 +30,17 @@ pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreac
 pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
 pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
 pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-pod 'ReactCommon/jscallinvoker', :path => '../node_modules/react-native/ReactCommon'
+pod 'ReactCommon/callinvoker', :path => '../node_modules/react-native/ReactCommon'
 pod 'ReactCommon/turbomodule/core', :path => '../node_modules/react-native/ReactCommon'
-pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
 
 pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
 pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
 pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
 pod 'RNVectorIcons', :path => '../node_modules/react-native-vector-icons'  
+pod 'RNGestureHandler', :path => '../node_modules/react-native-gesture-handler'
+pod 'react-native-safe-area-context', :path => '../node_modules/react-native-safe-area-context'
 
 pod 'SalesforceSDKCommon', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceAnalytics', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
@@ -46,6 +48,7 @@ pod 'SalesforceSDKCore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'MobileSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceReact', :path => '../node_modules/react-native-force'
+
 
 end
 

--- a/MobileSyncExplorerReactNative/js/App.js
+++ b/MobileSyncExplorerReactNative/js/App.js
@@ -25,26 +25,28 @@
  */
 
 import React from 'react';
-import { createStackNavigator } from 'react-navigation';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
 import styles from './Styles';
 import SearchScreen from './SearchScreen';
 import ContactScreen from './ContactScreen';
 
-export default createStackNavigator(
-    {
-        Contacts: {
-            screen: SearchScreen
-        },
-        Contact: {
-            screen: ContactScreen
-        }
-    },
-    {
-        initialRouteName: 'Contacts',
-        navigationOptions: {
-            headerStyle: styles.navBar,
-            headerTitleStyle: styles.navBarTitleText,
-            tabBarVisible: false
-        }
-    }
-);
+const Stack = createStackNavigator();
+
+export default function() {
+    return (
+        <NavigationContainer>
+            <Stack.Navigator
+                initialRouteName="Contacts"
+                screenOptions={{
+                    headerStyle: styles.navBar,
+                    headerTitleStyle: styles.navBarTitleText,
+                    tabBarVisible: false
+                }}
+            >
+            <Stack.Screen name="Contacts" component={SearchScreen} />
+            <Stack.Screen name="Contact" component={ContactScreen} />
+          </Stack.Navigator>
+        </NavigationContainer>
+    );
+}

--- a/MobileSyncExplorerReactNative/js/ContactScreen.js
+++ b/MobileSyncExplorerReactNative/js/ContactScreen.js
@@ -43,27 +43,9 @@ import { Card, Button } from 'react-native-elements';
 // State: contact
 // Props: contact
 class ContactScreen extends React.Component {
-    static navigationOptions = ({ navigation }) => {
-        const { params = {} } = navigation.state;
-        var deleteUndeleteIconName = 'delete';
-        if (params.contact.__locally_deleted__) {
-            deleteUndeleteIconName = 'delete-restore';
-        } 
-        
-        return {
-            title: 'Contact',
-            headerLeft: (<NavImgButton icon='arrow-back' color='white' onPress={() => params.onBack()} />),
-            headerRight: (
-                    <View style={styles.navButtonsGroup}>
-                        <NavImgButton icon={deleteUndeleteIconName} iconType='material-community' onPress={() => params.onDeleteUndeleteContact()} />
-                    </View>
-            )
-        };
-    }
-
     constructor(props) {
         super(props);
-        this.state = { contact: this.props.navigation.getParam('contact', {}) };
+        this.state = { contact: props.route.params.contact || {} };
         this.onBack = this.onBack.bind(this);
         this.onSave = this.onSave.bind(this);
         this.onChange = this.onChange.bind(this);
@@ -71,10 +53,19 @@ class ContactScreen extends React.Component {
     }
 
     componentDidMount() {
-        this.props.navigation.setParams({
-            onBack: this.onBack,
-            onDeleteUndeleteContact: this.onDeleteUndeleteContact,
-            contact: this.state.contact
+        var deleteUndeleteIconName = 'delete';
+        if (this.state.contact.__locally_deleted__) {
+            deleteUndeleteIconName = 'delete-restore';
+        } 
+        
+        this.props.navigation.setOptions({
+            title: 'Contact',
+            headerLeft: () => (<NavImgButton icon='arrow-back' color='white' onPress={() => this.onBack()} />),
+            headerRight: () => (
+                    <View style={styles.navButtonsGroup}>
+                        <NavImgButton icon={deleteUndeleteIconName} iconType='material-community' onPress={() => this.onDeleteUndeleteContact()} />
+                    </View>
+            )
         });
     }
     

--- a/MobileSyncExplorerReactNative/js/SearchScreen.js
+++ b/MobileSyncExplorerReactNative/js/SearchScreen.js
@@ -40,20 +40,6 @@ import ContactCell from './ContactCell';
 import storeMgr from './StoreMgr';
 
 class SearchScreen extends React.Component {
-    static navigationOptions = ({ navigation }) => {
-        const { params = {} } = navigation.state;
-        return {
-            title: 'Contacts',
-            headerRight: (
-                    <View style={styles.navButtonsGroup}>
-                    <NavImgButton icon='add' onPress={() => params.onAdd()} />
-                    <NavImgButton icon='cloud-sync' iconType='material-community' onPress={() => params.onSync()} />
-                    <NavImgButton icon='logout' iconType='material-community' onPress={() => params.onLogout()} />
-                    </View>
-            )
-        };
-    }
-
     constructor(props) {
         super(props);
         this.state = {
@@ -73,10 +59,15 @@ class SearchScreen extends React.Component {
     }
 
     componentDidMount() {
-        this.props.navigation.setParams({
-            onAdd: this.onAdd,
-            onSync: this.onSync,
-            onLogout: this.onLogout
+        this.props.navigation.setOptions({
+            title: 'Contacts',
+            headerRight: () => (
+                    <View style={styles.navButtonsGroup}>
+                    <NavImgButton icon='add' onPress={() => this.onAdd()} />
+                    <NavImgButton icon='cloud-sync' iconType='material-community' onPress={() => this.onSync()} />
+                    <NavImgButton icon='logout' iconType='material-community' onPress={() => this.onLogout()} />
+                    </View>
+            )
         });
         storeMgr.syncData();
         storeMgr.addStoreChangeListener(this.refresh);

--- a/MobileSyncExplorerReactNative/package.json
+++ b/MobileSyncExplorerReactNative/package.json
@@ -11,24 +11,30 @@
         "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev"
     },
     "dependencies": {
-        "eslint": "^5.0.0",
-        "acorn": "^6.0.0",
-        "react": "16.9.0",
-        "react-native": "0.61.3",
+        "@react-native-community/masked-view": "^0.1.10",
+        "@react-navigation/native": "^5.2.1",
+        "@react-navigation/stack": "^5.2.16",
+        "acorn": "^6.4.1",
+        "eslint": "^5.1.0",
+        "react": "16.11.0",
+        "react-native": "0.62.2",
+        "react-native-elements": "^0.19.1",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
-        "react-navigation": "2.18.3",
-        "react-native-elements": "^0.19.0",
-        "react-native-vector-icons": "^6.6.0"
+        "react-native-gesture-handler": "^1.6.1",
+        "react-native-reanimated": "^1.8.0",
+        "react-native-safe-area-context": "^0.7.3",
+        "react-native-screens": "^2.7.0",
+        "react-native-vector-icons": "^4.2.0"
     },
     "devDependencies": {
         "rimraf": "2.6.2",
-        "@babel/core": "^7.3.3",
-        "@babel/runtime": "^7.3.1",
+        "@babel/core": "^7.9.6",
+        "@babel/runtime": "^7.9.6",
         "@react-native-community/eslint-config": "^0.0.3",
-        "babel-jest": "^24.1.0",
-        "jest": "^24.1.0",
+        "babel-jest": "^24.9.0",
+        "jest": "^24.9.0",
         "metro-react-native-babel-preset": "^0.54.1",
-        "react-test-renderer": "16.9.0"
+        "react-test-renderer": "16.11.0"
     },
     "jest": {
         "preset": "react-native"

--- a/ReactNativeTemplate/android/settings.gradle
+++ b/ReactNativeTemplate/android/settings.gradle
@@ -1,4 +1,8 @@
 rootProject.name = 'ReactNativeTemplate'
+include ':react-native-safe-area-context'
+project(':react-native-safe-area-context').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-safe-area-context/android')
+include ':react-native-gesture-handler'
+project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 
 def libsRootDir = new File( settingsDir, '../mobile_sdk/SalesforceMobileSDK-Android/libs' )

--- a/ReactNativeTemplate/app.js
+++ b/ReactNativeTemplate/app.js
@@ -32,14 +32,11 @@ import {
     FlatList,
 } from 'react-native';
 
-import { createStackNavigator } from "react-navigation";
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
 import {oauth, net} from 'react-native-force';
 
 class ContactListScreen extends React.Component {
-    static navigationOptions = {
-        title: 'Mobile SDK Sample App'
-    };
-
     constructor(props) {
         super(props);
         this.state = {data: []};
@@ -59,7 +56,7 @@ class ContactListScreen extends React.Component {
 
     fetchData() {
         var that = this;
-        net.query('SELECT Id, Name FROM Contact LIMIT 10',
+        net.query('SELECT Id, Name FROM Contact LIMIT 100',
                   (response) => that.setState({data: response.records})
                  );
     }
@@ -90,8 +87,14 @@ const styles = StyleSheet.create({
     }
 });
 
-export const App = createStackNavigator({
-    Home: {
-        screen: ContactListScreen
-    }
-});
+const Stack = createStackNavigator();
+
+export const App = function() {
+    return (
+        <NavigationContainer>
+          <Stack.Navigator>
+            <Stack.Screen name="Mobile SDK Sample App" component={ContactListScreen} />
+          </Stack.Navigator>
+        </NavigationContainer>
+    );
+}

--- a/ReactNativeTemplate/ios/Podfile
+++ b/ReactNativeTemplate/ios/Podfile
@@ -30,13 +30,16 @@ pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreac
 pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
 pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
 pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-pod 'ReactCommon/jscallinvoker', :path => '../node_modules/react-native/ReactCommon'
+pod 'ReactCommon/callinvoker', :path => '../node_modules/react-native/ReactCommon'
 pod 'ReactCommon/turbomodule/core', :path => '../node_modules/react-native/ReactCommon'
-pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
 
 pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
 pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
 pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
+
+pod 'RNGestureHandler', :path => '../node_modules/react-native-gesture-handler'
+pod 'react-native-safe-area-context', :path => '../node_modules/react-native-safe-area-context'
 
 pod 'SalesforceSDKCommon', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceAnalytics', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
@@ -44,6 +47,8 @@ pod 'SalesforceSDKCore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'MobileSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceReact', :path => '../node_modules/react-native-force'
+
+
 
 end
 

--- a/ReactNativeTemplate/ios/ReactNativeTemplate.xcodeproj/project.pbxproj
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate.xcodeproj/project.pbxproj
@@ -236,9 +236,9 @@
 				"${BUILT_PRODUCTS_DIR}/Folly/folly.framework",
 				"${BUILT_PRODUCTS_DIR}/MobileSync/MobileSync.framework",
 				"${BUILT_PRODUCTS_DIR}/RCTTypeSafety/RCTTypeSafety.framework",
+				"${BUILT_PRODUCTS_DIR}/RNGestureHandler/RNGestureHandler.framework",
 				"${BUILT_PRODUCTS_DIR}/React-Core/React.framework",
 				"${BUILT_PRODUCTS_DIR}/React-CoreModules/CoreModules.framework",
-				"${BUILT_PRODUCTS_DIR}/React-RCTActionSheet/RCTActionSheet.framework",
 				"${BUILT_PRODUCTS_DIR}/React-RCTAnimation/RCTAnimation.framework",
 				"${BUILT_PRODUCTS_DIR}/React-RCTBlob/RCTBlob.framework",
 				"${BUILT_PRODUCTS_DIR}/React-RCTImage/RCTImage.framework",
@@ -260,6 +260,7 @@
 				"${BUILT_PRODUCTS_DIR}/SmartStore/SmartStore.framework",
 				"${BUILT_PRODUCTS_DIR}/Yoga/yoga.framework",
 				"${BUILT_PRODUCTS_DIR}/glog/glog.framework",
+				"${BUILT_PRODUCTS_DIR}/react-native-safe-area-context/react_native_safe_area_context.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -269,9 +270,9 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/folly.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MobileSync.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTTypeSafety.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNGestureHandler.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CoreModules.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTActionSheet.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTAnimation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTBlob.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RCTImage.framework",
@@ -293,6 +294,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SmartStore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/yoga.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/react_native_safe_area_context.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -11,22 +11,28 @@
         "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
     },
     "dependencies": {
-        "eslint": "^5.0.0",
-        "acorn": "^6.0.0",
-        "react": "16.9.0",
-        "react-native": "0.61.3",
+        "@react-native-community/masked-view": "^0.1.10",
+        "@react-navigation/native": "^5.2.0",
+        "@react-navigation/stack": "^5.2.15",
+        "acorn": "^6.4.1",
+        "eslint": "^5.1.0",
+        "react": "16.11.0",
+        "react-native": "0.62.2",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
-        "react-navigation": "2.18.3"
+        "react-native-gesture-handler": "^1.6.1",
+        "react-native-reanimated": "^1.8.0",
+        "react-native-safe-area-context": "^0.7.3",
+        "react-native-screens": "^2.7.0"
     },
     "devDependencies": {
         "rimraf": "2.6.2",
-        "@babel/core": "^7.3.3",
-        "@babel/runtime": "^7.3.1",
+        "@babel/core": "^7.9.6",
+        "@babel/runtime": "^7.9.6",
         "@react-native-community/eslint-config": "^0.0.3",
-        "babel-jest": "^24.1.0",
-        "jest": "^24.1.0",
+        "babel-jest": "^24.9.0",
+        "jest": "^24.9.0",
         "metro-react-native-babel-preset": "^0.54.1",
-        "react-test-renderer": "16.9.0"
+        "react-test-renderer": "16.11.0"
     },
     "jest": {
         "preset": "react-native"


### PR DESCRIPTION
We were using an old version of react navigation (2.18), so I moved to the latest react navigation (5.2). The js changes are for the new navigation.