### PR TITLE
Bump React Native to 0.67.1.

### DIFF
--- a/MobileSyncExplorerReactNative/package.json
+++ b/MobileSyncExplorerReactNative/package.json
@@ -15,7 +15,7 @@
         "@react-navigation/native": "^6.0.2",
         "@react-navigation/stack": "^6.0.7",
         "react": "17.0.2",
-        "react-native": "0.67.0",
+        "react-native": "0.67.1",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
         "react-native-elements": "^3.4.2",
         "react-native-gesture-handler": "^1.10.3",

--- a/ReactNativeDeferredTemplate/package.json
+++ b/ReactNativeDeferredTemplate/package.json
@@ -15,7 +15,7 @@
         "@react-navigation/native": "^6.0.2",
         "@react-navigation/stack": "^6.0.7",
         "react": "17.0.2",
-        "react-native": "0.67.0",
+        "react-native": "0.67.1",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
         "react-native-gesture-handler": "^1.10.3",
         "react-native-safe-area-context": "^3.3.0",

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -15,7 +15,7 @@
         "@react-navigation/native": "^6.0.2",
         "@react-navigation/stack": "^6.0.7",
         "react": "17.0.2",
-        "react-native": "0.67.0",
+        "react-native": "0.67.1",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
         "react-native-gesture-handler": "^1.10.3",
         "react-native-safe-area-context": "^3.3.0",

--- a/ReactNativeTypeScriptTemplate/package.json
+++ b/ReactNativeTypeScriptTemplate/package.json
@@ -15,7 +15,7 @@
         "@react-navigation/native": "^6.0.2",
         "@react-navigation/stack": "^6.0.7",
         "react": "17.0.2",
-        "react-native": "0.67.0",
+        "react-native": "0.67.1",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
         "react-native-gesture-handler": "^1.10.3",
         "react-native-safe-area-context": "^3.3.0",


### PR DESCRIPTION
This is fixes a crash for Android release builds.