### PR TITLE
Moving package name to build.gradle

### DIFF
--- a/AndroidIDPTemplate/app/AndroidManifest.xml
+++ b/AndroidIDPTemplate/app/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.samples.salesforceandroididptemplateapp"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/AndroidIDPTemplate/app/build.gradle
+++ b/AndroidIDPTemplate/app/build.gradle
@@ -6,6 +6,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.samples.salesforceandroididptemplateapp"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/AndroidIDPTemplate/template.js
+++ b/AndroidIDPTemplate/template.js
@@ -42,7 +42,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Key files
     var templatePackageJsonFile = 'package.json';
     var templateSettingsGradle = 'settings.gradle';
-    var templateAndroidManifestFile = path.join('app', 'AndroidManifest.xml');
+    var templateBuildGradleFile = path.join('app', 'build.gradle');
     var templateStringsXmlFile = path.join('app', 'res', 'values', 'strings.xml');
     var templateBootconfigFile = path.join('app', 'res', 'values', 'bootconfig.xml');
     var templateMainActivityFile = path.join('app', 'src', 'com', 'salesforce', 'samples', 'salesforceandroididptemplateapp', 'MainActivity.kt');
@@ -56,7 +56,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateSettingsGradle, templateStringsXmlFile]);
 
     // package name
-    replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+    replaceInFiles(templatePackageName, config.packagename, [templateBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
     
     //
     // Rename/move files

--- a/AndroidNativeKotlinTemplate/app/AndroidManifest.xml
+++ b/AndroidNativeKotlinTemplate/app/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidnativekotlintemplate"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/AndroidNativeKotlinTemplate/app/build.gradle
+++ b/AndroidNativeKotlinTemplate/app/build.gradle
@@ -6,6 +6,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.androidnativekotlintemplate"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/AndroidNativeKotlinTemplate/template.js
+++ b/AndroidNativeKotlinTemplate/template.js
@@ -42,7 +42,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Key files
     var templatePackageJsonFile = 'package.json';
     var templateSettingsGradle = 'settings.gradle';
-    var templateAndroidManifestFile = path.join('app', 'AndroidManifest.xml');
+    var templateBuildGradleFile = path.join('app', 'build.gradle');
     var templateStringsXmlFile = path.join('app', 'res', 'values', 'strings.xml');
     var templateBootconfigFile = path.join('app', 'res', 'values', 'bootconfig.xml');
     var templateMainActivityFile = path.join('app', 'src', 'com', 'salesforce', 'androidnativekotlintemplate', 'MainActivity.kt');
@@ -56,7 +56,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateSettingsGradle, templateStringsXmlFile]);
 
     // package name
-    replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+    replaceInFiles(templatePackageName, config.packagename, [templateBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
     
     //
     // Rename/move files

--- a/AndroidNativeTemplate/app/AndroidManifest.xml
+++ b/AndroidNativeTemplate/app/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidnativetemplate"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/AndroidNativeTemplate/app/build.gradle
+++ b/AndroidNativeTemplate/app/build.gradle
@@ -5,6 +5,8 @@ dependencies {
 }
 
 android {
+  namespace = "com.salesforce.androidnativetemplate"
+
   compileSdkVersion 33
 
   defaultConfig {

--- a/AndroidNativeTemplate/package.json
+++ b/AndroidNativeTemplate/package.json
@@ -3,6 +3,6 @@
     "version": "0.0.1",
     "private": true,
     "sdkDependencies": {
-        "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev"
+        "SalesforceMobileSDK-Android": "https://github.com/wmathurin/SalesforceMobileSDK-Android.git#dev"
     }
 }

--- a/AndroidNativeTemplate/package.json
+++ b/AndroidNativeTemplate/package.json
@@ -3,6 +3,6 @@
     "version": "0.0.1",
     "private": true,
     "sdkDependencies": {
-        "SalesforceMobileSDK-Android": "https://github.com/wmathurin/SalesforceMobileSDK-Android.git#dev"
+        "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev"
     }
 }

--- a/AndroidNativeTemplate/template.js
+++ b/AndroidNativeTemplate/template.js
@@ -42,7 +42,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Key files
     var templatePackageJsonFile = 'package.json';
     var templateSettingsGradle = 'settings.gradle';
-    var templateAndroidManifestFile = path.join('app', 'AndroidManifest.xml');
+    var templateBuildGradleFile = path.join('app', 'build.gradle');
     var templateStringsXmlFile = path.join('app', 'res', 'values', 'strings.xml');
     var templateBootconfigFile = path.join('app', 'res', 'values', 'bootconfig.xml');
     var templateMainActivityFile = path.join('app', 'src', 'com', 'salesforce', 'androidnativetemplate', 'MainActivity.java');
@@ -56,7 +56,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateSettingsGradle, templateStringsXmlFile]);
 
     // package name
