### PR TITLE
Fix for Xcode 14.3

### DIFF
--- a/MobileSyncExplorerSwift/Podfile
+++ b/MobileSyncExplorerSwift/Podfile
@@ -15,7 +15,9 @@ target 'RecentContactsExtension' do
   pod 'SalesforceSDKCore', :path => "./mobile_sdk/SalesforceMobileSDK-iOS"
 end
 
-# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
 post_install do |installer|
+  # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
   signposts_post_install(installer)
+
+  mobile_sdk_post_install(installer)
 end

--- a/iOSIDPTemplate/Podfile
+++ b/iOSIDPTemplate/Podfile
@@ -10,7 +10,9 @@ target 'Authenticator' do
   pod 'SwipeCellKit', '2.7.1'
 end
 
-# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
 post_install do |installer|
+  # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
   signposts_post_install(installer)
+
+  mobile_sdk_post_install(installer)
 end

--- a/iOSNativeSwiftEncryptedNotificationTemplate/Podfile
+++ b/iOSNativeSwiftEncryptedNotificationTemplate/Podfile
@@ -13,7 +13,9 @@ target 'EncryptedNotificationTemplate' do
   end
 end
 
-# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
 post_install do |installer|
+  # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
   signposts_post_install(installer)
+
+  mobile_sdk_post_install(installer)
 end

--- a/iOSNativeSwiftTemplate/Podfile
+++ b/iOSNativeSwiftTemplate/Podfile
@@ -9,7 +9,9 @@ target 'iOSNativeSwiftTemplate' do
   use_mobile_sdk!
 end
 
-# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
 post_install do |installer|
+  # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
   signposts_post_install(installer)
+
+  mobile_sdk_post_install(installer)
 end

--- a/iOSNativeTemplate/Podfile
+++ b/iOSNativeTemplate/Podfile
@@ -9,7 +9,9 @@ target 'iOSNativeTemplate' do
   use_mobile_sdk!
 end
 
-# Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
 post_install do |installer|
+  # Comment the following if you do not want the SDK to emit signpost events for instrumentation. Signposts are  enabled for non release version of the app.
   signposts_post_install(installer)
+
+  mobile_sdk_post_install(installer)
 end


### PR DESCRIPTION
Calling mobile_sdk_post_install which fixes deployment targets (see https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3601)