### PR TITLE
Simplifying pod files for RN templates

### DIFF
--- a/MobileSyncExplorerReactNative/ios/Podfile
+++ b/MobileSyncExplorerReactNative/ios/Podfile
@@ -1,3 +1,6 @@
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
 platform :ios, '13.0'
 
 use_frameworks!
@@ -7,40 +10,8 @@ target 'MobileSyncExplorerReactNative' do
 
 source 'https://cdn.cocoapods.org/'
 
-pod 'FBLazyVector', :path => '../node_modules/react-native/Libraries/FBLazyVector'
-pod 'FBReactNativeSpec', :path => '../node_modules/react-native/Libraries/FBReactNativeSpec'
-pod 'RCTRequired', :path => '../node_modules/react-native/Libraries/RCTRequired'
-pod 'RCTTypeSafety', :path => '../node_modules/react-native/Libraries/TypeSafety'
-pod 'React', :path => '../node_modules/react-native/'
-pod 'React-Core', :path => '../node_modules/react-native/'
-pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
-pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
-pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
-pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
-pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
-pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
-pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
-pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
-pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
-pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
-pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
-
-pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
-pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
-pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
-pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-pod 'React-callinvoker', :path => '../node_modules/react-native/ReactCommon/callinvoker'
-pod 'ReactCommon/turbomodule/core', :path => '../node_modules/react-native/ReactCommon'
-pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
-
-pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-
-pod 'RNVectorIcons', :path => '../node_modules/react-native-vector-icons'  
-pod 'RNGestureHandler', :path => '../node_modules/react-native-gesture-handler'
-pod 'react-native-safe-area-context', :path => '../node_modules/react-native-safe-area-context'
+config = use_native_modules!
+use_react_native!(:path => config["reactNativePath"])
 
 pod 'SalesforceSDKCommon', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceAnalytics', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
@@ -48,7 +19,6 @@ pod 'SalesforceSDKCore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'MobileSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceReact', :path => '../node_modules/react-native-force'
-
 
 end
 

--- a/ReactNativeDeferredTemplate/ios/Podfile
+++ b/ReactNativeDeferredTemplate/ios/Podfile
@@ -1,3 +1,6 @@
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
 platform :ios, '13.0'
 
 use_frameworks!
@@ -7,39 +10,8 @@ target 'ReactNativeDeferredTemplate' do
 
 source 'https://cdn.cocoapods.org/'
 
-pod 'FBLazyVector', :path => '../node_modules/react-native/Libraries/FBLazyVector'
-pod 'FBReactNativeSpec', :path => '../node_modules/react-native/Libraries/FBReactNativeSpec'
-pod 'RCTRequired', :path => '../node_modules/react-native/Libraries/RCTRequired'
-pod 'RCTTypeSafety', :path => '../node_modules/react-native/Libraries/TypeSafety'
-pod 'React', :path => '../node_modules/react-native/'
-pod 'React-Core', :path => '../node_modules/react-native/'
-pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
-pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
-pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
-pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
-pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
-pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
-pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
-pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
-pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
-pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
-pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
-
-pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
-pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
-pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
-pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-pod 'React-callinvoker', :path => '../node_modules/react-native/ReactCommon/callinvoker'
-pod 'ReactCommon/turbomodule/core', :path => '../node_modules/react-native/ReactCommon'
-pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
-
-pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-
-pod 'RNGestureHandler', :path => '../node_modules/react-native-gesture-handler'
-pod 'react-native-safe-area-context', :path => '../node_modules/react-native-safe-area-context'
+config = use_native_modules!
+use_react_native!(:path => config["reactNativePath"])
 
 pod 'SalesforceSDKCommon', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceAnalytics', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
@@ -47,8 +19,6 @@ pod 'SalesforceSDKCore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'MobileSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceReact', :path => '../node_modules/react-native-force'
-
-
 
 end
 

--- a/ReactNativeTemplate/ios/Podfile
+++ b/ReactNativeTemplate/ios/Podfile
@@ -1,3 +1,6 @@
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
 platform :ios, '13.0'
 
 use_frameworks!