-    replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+    replaceInFiles(templatePackageName, config.packagename, [templateBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
     
     //
     // Rename/move files

--- a/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
+++ b/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.mobilesyncexplorerkotlintemplate">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    
     <application
         android:name="com.salesforce.mobilesyncexplorerkotlintemplate.MainApplication"
         android:allowBackup="true"

--- a/MobileSyncExplorerKotlinTemplate/app/build.gradle
+++ b/MobileSyncExplorerKotlinTemplate/app/build.gradle
@@ -15,6 +15,8 @@ plugins {
 }
 
 android {
+    namespace =  "com.salesforce.mobilesyncexplorerkotlintemplate"
+
     compileSdk 33
 
     defaultConfig {

--- a/MobileSyncExplorerKotlinTemplate/template.js
+++ b/MobileSyncExplorerKotlinTemplate/template.js
@@ -63,7 +63,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Key files
     const templatePackageJsonFile = 'package.json';
     const templateSettingsGradle = 'settings.gradle';
-    const templateAndroidManifestFile = path.join('app', 'AndroidManifest.xml');
+    const templateBuildGradleFile = path.join('app', 'build.gradle');    
     const templateStringsXmlFile = path.join('app', 'src', 'main', 'res', 'values', 'strings.xml');
     const templateBootconfigFile = path.join('app', 'src', 'main', 'res', 'values', 'bootconfig.xml');
     const javaDirPath = path.join('app', 'src', 'main', 'java');
@@ -77,7 +77,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateSettingsGradle, templateStringsXmlFile]);
 
     // package name
-    replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateStringsXmlFile].concat(ktFiles));
+    replaceInFiles(templatePackageName, config.packagename, [templateBuildGradleFile, templateStringsXmlFile].concat(ktFiles));
 
     //
     // Rename/move files

--- a/MobileSyncExplorerKotlinTemplate/template.js
+++ b/MobileSyncExplorerKotlinTemplate/template.js
@@ -63,7 +63,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Key files
     const templatePackageJsonFile = 'package.json';
     const templateSettingsGradle = 'settings.gradle';
-    const templateBuildGradleFile = path.join('app', 'build.gradle');    
+    const templateBuildGradleFile = path.join('app', 'build.gradle');
     const templateStringsXmlFile = path.join('app', 'src', 'main', 'res', 'values', 'strings.xml');
     const templateBootconfigFile = path.join('app', 'src', 'main', 'res', 'values', 'bootconfig.xml');
     const javaDirPath = path.join('app', 'src', 'main', 'java');

--- a/MobileSyncExplorerReactNative/android/app/build.gradle
+++ b/MobileSyncExplorerReactNative/android/app/build.gradle
@@ -121,6 +121,8 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
+    namespace = "com.salesforce.samples.mobilesyncexplorerreactnative"
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {

--- a/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
+++ b/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.samples.mobilesyncexplorerreactnative"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/MobileSyncExplorerReactNative/template.js
+++ b/MobileSyncExplorerReactNative/template.js
@@ -108,7 +108,6 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         var templatePackageJsonFile = 'package.json';
         var templateIndexAndroidFile = 'index.js';
         var templateSettingsGradle = path.join('android', 'settings.gradle');
-        var templateAndroidManifestFile = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
         var templateBuckFile = path.join('android', 'app', 'BUCK');
         var templateAppBuildGradleFile = path.join('android', 'app', 'build.gradle');
         var templateStringsXmlFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
@@ -124,7 +123,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateIndexAndroidFile, templateSettingsGradle, templateStringsXmlFile, templateMainActivityFile]);
 
         // package name
