### PR TITLE
Moving to most recent react-native-screens

### DIFF
--- a/MobileSyncExplorerReactNative/package.json
+++ b/MobileSyncExplorerReactNative/package.json
@@ -21,7 +21,7 @@
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "^2.14.0",
     "react-native-safe-area-context": "^4.7.4",
-    "react-native-screens": "^3.27.0",
+    "react-native-screens": "^3.30.1",
     "react-native-vector-icons": "^10.0.2"
   },
   "devDependencies": {

--- a/ReactNativeDeferredTemplate/package.json
+++ b/ReactNativeDeferredTemplate/package.json
@@ -19,7 +19,7 @@
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "^2.14.0",
     "react-native-safe-area-context": "^4.7.4",
-    "react-native-screens": "^3.27.0",
+    "react-native-screens": "^3.30.1",
     "create-react-class": "^15.7.0"
   },
   "devDependencies": {

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -19,7 +19,7 @@
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "^2.14.0",
     "react-native-safe-area-context": "^4.7.4",
-    "react-native-screens": "^3.27.0",
+    "react-native-screens": "^3.30.1",
     "create-react-class": "^15.7.0"
   },
   "devDependencies": {

--- a/ReactNativeTypeScriptTemplate/package.json
+++ b/ReactNativeTypeScriptTemplate/package.json
@@ -19,7 +19,7 @@
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "^2.14.0",
     "react-native-safe-area-context": "^4.7.4",
-    "react-native-screens": "^3.27.0",
+    "react-native-screens": "^3.30.1",
     "create-react-class": "^15.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
On CI getting this error
> Execution failed for task ':react-native-screens:configureCMakeDebug[arm64-v8a]'.

So moving to most recent version of react-native-screens.
Some of the recent updates have release notes about supporting React Native 0.73.