### PR TITLE
Fix iOS hybrid generation.

### DIFF
--- a/HybridLocalTemplate/template.js
+++ b/HybridLocalTemplate/template.js
@@ -52,10 +52,12 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Move/remove some files
     //
     moveFile(path.join('mobile_sdk', 'SalesforceMobileSDK-Shared', 'libs', 'force.js'), 'force.js');
-    var msdkAndroidPath = path.join('mobile_sdk', 'SalesforceMobileSDK-Android')
-    if (fs.existsSync(msdkAndroidPath)) {
-        fs.mkdirSync('../platforms/android/mobile_sdk/');
-        moveFile(msdkAndroidPath, '../platforms/android/mobile_sdk/');
+    if (config.platform.includes('android')) {
+        var msdkAndroidPath = path.join('mobile_sdk', 'SalesforceMobileSDK-Android')
+        if (fs.existsSync(msdkAndroidPath)) {
+            fs.mkdirSync('../platforms/android/mobile_sdk/');
+            moveFile(msdkAndroidPath, '../platforms/android/mobile_sdk/');
+        }
     }
     moveFile(path.join('node_modules', 'ratchet-npm', 'dist', 'css', 'ratchet.min.css'), 'ratchet.css');
     moveFile(path.join('node_modules', 'ratchet-npm', 'dist', 'css', 'ratchet-theme-' + theme + '.min.css'), 'ratchet-theme.css');

--- a/HybridLwcTemplate/template.js
+++ b/HybridLwcTemplate/template.js
@@ -66,10 +66,12 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Move/remove some files
     //
     moveFile(path.join('mobile_sdk', 'SalesforceMobileSDK-Shared', 'libs', 'force.js'), path.join(staticResourceDir, 'other', 'force.js'));
-    var msdkAndroidPath = path.join('mobile_sdk', 'SalesforceMobileSDK-Android')
-    if (fs.existsSync(msdkAndroidPath)) {
-        fs.mkdirSync('../platforms/android/mobile_sdk/');
-        moveFile(msdkAndroidPath, '../platforms/android/mobile_sdk/');
+    if (config.platform.includes('android')) {
+        var msdkAndroidPath = path.join('mobile_sdk', 'SalesforceMobileSDK-Android')
+        if (fs.existsSync(msdkAndroidPath)) {
+            fs.mkdirSync('../platforms/android/mobile_sdk/');
+            moveFile(msdkAndroidPath, '../platforms/android/mobile_sdk/');
+        }
     }
     moveFile(mainPage, path.join(pagesDir, safeName + '.page'))
     moveFile(mainPageMeta, path.join(pagesDir, safeName + '.page-meta.xml'))

--- a/HybridRemoteTemplate/template.js
+++ b/HybridRemoteTemplate/template.js
@@ -58,10 +58,12 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Move/remove some files
     //
     moveFile(path.join('mobile_sdk', 'SalesforceMobileSDK-Shared', 'libs', 'force.js'), 'force.js');
-    var msdkAndroidPath = path.join('mobile_sdk', 'SalesforceMobileSDK-Android')
-    if (fs.existsSync(msdkAndroidPath)) {
-        fs.mkdirSync('../platforms/android/mobile_sdk/');
-        moveFile(msdkAndroidPath, '../platforms/android/mobile_sdk/');
+    if (config.platform.includes('android')) {
+        var msdkAndroidPath = path.join('mobile_sdk', 'SalesforceMobileSDK-Android')
+        if (fs.existsSync(msdkAndroidPath)) {
+            fs.mkdirSync('../platforms/android/mobile_sdk/');
+            moveFile(msdkAndroidPath, '../platforms/android/mobile_sdk/');
+        }
     }
     removeFile('node_modules');
     removeFile('mobile_sdk');


### PR DESCRIPTION
Without this check if you build an hybrid app only for iOS it fails because it can't find the Android directory it is looking for.  