### PR TITLE
Cleaner pod files for React Native templates

### DIFF
--- a/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative.xcodeproj/project.pbxproj
+++ b/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative.xcodeproj/project.pbxproj
@@ -9,13 +9,11 @@
 /* Begin PBXBuildFile section */
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		4F08604A236D0F380087150A /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4F086048236D0EFC0087150A /* MaterialCommunityIcons.ttf */; };
-		4F08604B236D0F3B0087150A /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4F086049236D0EFC0087150A /* MaterialIcons.ttf */; };
 		4F3AFF401DC2C79E006FF6B0 /* InitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F3AFF3E1DC2C79E006FF6B0 /* InitialViewController.m */; };
-		8BC5214908B3BE588047AD03 /* Pods_MobileSyncExplorerReactNative.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 241B7882460CD09A8AF3E536 /* Pods_MobileSyncExplorerReactNative.framework */; };
 		B7168FC01FACCB8A00A48DB5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B7168FBF1FACCB8900A48DB5 /* LaunchScreen.storyboard */; };
 		B77BD8B1211363F70036B284 /* bootconfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = B77BD8B0211363F70036B284 /* bootconfig.plist */; };
 		CE6BC3F620F12070009E4AAE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F3AFF441DC2C8C8006FF6B0 /* Images.xcassets */; };
+		F82D7DA349881BDCDC7A44CA /* libPods-MobileSyncExplorerReactNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6919252FC5A12C953709275E /* libPods-MobileSyncExplorerReactNative.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,13 +23,13 @@
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = MobileSyncExplorerReactNative/AppDelegate.m; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = MobileSyncExplorerReactNative/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = MobileSyncExplorerReactNative/main.m; sourceTree = "<group>"; };
-		241B7882460CD09A8AF3E536 /* Pods_MobileSyncExplorerReactNative.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MobileSyncExplorerReactNative.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F086048236D0EFC0087150A /* MaterialCommunityIcons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = MaterialCommunityIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf"; sourceTree = "<group>"; };
 		4F086049236D0EFC0087150A /* MaterialIcons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
 		4F3AFF3D1DC2C79E006FF6B0 /* InitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InitialViewController.h; path = MobileSyncExplorerReactNative/InitialViewController.h; sourceTree = "<group>"; };
 		4F3AFF3E1DC2C79E006FF6B0 /* InitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InitialViewController.m; path = MobileSyncExplorerReactNative/InitialViewController.m; sourceTree = "<group>"; };
 		4F3AFF441DC2C8C8006FF6B0 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../mobile_sdk/SalesforceMobileSDK-iOS/shared/resources/Images.xcassets"; sourceTree = "<group>"; };
 		4FF12F8E1DCA93E2004D9EF9 /* MobileSyncExplorerReactNative.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = MobileSyncExplorerReactNative.entitlements; path = MobileSyncExplorerReactNative/MobileSyncExplorerReactNative.entitlements; sourceTree = "<group>"; };
+		6919252FC5A12C953709275E /* libPods-MobileSyncExplorerReactNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MobileSyncExplorerReactNative.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE79D28E6E57F5B77FA24716 /* Pods-MobileSyncExplorerReactNative.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MobileSyncExplorerReactNative.release.xcconfig"; path = "Pods/Target Support Files/Pods-MobileSyncExplorerReactNative/Pods-MobileSyncExplorerReactNative.release.xcconfig"; sourceTree = "<group>"; };
 		B7168FBF1FACCB8900A48DB5 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = "../mobile_sdk/salesforcemobilesdk-ios/shared/resources/LaunchScreen.storyboard"; sourceTree = "<group>"; };
 		B77BD8B0211363F70036B284 /* bootconfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = bootconfig.plist; path = MobileSyncExplorerReactNative/bootconfig.plist; sourceTree = "<group>"; };
@@ -43,7 +41,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8BC5214908B3BE588047AD03 /* Pods_MobileSyncExplorerReactNative.framework in Frameworks */,
+				F82D7DA349881BDCDC7A44CA /* libPods-MobileSyncExplorerReactNative.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -126,7 +124,7 @@
 			isa = PBXGroup;
 			children = (
 				CE46D5431E9C942C006E6537 /* XCTest.framework */,
