### PR TITLE
Removing the package name from AndroidManifest.xml broke RN for Android and iOS

### DIFF
--- a/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
+++ b/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	package="com.salesforce.samples.mobilesyncexplorerreactnative"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/MobileSyncExplorerReactNative/template.js
+++ b/MobileSyncExplorerReactNative/template.js
@@ -108,6 +108,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         var templatePackageJsonFile = 'package.json';
         var templateIndexAndroidFile = 'index.js';
         var templateSettingsGradle = path.join('android', 'settings.gradle');
+        var templateAndroidManifestFile = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
         var templateBuckFile = path.join('android', 'app', 'BUCK');
         var templateAppBuildGradleFile = path.join('android', 'app', 'build.gradle');
         var templateStringsXmlFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
@@ -123,7 +124,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateIndexAndroidFile, templateSettingsGradle, templateStringsXmlFile, templateMainActivityFile]);
 
         // package name
-        replaceInFiles(templatePackageName, config.packagename, [templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+        replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
         
         //
         // Rename/move/remove files

--- a/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	package="com.salesforce.reactnativedeferredtemplate"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/ReactNativeDeferredTemplate/template.js
+++ b/ReactNativeDeferredTemplate/template.js
@@ -108,6 +108,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         var templatePackageJsonFile = 'package.json';
         var templateIndexAndroidFile = 'index.js';
         var templateSettingsGradle = path.join('android', 'settings.gradle');
+        var templateAndroidManifestFile = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
         var templateBuckFile = path.join('android', 'app', 'BUCK');
         var templateAppBuildGradleFile = path.join('android', 'app', 'build.gradle');
         var templateStringsXmlFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
@@ -123,7 +124,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateIndexAndroidFile, templateSettingsGradle, templateStringsXmlFile, templateMainActivityFile]);
 
         // package name
-        replaceInFiles(templatePackageName, config.packagename, [templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+        replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
         
         //
         // Rename/move/remove files

--- a/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	package="com.salesforce.reactnativetemplate"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/ReactNativeTemplate/template.js
+++ b/ReactNativeTemplate/template.js
@@ -108,6 +108,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         var templatePackageJsonFile = 'package.json';
         var templateIndexAndroidFile = 'index.js';
         var templateSettingsGradle = path.join('android', 'settings.gradle');
+        var templateAndroidManifestFile = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
         var templateBuckFile = path.join('android', 'app', 'BUCK');
         var templateAppBuildGradleFile = path.join('android', 'app', 'build.gradle');
         var templateStringsXmlFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
@@ -123,7 +124,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateIndexAndroidFile, templateSettingsGradle, templateStringsXmlFile, templateMainActivityFile]);
 
         // package name
-        replaceInFiles(templatePackageName, config.packagename, [templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+        replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
         
         //
         // Rename/move/remove files

--- a/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	package="com.salesforce.reactnativetypescripttemplate"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/ReactNativeTypeScriptTemplate/template.js
+++ b/ReactNativeTypeScriptTemplate/template.js
@@ -108,6 +108,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         var templatePackageJsonFile = 'package.json';
         var templateIndexAndroidFile = 'index.js';
         var templateSettingsGradle = path.join('android', 'settings.gradle');
+        var templateAndroidManifestFile = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
         var templateBuckFile = path.join('android', 'app', 'BUCK');
         var templateAppBuildGradleFile = path.join('android', 'app', 'build.gradle');
         var templateStringsXmlFile = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
@@ -123,7 +124,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateIndexAndroidFile, templateSettingsGradle, templateStringsXmlFile, templateMainActivityFile]);
 
         // package name
-        replaceInFiles(templatePackageName, config.packagename, [templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
+        replaceInFiles(templatePackageName, config.packagename, [templateAndroidManifestFile, templateBuckFile, templateAppBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile]);
         
         //
         // Rename/move/remove files


### PR DESCRIPTION
On iOS, our Podfile has

- config = use_native_modules!
- Which comes from node_modules/@react-native-community/cli-platform-ios/native_modules 
- Which calls node_modules/@react-native-community/cli/build/bin.js

On Android, our build.gradle has
- apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle") 
- Which also calls node_modules/@react-native-community/cli/build/bin.js

bin.js is the one complaining about not finding a package name in the AndroidManifest.xml