### PR TITLE
Cleaning up and Upgrading Android Templates

### DIFF
--- a/AndroidIDPTemplate/app/build.gradle
+++ b/AndroidIDPTemplate/app/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 dependencies {
-  api project(':libs:MobileSync')
-  api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+  implementation project(':libs:MobileSync')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 android {
@@ -41,5 +41,6 @@ android {
 }
 
 repositories {
+  google()
   mavenCentral()
 }

--- a/AndroidIDPTemplate/build.gradle
+++ b/AndroidIDPTemplate/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-  ext.kotlin_version = '1.3.72'
+  ext.kotlin_version = '1.5.0'
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.2'
+    classpath 'com.android.tools.build:gradle:4.2.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
 }
@@ -14,6 +14,9 @@ buildscript {
 allprojects {
   repositories {
     google()
+    mavenCentral()
+
+    // FIXME: Remove this once we can figure out an alternate source to fetch PaperDB from.
     jcenter()
   }
 }

--- a/AndroidIDPTemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidIDPTemplate/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/AndroidNativeKotlinTemplate/app/build.gradle
+++ b/AndroidNativeKotlinTemplate/app/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 dependencies {
-  api project(':libs:MobileSync')
-  api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+  implementation project(':libs:MobileSync')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 android {
@@ -41,5 +41,6 @@ android {
 }
 
 repositories {
+  google()
   mavenCentral()
 }

--- a/AndroidNativeKotlinTemplate/build.gradle
+++ b/AndroidNativeKotlinTemplate/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
-    ext.kotlin_version = '1.3.72'
-    repositories {
+  ext.kotlin_version = '1.5.0'
+
+  repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.2'
+    classpath 'com.android.tools.build:gradle:4.2.0'
       classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
 }
@@ -14,6 +15,9 @@ buildscript {
 allprojects {
   repositories {
     google()
+    mavenCentral()
+
+    // FIXME: Remove this once we can figure out an alternate source to fetch PaperDB from.
     jcenter()
   }
 }

--- a/AndroidNativeKotlinTemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidNativeKotlinTemplate/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/AndroidNativeTemplate/app/build.gradle
+++ b/AndroidNativeTemplate/app/build.gradle
@@ -1,22 +1,22 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-  api project(':libs:MobileSync') // From node_modules
+  implementation project(':libs:MobileSync')
 }
 
 android {
-    compileSdkVersion 30
+  compileSdkVersion 30
 
-    defaultConfig {
-        targetSdkVersion 30
-        minSdkVersion 23
-    }
-  
+  defaultConfig {
+    targetSdkVersion 30
+    minSdkVersion 23
+  }
+
   buildTypes {
-      debug {
-         testCoverageEnabled = true
-      }
-   }
+    debug {
+      testCoverageEnabled = true
+    }
+  }
 
   sourceSets {
 

--- a/AndroidNativeTemplate/build.gradle
+++ b/AndroidNativeTemplate/build.gradle
@@ -1,17 +1,20 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.2'
+    classpath 'com.android.tools.build:gradle:4.2.0'
   }
 }
 
 allprojects {
   repositories {
     google()
+    mavenCentral()
+
+    // FIXME: Remove this once we can figure out an alternate source to fetch PaperDB from.
     jcenter()
   }
 }

--- a/AndroidNativeTemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidNativeTemplate/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/MobileSyncExplorerReactNative/android/app/build.gradle
+++ b/MobileSyncExplorerReactNative/android/app/build.gradle
@@ -141,10 +141,10 @@ android {
 }
 
 dependencies {
-    api fileTree(dir: "libs", include: ["*.jar"])
-    api 'androidx.appcompat:appcompat:1.1.0'
-    api "com.facebook.react:react-native:+"  // From node_modules
-    api project(':libs:SalesforceReact') // From node_modules
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':libs:SalesforceReact') // From node_modules
 
     // JSC from node_modules
     if (useIntlJsc) {

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -7,11 +7,11 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.2'
+    classpath 'com.android.tools.build:gradle:4.2.0'
   }
 }
 
@@ -27,6 +27,9 @@ allprojects {
       url("$rootDir/../node_modules/jsc-android/dist")
     }
     google()
+    mavenCentral()
+
+    // FIXME: Remove this once we can figure out an alternate source to fetch PaperDB from.
     jcenter()
   }
 }