-				241B7882460CD09A8AF3E536 /* Pods_MobileSyncExplorerReactNative.framework */,
+				6919252FC5A12C953709275E /* libPods-MobileSyncExplorerReactNative.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -144,6 +142,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				2E0BD7FE4A4B39D5E6E2F291 /* [CP] Embed Pods Frameworks */,
+				AD789C7F8A064EA59E21E621 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -198,8 +197,6 @@
 			files = (
 				B77BD8B1211363F70036B284 /* bootconfig.plist in Resources */,
 				CE6BC3F620F12070009E4AAE /* Images.xcassets in Resources */,
-				4F08604B236D0F3B0087150A /* MaterialIcons.ttf in Resources */,
-				4F08604A236D0F380087150A /* MaterialCommunityIcons.ttf in Resources */,
 				B7168FC01FACCB8A00A48DB5 /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -254,6 +251,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MobileSyncExplorerReactNative/Pods-MobileSyncExplorerReactNative-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AD789C7F8A064EA59E21E621 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MobileSyncExplorerReactNative/Pods-MobileSyncExplorerReactNative-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MobileSyncExplorerReactNative/Pods-MobileSyncExplorerReactNative-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MobileSyncExplorerReactNative/Pods-MobileSyncExplorerReactNative-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -377,7 +391,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -438,7 +452,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/MobileSyncExplorerReactNative/ios/Podfile
+++ b/MobileSyncExplorerReactNative/ios/Podfile
@@ -5,8 +5,6 @@ require_relative '../mobile_sdk/SalesforceMobileSDK-iOS/mobilesdk_pods'
 
 platform :ios, '14.0'
 
-use_frameworks!
-
 project 'MobileSyncExplorerReactNative.xcodeproj'
 target 'MobileSyncExplorerReactNative' do
   source 'https://cdn.cocoapods.org/'
@@ -17,30 +15,25 @@ target 'MobileSyncExplorerReactNative' do
 
   use_react_native!(
     :path => config[:reactNativePath],
-    :hermes_enabled => false,
+    :hermes_enabled => true,
     :fabric_enabled => flags[:fabric_enabled],
     :flipper_configuration => FlipperConfiguration.disabled,
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  use_mobile_sdk(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
   pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 end
 
-# To avoid Xcode 12 compilation errors in RNScreens and RNCMaskedView
 pre_install do |installer|
-  installer.pod_targets.each do |pod|
-    if pod.name.eql?('RNScreens') || pod.name.eql?('RNCMaskedView')
-      def pod.build_type
-        Pod::BuildType.static_library
-      end
-    end
-  end
+  # Mobile SDK pre install
+  mobile_sdk_pre_install(installer)  
 end
+
 
 post_install do |installer|
   # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
-  signposts_post_install(installer)
+  enable_sign_posts_post_install(installer)
 
   # React native post install
   react_native_post_install(
@@ -53,12 +46,6 @@ post_install do |installer|
   # Cocoapods workaround for M1 machines
   __apply_Xcode_12_5_M1_post_install_workaround(installer)
   
-  # Keeping Mobile SDK iOS deployment target at 14 (__apply_Xcode_12_5_M1_post_install_workaround changes it to 11)
-  installer.pods_project.targets.each do |target|
-    if ['SalesforceAnalytics', 'SalesforceSDKCommon', 'SalesforceSDKCore', 'SmartStore', 'MobileSync', 'SalesforceReact'].include?(target.name)
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
-      end
-    end
-  end
+  # Mobile SDK post install
+  mobile_sdk_post_install(installer)
 end

--- a/MobileSyncExplorerReactNative/ios/Podfile
+++ b/MobileSyncExplorerReactNative/ios/Podfile
@@ -21,7 +21,7 @@ target 'MobileSyncExplorerReactNative' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  use_mobile_sdk(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
   pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 end
 
@@ -33,7 +33,7 @@ end
 
 post_install do |installer|
   # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
-  enable_sign_posts_post_install(installer)
+  signposts_post_install(installer)
 
   # React native post install
   react_native_post_install(

--- a/ReactNativeDeferredTemplate/ios/Podfile
+++ b/ReactNativeDeferredTemplate/ios/Podfile
@@ -20,7 +20,7 @@ target 'ReactNativeDeferredTemplate' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  use_mobile_sdk(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
   pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 end
 
@@ -32,7 +32,7 @@ end
 
 post_install do |installer|
   # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
-  enable_sign_posts_post_install(installer)
+  signposts_post_install(installer)
 
   # React native post install
   react_native_post_install(

--- a/ReactNativeDeferredTemplate/ios/Podfile
+++ b/ReactNativeDeferredTemplate/ios/Podfile
@@ -4,8 +4,6 @@ require_relative '../mobile_sdk/SalesforceMobileSDK-iOS/mobilesdk_pods'
 
 platform :ios, '14.0'
 
-use_frameworks!
-
 project 'ReactNativeDeferredTemplate.xcodeproj'
 target 'ReactNativeDeferredTemplate' do
   source 'https://cdn.cocoapods.org/'
@@ -16,30 +14,25 @@ target 'ReactNativeDeferredTemplate' do
 
   use_react_native!(
     :path => config[:reactNativePath],
-    :hermes_enabled => false,
+    :hermes_enabled => true,
     :fabric_enabled => flags[:fabric_enabled],
     :flipper_configuration => FlipperConfiguration.disabled,
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  use_mobile_sdk(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
   pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 end
 
-# To avoid Xcode 12 compilation errors in RNScreens and RNCMaskedView
 pre_install do |installer|
-  installer.pod_targets.each do |pod|
-    if pod.name.eql?('RNScreens') || pod.name.eql?('RNCMaskedView')
-      def pod.build_type
-        Pod::BuildType.static_library
-      end
-    end
-  end
+  # Mobile SDK pre install
+  mobile_sdk_pre_install(installer)  
 end
+
 
 post_install do |installer|
   # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
-  signposts_post_install(installer)
+  enable_sign_posts_post_install(installer)
 
   # React native post install
   react_native_post_install(
@@ -52,12 +45,6 @@ post_install do |installer|
   # Cocoapods workaround for M1 machines
   __apply_Xcode_12_5_M1_post_install_workaround(installer)
   
-  # Keeping Mobile SDK iOS deployment target at 14 (__apply_Xcode_12_5_M1_post_install_workaround changes it to 11)
-  installer.pods_project.targets.each do |target|
-    if ['SalesforceAnalytics', 'SalesforceSDKCommon', 'SalesforceSDKCore', 'SmartStore', 'MobileSync', 'SalesforceReact'].include?(target.name)
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
-      end
-    end
-  end
+  # Mobile SDK post install
+  mobile_sdk_post_install(installer)
 end

--- a/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate.xcodeproj/project.pbxproj
+++ b/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate.xcodeproj/project.pbxproj
@@ -10,10 +10,10 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		4F3AFF401DC2C79E006FF6B0 /* InitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F3AFF3E1DC2C79E006FF6B0 /* InitialViewController.m */; };
+		95C7C3652A03B3F2EC5A80D1 /* libPods-ReactNativeDeferredTemplate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CC492F435FC814C9A5D1930 /* libPods-ReactNativeDeferredTemplate.a */; };
 		B7168FBE1FACC7EB00A48DB5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B7168FBD1FACC7EB00A48DB5 /* LaunchScreen.storyboard */; };
 		B77BD8AF2113632C0036B284 /* bootconfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = B77BD8AE2113632C0036B284 /* bootconfig.plist */; };
 		CEA8CA061F071C3300448B51 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEA8CA051F071C3300448B51 /* Images.xcassets */; };
-		F5912893D1259DD728C3911A /* Pods_ReactNativeDeferredTemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C3F430144BCD949E2D63D5 /* Pods_ReactNativeDeferredTemplate.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,10 +24,10 @@
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = ReactNativeDeferredTemplate/AppDelegate.m; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ReactNativeDeferredTemplate/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ReactNativeDeferredTemplate/main.m; sourceTree = "<group>"; };
+		1CC492F435FC814C9A5D1930 /* libPods-ReactNativeDeferredTemplate.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReactNativeDeferredTemplate.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F3AFF3D1DC2C79E006FF6B0 /* InitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InitialViewController.h; path = ReactNativeDeferredTemplate/InitialViewController.h; sourceTree = "<group>"; };
 		4F3AFF3E1DC2C79E006FF6B0 /* InitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InitialViewController.m; path = ReactNativeDeferredTemplate/InitialViewController.m; sourceTree = "<group>"; };
 		4FF12F8E1DCA93E2004D9EF9 /* ReactNativeDeferredTemplate.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ReactNativeDeferredTemplate.entitlements; path = ReactNativeDeferredTemplate/ReactNativeDeferredTemplate.entitlements; sourceTree = "<group>"; };
-		A8C3F430144BCD949E2D63D5 /* Pods_ReactNativeDeferredTemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactNativeDeferredTemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE79D28E6E57F5B77FA24716 /* Pods-ReactNativeDeferredTemplate.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNativeDeferredTemplate.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReactNativeDeferredTemplate/Pods-ReactNativeDeferredTemplate.release.xcconfig"; sourceTree = "<group>"; };
 		B7168FBD1FACC7EB00A48DB5 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = "../mobile_sdk/SalesforceMobileSDK-iOS/shared/resources/LaunchScreen.storyboard"; sourceTree = "<group>"; };
 		B77BD8AE2113632C0036B284 /* bootconfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = bootconfig.plist; path = ReactNativeDeferredTemplate/bootconfig.plist; sourceTree = "<group>"; };
@@ -39,7 +39,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F5912893D1259DD728C3911A /* Pods_ReactNativeDeferredTemplate.framework in Frameworks */,
+				95C7C3652A03B3F2EC5A80D1 /* libPods-ReactNativeDeferredTemplate.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,7 +112,7 @@
 		C73512AABD4BDBC0734E686B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A8C3F430144BCD949E2D63D5 /* Pods_ReactNativeDeferredTemplate.framework */,
+				1CC492F435FC814C9A5D1930 /* libPods-ReactNativeDeferredTemplate.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -130,6 +130,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				B891CA51A709510414527DB8 /* [CP] Embed Pods Frameworks */,
+				FBE78BC7211EEDB392696990 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -238,6 +239,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ReactNativeDeferredTemplate/Pods-ReactNativeDeferredTemplate-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FBE78BC7211EEDB392696990 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ReactNativeDeferredTemplate/Pods-ReactNativeDeferredTemplate-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ReactNativeDeferredTemplate/Pods-ReactNativeDeferredTemplate-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ReactNativeDeferredTemplate/Pods-ReactNativeDeferredTemplate-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -354,7 +372,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -415,7 +433,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/ReactNativeTemplate/ios/Podfile
+++ b/ReactNativeTemplate/ios/Podfile
@@ -21,7 +21,7 @@ target 'ReactNativeTemplate' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  use_mobile_sdk(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
   pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 end
 
@@ -33,7 +33,7 @@ end
 
 post_install do |installer|
   # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
-  enable_sign_posts_post_install(installer)
+  signposts_post_install(installer)
 
   # React native post install
   react_native_post_install(

--- a/ReactNativeTemplate/ios/Podfile
+++ b/ReactNativeTemplate/ios/Podfile
@@ -5,8 +5,6 @@ require_relative '../mobile_sdk/SalesforceMobileSDK-iOS/mobilesdk_pods'
 
 platform :ios, '14.0'
 
-use_frameworks!
-
 project 'ReactNativeTemplate.xcodeproj'
 target 'ReactNativeTemplate' do
   source 'https://cdn.cocoapods.org/'
@@ -17,30 +15,25 @@ target 'ReactNativeTemplate' do
 
   use_react_native!(
     :path => config[:reactNativePath],
-    :hermes_enabled => false,
+    :hermes_enabled => true,
     :fabric_enabled => flags[:fabric_enabled],
     :flipper_configuration => FlipperConfiguration.disabled,
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  use_mobile_sdk(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
   pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 end
 
-# To avoid Xcode 12 compilation errors in RNScreens and RNCMaskedView
 pre_install do |installer|
-  installer.pod_targets.each do |pod|
-    if pod.name.eql?('RNScreens') || pod.name.eql?('RNCMaskedView')
-      def pod.build_type
-        Pod::BuildType.static_library
-      end
-    end
-  end
+  # Mobile SDK pre install
+  mobile_sdk_pre_install(installer)  
 end
+
 
 post_install do |installer|
   # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
-  signposts_post_install(installer)
+  enable_sign_posts_post_install(installer)
 
   # React native post install
   react_native_post_install(
@@ -53,12 +46,6 @@ post_install do |installer|
   # Cocoapods workaround for M1 machines
   __apply_Xcode_12_5_M1_post_install_workaround(installer)
   
-  # Keeping Mobile SDK iOS deployment target at 14 (__apply_Xcode_12_5_M1_post_install_workaround changes it to 11)
-  installer.pods_project.targets.each do |target|
-    if ['SalesforceAnalytics', 'SalesforceSDKCommon', 'SalesforceSDKCore', 'SmartStore', 'MobileSync', 'SalesforceReact'].include?(target.name)
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
-      end
-    end
-  end
+  # Mobile SDK post install
+  mobile_sdk_post_install(installer)
 end

--- a/ReactNativeTemplate/ios/ReactNativeTemplate.xcodeproj/project.pbxproj
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate.xcodeproj/project.pbxproj
@@ -9,8 +9,8 @@
 /* Begin PBXBuildFile section */
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		2A90C415C6232DFBB08AB3A6 /* libPods-ReactNativeTemplate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E37643224D36EE3F2C35C05E /* libPods-ReactNativeTemplate.a */; };
 		4F3AFF401DC2C79E006FF6B0 /* InitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F3AFF3E1DC2C79E006FF6B0 /* InitialViewController.m */; };
-		AEB6207A931E33F5FD5BDA40 /* Pods_ReactNativeTemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D50B911E2F045A460A23459 /* Pods_ReactNativeTemplate.framework */; };
 		B7168FBE1FACC7EB00A48DB5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B7168FBD1FACC7EB00A48DB5 /* LaunchScreen.storyboard */; };
 		B77BD8AF2113632C0036B284 /* bootconfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = B77BD8AE2113632C0036B284 /* bootconfig.plist */; };
 		CEA8CA061F071C3300448B51 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEA8CA051F071C3300448B51 /* Images.xcassets */; };
@@ -27,11 +27,11 @@
 		4F3AFF3D1DC2C79E006FF6B0 /* InitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InitialViewController.h; path = ReactNativeTemplate/InitialViewController.h; sourceTree = "<group>"; };
 		4F3AFF3E1DC2C79E006FF6B0 /* InitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InitialViewController.m; path = ReactNativeTemplate/InitialViewController.m; sourceTree = "<group>"; };
 		4FF12F8E1DCA93E2004D9EF9 /* ReactNativeTemplate.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ReactNativeTemplate.entitlements; path = ReactNativeTemplate/ReactNativeTemplate.entitlements; sourceTree = "<group>"; };
-		7D50B911E2F045A460A23459 /* Pods_ReactNativeTemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactNativeTemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE79D28E6E57F5B77FA24716 /* Pods-ReactNativeTemplate.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNativeTemplate.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReactNativeTemplate/Pods-ReactNativeTemplate.release.xcconfig"; sourceTree = "<group>"; };
 		B7168FBD1FACC7EB00A48DB5 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = "../mobile_sdk/SalesforceMobileSDK-iOS/shared/resources/LaunchScreen.storyboard"; sourceTree = "<group>"; };
 		B77BD8AE2113632C0036B284 /* bootconfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = bootconfig.plist; path = ReactNativeTemplate/bootconfig.plist; sourceTree = "<group>"; };
 		CEA8CA051F071C3300448B51 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../mobile_sdk/SalesforceMobileSDK-iOS/shared/resources/Images.xcassets"; sourceTree = "<group>"; };
+		E37643224D36EE3F2C35C05E /* libPods-ReactNativeTemplate.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReactNativeTemplate.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -39,7 +39,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AEB6207A931E33F5FD5BDA40 /* Pods_ReactNativeTemplate.framework in Frameworks */,
+				2A90C415C6232DFBB08AB3A6 /* libPods-ReactNativeTemplate.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,7 +112,7 @@
 		C73512AABD4BDBC0734E686B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				7D50B911E2F045A460A23459 /* Pods_ReactNativeTemplate.framework */,
+				E37643224D36EE3F2C35C05E /* libPods-ReactNativeTemplate.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -130,6 +130,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				B891CA51A709510414527DB8 /* [CP] Embed Pods Frameworks */,
+				00DC77A9A87EDA30467C15DD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -191,6 +192,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		00DC77A9A87EDA30467C15DD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ReactNativeTemplate/Pods-ReactNativeTemplate-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ReactNativeTemplate/Pods-ReactNativeTemplate-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ReactNativeTemplate/Pods-ReactNativeTemplate-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/ReactNativeTypeScriptTemplate/ios/Podfile
+++ b/ReactNativeTypeScriptTemplate/ios/Podfile
@@ -4,8 +4,6 @@ require_relative '../mobile_sdk/SalesforceMobileSDK-iOS/mobilesdk_pods'
 
 platform :ios, '14.0'
 
-use_frameworks!
-
 project 'ReactNativeTypeScriptTemplate.xcodeproj'
 target 'ReactNativeTypeScriptTemplate' do
   source 'https://cdn.cocoapods.org/'
@@ -16,30 +14,25 @@ target 'ReactNativeTypeScriptTemplate' do
 
   use_react_native!(
     :path => config[:reactNativePath],
-    :hermes_enabled => false,
+    :hermes_enabled => true,
     :fabric_enabled => flags[:fabric_enabled],
     :flipper_configuration => FlipperConfiguration.disabled,
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  use_mobile_sdk(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
   pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 end
 
-# To avoid Xcode 12 compilation errors in RNScreens and RNCMaskedView
 pre_install do |installer|
-  installer.pod_targets.each do |pod|
-    if pod.name.eql?('RNScreens') || pod.name.eql?('RNCMaskedView')
-      def pod.build_type
-        Pod::BuildType.static_library
-      end
-    end
-  end
+  # Mobile SDK pre install
+  mobile_sdk_pre_install(installer)  
 end
+
 
 post_install do |installer|
   # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
-  signposts_post_install(installer)
+  enable_sign_posts_post_install(installer)
 
   # React native post install
   react_native_post_install(
@@ -52,12 +45,6 @@ post_install do |installer|
   # Cocoapods workaround for M1 machines
   __apply_Xcode_12_5_M1_post_install_workaround(installer)
   
-  # Keeping Mobile SDK iOS deployment target at 14 (__apply_Xcode_12_5_M1_post_install_workaround changes it to 11)
-  installer.pods_project.targets.each do |target|
-    if ['SalesforceAnalytics', 'SalesforceSDKCommon', 'SalesforceSDKCore', 'SmartStore', 'MobileSync', 'SalesforceReact'].include?(target.name)
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
-      end
-    end
-  end
+  # Mobile SDK post install
+  mobile_sdk_post_install(installer)
 end

--- a/ReactNativeTypeScriptTemplate/ios/Podfile
+++ b/ReactNativeTypeScriptTemplate/ios/Podfile
@@ -20,7 +20,7 @@ target 'ReactNativeTypeScriptTemplate' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  use_mobile_sdk(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
   pod 'SalesforceReact', :path => '../node_modules/react-native-force'
 end
 
@@ -32,7 +32,7 @@ end
 
 post_install do |installer|
   # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
-  enable_sign_posts_post_install(installer)
+  signposts_post_install(installer)
 
   # React native post install
   react_native_post_install(

--- a/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate.xcodeproj/project.pbxproj
+++ b/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate.xcodeproj/project.pbxproj
@@ -10,10 +10,10 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		4F3AFF401DC2C79E006FF6B0 /* InitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F3AFF3E1DC2C79E006FF6B0 /* InitialViewController.m */; };
+		9B154E56ECA590684B374220 /* libPods-ReactNativeTypeScriptTemplate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A088E6AA6C5AA26C0E186760 /* libPods-ReactNativeTypeScriptTemplate.a */; };
 		B7168FBE1FACC7EB00A48DB5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B7168FBD1FACC7EB00A48DB5 /* LaunchScreen.storyboard */; };
 		B77BD8AF2113632C0036B284 /* bootconfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = B77BD8AE2113632C0036B284 /* bootconfig.plist */; };
 		CEA8CA061F071C3300448B51 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEA8CA051F071C3300448B51 /* Images.xcassets */; };
-		F5912893D1259DD728C3911A /* Pods_ReactNativeTypeScriptTemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C3F430144BCD949E2D63D5 /* Pods_ReactNativeTypeScriptTemplate.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,7 +27,7 @@
 		4F3AFF3D1DC2C79E006FF6B0 /* InitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InitialViewController.h; path = ReactNativeTypeScriptTemplate/InitialViewController.h; sourceTree = "<group>"; };
 		4F3AFF3E1DC2C79E006FF6B0 /* InitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InitialViewController.m; path = ReactNativeTypeScriptTemplate/InitialViewController.m; sourceTree = "<group>"; };
 		4FF12F8E1DCA93E2004D9EF9 /* ReactNativeTypeScriptTemplate.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ReactNativeTypeScriptTemplate.entitlements; path = ReactNativeTypeScriptTemplate/ReactNativeTypeScriptTemplate.entitlements; sourceTree = "<group>"; };
-		A8C3F430144BCD949E2D63D5 /* Pods_ReactNativeTypeScriptTemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactNativeTypeScriptTemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A088E6AA6C5AA26C0E186760 /* libPods-ReactNativeTypeScriptTemplate.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReactNativeTypeScriptTemplate.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE79D28E6E57F5B77FA24716 /* Pods-ReactNativeTypeScriptTemplate.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNativeTypeScriptTemplate.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReactNativeTypeScriptTemplate/Pods-ReactNativeTypeScriptTemplate.release.xcconfig"; sourceTree = "<group>"; };
 		B7168FBD1FACC7EB00A48DB5 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = "../mobile_sdk/SalesforceMobileSDK-iOS/shared/resources/LaunchScreen.storyboard"; sourceTree = "<group>"; };
 		B77BD8AE2113632C0036B284 /* bootconfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = bootconfig.plist; path = ReactNativeTypeScriptTemplate/bootconfig.plist; sourceTree = "<group>"; };
@@ -39,7 +39,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F5912893D1259DD728C3911A /* Pods_ReactNativeTypeScriptTemplate.framework in Frameworks */,
+				9B154E56ECA590684B374220 /* libPods-ReactNativeTypeScriptTemplate.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,7 +112,7 @@
 		C73512AABD4BDBC0734E686B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A8C3F430144BCD949E2D63D5 /* Pods_ReactNativeTypeScriptTemplate.framework */,
+				A088E6AA6C5AA26C0E186760 /* libPods-ReactNativeTypeScriptTemplate.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -130,6 +130,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				B891CA51A709510414527DB8 /* [CP] Embed Pods Frameworks */,
+				5913213DF7990ECB39442662 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -221,6 +222,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5913213DF7990ECB39442662 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ReactNativeTypeScriptTemplate/Pods-ReactNativeTypeScriptTemplate-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ReactNativeTypeScriptTemplate/Pods-ReactNativeTypeScriptTemplate-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ReactNativeTypeScriptTemplate/Pods-ReactNativeTypeScriptTemplate-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B891CA51A709510414527DB8 /* [CP] Embed Pods Frameworks */ = {
@@ -354,7 +372,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -415,7 +433,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;


### PR DESCRIPTION
- no longer using use_frameworks!
- calling helper functions defined in mobilesdk_pods.rb
- now it works with Hermes enabled

(however it still failing to build with Xcode 13 / it works fine with Xcode 14)