### PR TITLE
Fixes compiler error with MobileSync Explorer Kotlin Template

### DIFF
--- a/MobileSyncExplorerKotlinTemplate/app/src/main/java/com/salesforce/mobilesyncexplorerkotlintemplate/core/extensions/SmartStoreExt.kt
+++ b/MobileSyncExplorerKotlinTemplate/app/src/main/java/com/salesforce/mobilesyncexplorerkotlintemplate/core/extensions/SmartStoreExt.kt
@@ -51,8 +51,8 @@ fun SmartStore.retrieveSingleById(
 
         soupIdResult.exceptionOrNull()?.let {
             throw IllegalArgumentException(
-                message = "Could not retrieve single soup ID for provided ID=$id and column name=$idColName",
-                cause = it
+                "Could not retrieve single soup ID for provided ID=$id and column name=$idColName",
+                it
             )
         }
 
@@ -65,8 +65,8 @@ fun SmartStore.retrieveSingleById(
 
             results.exceptionOrNull()?.let {
                 throw IllegalArgumentException(
-                    message = "Could not retrieve single soup ID for provided ID=$id and column name=$idColName",
-                    cause = it
+                    "Could not retrieve single soup ID for provided ID=$id and column name=$idColName",
+                    it
                 )
             }
 


### PR DESCRIPTION
Somehow a bug slipped through where Kotlin named parameters were filled in by the IDE when trying to use a Java-only construct.  This cannot compile, and it was probably due to not running the app after a cleanup commit late in the development of the template.

Removing these named arguments gets the app to compile.