### PR TITLE
@W-14584260: [iOS] OTPs Sample App (Correct Template Properties)

### DIFF
--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginViewFactory.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginViewFactory.swift
@@ -53,8 +53,6 @@ class NativeLoginTemplateHostingController<Content>: UIHostingController<Content
         // navigation bar that is redundant with the SwiftUI navigation in the
         // template app, so hide it.
         //
-        // TODO: See if this should be resolved in SFMSDK. ECJ20240516
-        //
         navigationController.setNavigationBarHidden(true, animated: true)
     }
 }

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/SceneDelegate.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/SceneDelegate.swift
@@ -45,11 +45,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Fill in the values below from the connected app that was created for Native Login and
         // the url of your Experience Cloud community.
         //
-        // TODO: Revert this change to enable the assertions. ECJ20240314
-        //
-        let clientId = "3MVG9CEn_O3jvv0wTqRT0Le6tmzX.EQ9ZvtHL1TG3gHFV.4IvKZyXw5SgdiVPi61mXrpu40mCOhKevEfYNMOm" // "your-client-id"
-        let redirectUri = "https://msdk-enhanced-dev-ed.my.site.com/services/oauth2/echo" // "your-redirect-uri"
-        let loginUrl = "https://msdk-enhanced-dev-ed.my.site.com/headless" // "your-community-url"
+        let clientId = "your-client-id"
+        let redirectUri = "your-redirect-uri"
+        let loginUrl = "your-community-url"
         
         assert(clientId != "your-client-id", "Please add your Native Login client id.")
         assert(redirectUri != "your-redirect-uri", "Please add your Native Login redirect uri.")
@@ -64,10 +62,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Google Cloud Project Id to nil along with a false value for the
         // enterprise parameter.
         //
-        // TODO: Revert this change to enable the assertions. ECJ20240314
-        //
-        let reCaptchaSiteKeyId = "6Lc3vVwpAAAAAL9noKtP5yACufTp5Tu7lIxqLmzQ" // "your-recaptcha-site-key-id"
-        let googleCloudProjectId = "mobile-apps-team-sfdc" // "your-google-cloud-project-id"
+        let reCaptchaSiteKeyId = "your-recaptcha-site-key-id"
+        let googleCloudProjectId = "your-google-cloud-project-id"
         let isReCaptchaEnterprise = true
         
         assert(clientId != "your-recaptcha-site-key-id", "Please add your Google Cloud reCAPTCHA Site Key Id.")


### PR DESCRIPTION
🎸 _Ready For Review_ 🥁 

  This is a simple follow-up to https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/395 to (again) revert the native login properties to the template values.  This was correct, but looks to have been accidentally set back during a code review commit.