### PR TITLE
Changing min sdk from 24 to 26

### DIFF
--- a/AndroidIDPTemplate/app/build.gradle.kts
+++ b/AndroidIDPTemplate/app/build.gradle.kts
@@ -15,8 +15,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 26
     }
 
     buildTypes {

--- a/AndroidNativeKotlinTemplate/app/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/app/build.gradle.kts
@@ -15,8 +15,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 26
     }
 
     buildTypes {

--- a/AndroidNativeTemplate/app/build.gradle.kts
+++ b/AndroidNativeTemplate/app/build.gradle.kts
@@ -15,8 +15,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 26
     }
 
     buildTypes {

--- a/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
@@ -32,8 +32,7 @@ android {
 
     defaultConfig {
         applicationId = "com.salesforce.mobilesyncexplorerkotlintemplate"
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 26
         versionCode = 1
         versionName = "1.0"
 

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext {
-        minSdkVersion = 24
+        minSdkVersion = 26
         compileSdk = 34
-        targetSdkVersion = 34
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext {
-        minSdkVersion = 24
+        minSdkVersion = 26
         compileSdk = 34
-        targetSdkVersion = 33
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext {
-        minSdkVersion = 24
+        minSdkVersion = 26
         compileSdk = 34
-        targetSdkVersion = 33
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext {
-        minSdkVersion = 24
+        minSdkVersion = 26
         compileSdk = 34
-        targetSdkVersion = 33
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"


### PR DESCRIPTION
Also removing target sdk

> The targetSdk property in the Android library Gradle plugin ("com.android.library") has been deprecated. As it is an advisory property, you can safely remove it from your configuration. The minSdk property alone is sufficient.