### PR TITLE
Bug fix: search screen should show results for most recently typed query

### DIFF
--- a/MobileSyncExplorerReactNative/js/SearchScreen.js
+++ b/MobileSyncExplorerReactNative/js/SearchScreen.js
@@ -39,6 +39,9 @@ import ContactScreen from './ContactScreen';
 import ContactCell from './ContactCell';
 import storeMgr from './StoreMgr';
 
+// Global sequence number, incremented every time a query is run
+var seq = 0;
+
 class SearchScreen extends React.Component {
     constructor(props) {
         super(props);
@@ -152,14 +155,19 @@ class SearchScreen extends React.Component {
 
         const that = this;
         storeMgr.searchContacts(
+            ++seq,
             query,
-            (contacts, currentStoreQuery) => {
-                that.setState({
-                    isLoading: false,
-                    filter: query,
-                    data: contacts,
-                    queryNumber: currentStoreQuery
-                });
+            (contacts, queryId) => {
+                if (queryId < seq) {
+                    console.log(`IGNORING Response for #${queryId}`);
+                } else {
+                    that.setState({
+                        isLoading: false,
+                        filter: query,
+                        data: contacts,
+                        queryNumber: queryId,
+                    });
+                }
             },
             (error) => {
                 that.setState({

--- a/MobileSyncExplorerReactNative/js/StoreMgr.js
+++ b/MobileSyncExplorerReactNative/js/StoreMgr.js
@@ -167,7 +167,7 @@ function traverseCursor(accumulatedResults, cursor, pageIndex, successCallback, 
     }
 }
 
-function searchContacts(query, successCallback, errorCallback) {
+function searchContacts(queryId, query, successCallback, errorCallback) {
     let querySpec;
     
     if (query === "") {
@@ -183,11 +183,8 @@ function searchContacts(query, successCallback, errorCallback) {
     }
     const that = this;
 
-    lastStoreQuerySent++;
-    const currentStoreQuery = lastStoreQuerySent;
-
     const querySuccessCB = (contacts) => {
-        successCallback(contacts, currentStoreQuery);
+        successCallback(contacts, queryId);
     };
 
     const queryErrorCB = (error) => {
@@ -199,14 +196,7 @@ function searchContacts(query, successCallback, errorCallback) {
                          "contacts",
                          querySpec,
                          (cursor) => {
-                             console.log(`Response for #${currentStoreQuery}`);
-                             if (currentStoreQuery > lastStoreResponseReceived) {
-                                 lastStoreResponseReceived = currentStoreQuery;
-                                 traverseCursor([], cursor, 0, querySuccessCB, queryErrorCB);
-                             }
-                             else {
-                                 console.log(`IGNORING Response for #${currentStoreQuery}`);
-                             }
+                             traverseCursor([], cursor, 0, querySuccessCB, queryErrorCB);
                          },
                          queryErrorCB);
 


### PR DESCRIPTION
Behavior before fix:
If you have many contacts and search for abcd (typing the letters quickly), a search is fired for a, then for ab, then for abc, and finally for abcd. Naturally, the search for abcd ends first, followed by the search for abc, the one for ab and the one for a. So you will end up with the results for a (and the "a" in the search box).

Behavior with fix:
Only results for the most recent search should be shown, other results should be discarded without changing the state of the screen.