@@ -7,39 +10,8 @@ target 'ReactNativeTemplate' do
 
 source 'https://cdn.cocoapods.org/'
 
-pod 'FBLazyVector', :path => '../node_modules/react-native/Libraries/FBLazyVector'
-pod 'FBReactNativeSpec', :path => '../node_modules/react-native/Libraries/FBReactNativeSpec'
-pod 'RCTRequired', :path => '../node_modules/react-native/Libraries/RCTRequired'
-pod 'RCTTypeSafety', :path => '../node_modules/react-native/Libraries/TypeSafety'
-pod 'React', :path => '../node_modules/react-native/'
-pod 'React-Core', :path => '../node_modules/react-native/'
-pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
-pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
-pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
-pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
-pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
-pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
-pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
-pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
-pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
-pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
-pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
-
-pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
-pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
-pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
-pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-pod 'React-callinvoker', :path => '../node_modules/react-native/ReactCommon/callinvoker'
-pod 'ReactCommon/turbomodule/core', :path => '../node_modules/react-native/ReactCommon'
-pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
-
-pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-
-pod 'RNGestureHandler', :path => '../node_modules/react-native-gesture-handler'
-pod 'react-native-safe-area-context', :path => '../node_modules/react-native-safe-area-context'
+config = use_native_modules!
+use_react_native!(:path => config["reactNativePath"])
 
 pod 'SalesforceSDKCommon', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceAnalytics', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
@@ -47,8 +19,6 @@ pod 'SalesforceSDKCore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'MobileSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceReact', :path => '../node_modules/react-native-force'
-
-
 
 end
 

--- a/ReactNativeTypeScriptTemplate/ios/Podfile
+++ b/ReactNativeTypeScriptTemplate/ios/Podfile
@@ -1,3 +1,6 @@
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
 platform :ios, '13.0'
 
 use_frameworks!
@@ -7,39 +10,8 @@ target 'ReactNativeTypeScriptTemplate' do
 
 source 'https://cdn.cocoapods.org/'
 
-pod 'FBLazyVector', :path => '../node_modules/react-native/Libraries/FBLazyVector'
-pod 'FBReactNativeSpec', :path => '../node_modules/react-native/Libraries/FBReactNativeSpec'
-pod 'RCTRequired', :path => '../node_modules/react-native/Libraries/RCTRequired'
-pod 'RCTTypeSafety', :path => '../node_modules/react-native/Libraries/TypeSafety'
-pod 'React', :path => '../node_modules/react-native/'
-pod 'React-Core', :path => '../node_modules/react-native/'
-pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
-pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
-pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
-pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
-pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
-pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
-pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
-pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
-pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
-pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
-pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
-
-pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
-pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
-pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
-pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-pod 'React-callinvoker', :path => '../node_modules/react-native/ReactCommon/callinvoker'
-pod 'ReactCommon/turbomodule/core', :path => '../node_modules/react-native/ReactCommon'
-pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
-
-pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-
-pod 'RNGestureHandler', :path => '../node_modules/react-native-gesture-handler'
-pod 'react-native-safe-area-context', :path => '../node_modules/react-native-safe-area-context'
+config = use_native_modules!
+use_react_native!(:path => config["reactNativePath"])
 
 pod 'SalesforceSDKCommon', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceAnalytics', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
@@ -47,8 +19,6 @@ pod 'SalesforceSDKCore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SmartStore', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'MobileSync', :path => '../mobile_sdk/SalesforceMobileSDK-iOS'
 pod 'SalesforceReact', :path => '../node_modules/react-native-force'
-
-
 
 end
 


### PR DESCRIPTION
With this change, forcereact generated apps will auto-link their dependencies.
Mobile SDK dependencies are still brought in "manually".
Auto-linking mobile sdk is of limited value because the app needs certain things in the native side of the project (e.g. AppDelegate, bootconfig) which are best brought in by using forcereact to generate the app.