### PR TITLE
Not having full package name in AndroidManifest.xml

### DIFF
--- a/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
+++ b/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     
     <application
-        android:name="com.salesforce.mobilesyncexplorerkotlintemplate.MainApplication"
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -10,7 +10,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.SalesforceMobileSDKAndroid">
         <activity
-            android:name="com.salesforce.mobilesyncexplorerkotlintemplate.contacts.activity.ContactsActivity"
+            android:name=".contacts.activity.ContactsActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.SalesforceMobileSDKAndroid">


### PR DESCRIPTION
In the past template.js was replacing the template package name by the user provided package name in AndroidManifest.xml, so having the full package name in there was not a problem.
With https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/360, I moved the package name to build.gradle and modified template.js to no touch AndroidManifest.xml.