-        replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+        replaceInFiles(templatePackageName, config.packagename, [templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
         
         //
         // Rename/move/remove files

--- a/ReactNativeDeferredTemplate/android/app/build.gradle
+++ b/ReactNativeDeferredTemplate/android/app/build.gradle
@@ -121,6 +121,8 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
+    namespace =  "com.salesforce.reactnativedeferredtemplate"
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {

--- a/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.reactnativedeferredtemplate"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/ReactNativeDeferredTemplate/template.js
+++ b/ReactNativeDeferredTemplate/template.js
@@ -108,7 +108,6 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         var templatePackageJsonFile = 'package.json';
         var templateIndexAndroidFile = 'index.js';
         var templateSettingsGradle = path.join('android', 'settings.gradle');
-        var templateAndroidManifestFile = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
         var templateBuckFile = path.join('android', 'app', 'BUCK');
         var templateAppBuildGradleFile = path.join('android', 'app', 'build.gradle');
         var templateStringsXmlFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
@@ -124,7 +123,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateIndexAndroidFile, templateSettingsGradle, templateStringsXmlFile, templateMainActivityFile]);
 
         // package name
-        replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+        replaceInFiles(templatePackageName, config.packagename, [templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
         
         //
         // Rename/move/remove files

--- a/ReactNativeTemplate/android/app/build.gradle
+++ b/ReactNativeTemplate/android/app/build.gradle
@@ -121,6 +121,8 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
+    namespace =  "com.salesforce.reactnativetemplate"
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {

--- a/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.reactnativetemplate"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/ReactNativeTemplate/template.js
+++ b/ReactNativeTemplate/template.js
@@ -108,7 +108,6 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         var templatePackageJsonFile = 'package.json';
         var templateIndexAndroidFile = 'index.js';
         var templateSettingsGradle = path.join('android', 'settings.gradle');
-        var templateAndroidManifestFile = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
         var templateBuckFile = path.join('android', 'app', 'BUCK');
         var templateAppBuildGradleFile = path.join('android', 'app', 'build.gradle');
         var templateStringsXmlFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
@@ -124,7 +123,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateIndexAndroidFile, templateSettingsGradle, templateStringsXmlFile, templateMainActivityFile]);
 
         // package name
-        replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+        replaceInFiles(templatePackageName, config.packagename, [templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
         
         //
         // Rename/move/remove files

--- a/ReactNativeTypeScriptTemplate/android/app/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/app/build.gradle
@@ -121,6 +121,8 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
+    namespace = "com.salesforce.reactnativetypescripttemplate"
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {

--- a/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.reactnativetypescripttemplate"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/ReactNativeTypeScriptTemplate/template.js
+++ b/ReactNativeTypeScriptTemplate/template.js
@@ -108,7 +108,6 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         var templatePackageJsonFile = 'package.json';
         var templateIndexAndroidFile = 'index.js';
         var templateSettingsGradle = path.join('android', 'settings.gradle');
-        var templateAndroidManifestFile = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
         var templateBuckFile = path.join('android', 'app', 'BUCK');
         var templateAppBuildGradleFile = path.join('android', 'app', 'build.gradle');
         var templateStringsXmlFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
@@ -124,7 +123,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateIndexAndroidFile, templateSettingsGradle, templateStringsXmlFile, templateMainActivityFile]);
 
         // package name
-        replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+        replaceInFiles(templatePackageName, config.packagename, [templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
         
         //
         // Rename/move/remove files


### PR DESCRIPTION
Addressing deprecation message during builds:

> package="com.salesforce.androidsdk" found in source AndroidManifest.xml: /home/circleci/SalesforceMobileSDK-Package/tmp20230608T035347.445/androidnativekotlin/mobile_sdk/SalesforceMobileSDK-Android/libs/SalesforceSDK/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace