### PR TITLE
Fix ReactNativeTypeScriptTemplate issue on Linux systems.

### DIFF
--- a/ReactNativeTypeScriptTemplate/template.js
+++ b/ReactNativeTypeScriptTemplate/template.js
@@ -113,8 +113,8 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         var templateAppBuildGradleFile = path.join('android', 'app', 'build.gradle');
         var templateStringsXmlFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
         var templateBootconfigFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'bootconfig.xml');
-        var templateMainActivityFile = path.join('android', 'app', 'src', 'main', 'java', 'com', 'salesforce', 'ReactNativeTypeScriptTemplate', 'MainActivity.java');
-        var templateMainApplicationFile = path.join('android', 'app', 'src', 'main', 'java', 'com', 'salesforce', 'ReactNativeTypeScriptTemplate', 'MainApplication.java');
+        var templateMainActivityFile = path.join('android', 'app', 'src', 'main', 'java', 'com', 'salesforce', 'reactnativetypescripttemplate', 'MainActivity.java');
+        var templateMainApplicationFile = path.join('android', 'app', 'src', 'main', 'java', 'com', 'salesforce', 'reactnativetypescripttemplate', 'MainApplication.java');
 
         //
         // Replace in files


### PR DESCRIPTION
The actual path contains the app name in all lowercase but the path being technically wrong only affects Linux.  I believe this is due to how the filesystem handles paths at a low level and it appears OSX is case insensitive while linux is case sensitive.  So the same `fs.readfilesync` call will fail on one but not the other.