### PR TITLE
@W-14246983: [MSDK Android Templates] Templates Use Maven Central MSDK Dependencies By Default (Pt. 2)

### DIFF
--- a/MobileSyncExplorerReactNative/package.json
+++ b/MobileSyncExplorerReactNative/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "sdkDependencies": {
-    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#v77.77.77",
+    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev",
     "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
   },
   "dependencies": {
@@ -17,7 +17,7 @@
     "react-native-elements": "^3.4.2",
     "react": "18.1.0",
     "react-native": "0.70.6",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#v77.77.77",
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-safe-area-context": "^3.3.0",
     "react-native-screens": "^3.6.0",

--- a/ReactNativeDeferredTemplate/package.json
+++ b/ReactNativeDeferredTemplate/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "sdkDependencies": {
-    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#v77.77.77",
+    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev",
     "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
   },
   "dependencies": {
@@ -16,7 +16,7 @@
     "@react-navigation/stack": "^6.0.7",
     "react": "18.1.0",
     "react-native": "0.70.6",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#v77.77.77",
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-safe-area-context": "^3.3.0",
     "react-native-screens": "^3.6.0",

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "sdkDependencies": {
-    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#v77.77.77",
+    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev",
     "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
   },
   "dependencies": {
@@ -16,7 +16,7 @@
     "@react-navigation/stack": "^6.0.7",
     "react": "18.1.0",
     "react-native": "0.70.6",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#v77.77.77",
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-safe-area-context": "^3.3.0",
     "react-native-screens": "^3.6.0",

--- a/ReactNativeTypeScriptTemplate/package.json
+++ b/ReactNativeTypeScriptTemplate/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "sdkDependencies": {
-    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#v77.77.77",
+    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev",
     "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
   },
   "dependencies": {
@@ -16,7 +16,7 @@
     "@react-navigation/stack": "^6.0.7",
     "react": "18.1.0",
     "react-native": "0.70.6",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#v77.77.77",
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-safe-area-context": "^3.3.0",
     "react-native-screens": "^3.6.0",


### PR DESCRIPTION
🎸 _Ready For Review_ 🥁

This corrects a few remaining placeholder versions in the template `package.json` files from `setVersion.sh` testing.  Thanks, @wmathurin 🦅