--- a/MobileSyncExplorerReactNative/android/gradle/wrapper/gradle-wrapper.properties
+++ b/MobileSyncExplorerReactNative/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/ReactNativeDeferredTemplate/android/app/build.gradle
+++ b/ReactNativeDeferredTemplate/android/app/build.gradle
@@ -140,10 +140,10 @@ android {
 }
 
 dependencies {
-    api fileTree(dir: "libs", include: ["*.jar"])
-    api 'androidx.appcompat:appcompat:1.1.0'
-    api "com.facebook.react:react-native:+"  // From node_modules
-    api project(':libs:SalesforceReact') // From node_modules
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':libs:SalesforceReact') // From node_modules
 
     // JSC from node_modules
     if (useIntlJsc) {

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -7,11 +7,11 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.2'
+    classpath 'com.android.tools.build:gradle:4.2.0'
   }
 }
 
@@ -27,6 +27,9 @@ allprojects {
       url("$rootDir/../node_modules/jsc-android/dist")
     }
     google()
+    mavenCentral()
+
+    // FIXME: Remove this once we can figure out an alternate source to fetch PaperDB from.
     jcenter()
   }
 }

--- a/ReactNativeDeferredTemplate/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ReactNativeDeferredTemplate/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/ReactNativeTemplate/android/app/build.gradle
+++ b/ReactNativeTemplate/android/app/build.gradle
@@ -140,10 +140,10 @@ android {
 }
 
 dependencies {
-    api fileTree(dir: "libs", include: ["*.jar"])
-    api 'androidx.appcompat:appcompat:1.1.0'
-    api "com.facebook.react:react-native:+"  // From node_modules
-    api project(':libs:SalesforceReact') // From node_modules
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':libs:SalesforceReact') // From node_modules
 
     // JSC from node_modules
     if (useIntlJsc) {

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -7,11 +7,11 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.2'
+    classpath 'com.android.tools.build:gradle:4.2.0'
   }
 }
 
@@ -27,6 +27,9 @@ allprojects {
       url("$rootDir/../node_modules/jsc-android/dist")
     }
     google()
+    mavenCentral()
+
+    // FIXME: Remove this once we can figure out an alternate source to fetch PaperDB from.
     jcenter()
   }
 }

--- a/ReactNativeTemplate/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ReactNativeTemplate/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/ReactNativeTypeScriptTemplate/android/app/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/app/build.gradle
@@ -140,10 +140,10 @@ android {
 }
 
 dependencies {
-    api fileTree(dir: "libs", include: ["*.jar"])
-    api 'androidx.appcompat:appcompat:1.1.0'
-    api "com.facebook.react:react-native:+"  // From node_modules
-    api project(':libs:SalesforceReact') // From node_modules
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':libs:SalesforceReact') // From node_modules
 
     // JSC from node_modules
     if (useIntlJsc) {

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -7,11 +7,11 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.2'
+    classpath 'com.android.tools.build:gradle:4.2.0'
   }
 }
 
@@ -27,6 +27,9 @@ allprojects {
       url("$rootDir/../node_modules/jsc-android/dist")
     }
     google()
+    mavenCentral()
+
+    // FIXME: Remove this once we can figure out an alternate source to fetch PaperDB from.
     jcenter()
   }
 }

--- a/ReactNativeTypeScriptTemplate/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ReactNativeTypeScriptTemplate/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
- Upgrading to `AGP 4.2` for `Android Studio 4.2`.
- Upgrading to `Kotlin 1.5`.
- Removing `jcenter()` from most places, except where it's required for `PaperDB`.
- Replacing `api` with `implementation`.