### PR TITLE
Disabling link on contact list item

### DIFF
--- a/HybridLwcTemplate/server/force-app/main/default/lwc/contactListItem/contactListItem.html
+++ b/HybridLwcTemplate/server/force-app/main/default/lwc/contactListItem/contactListItem.html
@@ -1,5 +1,5 @@
 <template>
-    <lightning-tile label={contact.Name} type="media">
+    <lightning-tile label={contact.Name} type="media" href="javascript:void(0);">
         <ul class="slds-list_horizontal slds-has-dividers_right">
             <li class="slds-item">{contact.Department}</li>
             <li class="slds-item">{contact.MobilePhone}</li>


### PR DESCRIPTION
Like the other basic template, we only show a list of contacts, we don't have a detail screen.
Before this change, clicking on a list item would cause the whole screen to re-render (and a few times it went blank).