### PR TITLE
@W-15316962/W-15316987: [iOS] Update native login sample app to include User Registration/Forgot Password flows

### DIFF
--- a/AndroidNativeLoginTemplate/settings.gradle.kts
+++ b/AndroidNativeLoginTemplate/settings.gradle.kts
@@ -2,7 +2,7 @@ rootProject.name = "AndroidNativeLoginTemplate"
 
 include(":app")
 
-val salesforceMobileSdkRoot = File("../../SalesforceMobileSDK-Android")
+val salesforceMobileSdkRoot = File("mobile_sdk/SalesforceMobileSDK-Android")
 if (salesforceMobileSdkRoot.exists()) {
     includeBuild(salesforceMobileSdkRoot)
 }

--- a/AndroidNativeLoginTemplate/settings.gradle.kts
+++ b/AndroidNativeLoginTemplate/settings.gradle.kts
@@ -2,7 +2,7 @@ rootProject.name = "AndroidNativeLoginTemplate"
 
 include(":app")
 
-val salesforceMobileSdkRoot = File("mobile_sdk/SalesforceMobileSDK-Android")
+val salesforceMobileSdkRoot = File("../../SalesforceMobileSDK-Android")
 if (salesforceMobileSdkRoot.exists()) {
     includeBuild(salesforceMobileSdkRoot)
 }

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
@@ -36,9 +36,32 @@ struct NativeLoginView: View {
     
     /// The layout type for the user's active identity flow, such as registration, forgot password or login
     @State private var identityFlowLayoutType = IdentityFlowLayoutType.LoginViaUsernamePassword
+
+    // mark: Start Registration
     
-    /// An error message displayed to the user.  Note this is used by multiple layout types
-    @State private var errorMessage = ""
+    /// Start Registration: The user's entered first name.
+    @State private var firstName = ""
+    
+    /// Start Registration: The user's entered last name.
+    @State private var lastName = ""
+    
+    /// Start Registration: The user's entered email address.
+    @State private var email = ""
+    
+    // mark: Complete Registration
+    
+    /// Complete Registration:  The request identifier returned by the Salesforce Identity API's initialize registration endpoint
+    @State private var requestIdentifier: String? = nil
+    
+    // mark: User Messaging
+    
+    /// Indicates if the message displayed to the user is informational or an error.  Note this is used by multiple layout types
+    @State private var isMessageError = false
+    
+    /// A message displayed to the user.  Note this is used by multiple layout types
+    @State private var messageText = ""
+    
+    // mark: Common User Interface State
     
     /// An option to display indicators when an identity action is in progress. Note this is used by multiple layout types
     @State private var isAuthenticating = false
@@ -87,14 +110,14 @@ struct NativeLoginView: View {
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
                     .fill(.gray.opacity(0.25))
-                    .frame(width: 300, height: 500)
+                    .frame(width: 300, height: 650)
                     .padding(.top, 0)
                 
                 VStack {
                     Image(.msdkPhone)
                         .resizable()
-                        .frame(width: 150, height: 150)
-                        .padding(.bottom, 20)
+                        .frame(width: 100, height: 100)
+                        .padding(.bottom, 10)
                         .shadow(color: .black, radius: 3)
                         .blur(radius: 0.0)
                     
@@ -104,9 +127,14 @@ struct NativeLoginView: View {
                         Spacer().frame(height: 35)
                     }
                     
-                    if !errorMessage.isEmpty {
-                        Text(errorMessage)
-                            .foregroundStyle(.red)
+                    if !messageText.isEmpty {
+                        Text(messageText)
+                            .foregroundStyle({switch(isMessageError) {
+                            case true:
+                                return Color.red
+                            default:
+                                return Color.blue
+                            }}())
                             .frame(width: 250, height: 50)
                     } else {
                         Spacer().frame(width: 250, height: 65)
@@ -139,7 +167,7 @@ struct NativeLoginView: View {
                         
                         Button {
                             Task {
-                                errorMessage = ""
+                                messageReset()
                                 isAuthenticating = true
                                 
                                 // Login
@@ -149,16 +177,19 @@ struct NativeLoginView: View {
                                 
                                 switch result {
                                 case .invalidCredentials:
-                                    errorMessage = "Please check your username and password."
+                                    errorMessage("Please check your username and password.")
+                                    break
+                                case .invalidEmail:
+                                    errorMessage("Invalid email address.")
                                     break
                                 case .invalidUsername:
-                                    errorMessage = "Username format is incorrect."
+                                    errorMessage("Username format is incorrect.")
                                     break
                                 case .invalidPassword:
-                                    errorMessage = "Invalid password."
+                                    errorMessage("Invalid password.")
                                     break
                                 case .unknownError:
-                                    errorMessage = "An unknown error has occurred."
+                                    errorMessage("An unknown error has occurred.")
                                     break
                                 case .success:
                                     password = ""
@@ -176,7 +207,7 @@ struct NativeLoginView: View {
                         .padding(.bottom, 25)
                         
                         Button {
-                            identityFlowLayoutType = .InitializePasswordLessLoginViaOtp
+                            navigate(.InitializePasswordLessLoginViaOtp)
                         } label: {
                             Text("Use One Time Password Instead").frame(minWidth: 150)
                         }
@@ -184,6 +215,222 @@ struct NativeLoginView: View {
                         .tint(colorScheme == .dark ? .white : .blue)
                         .zIndex(2.0)
                         
+                        Button {
+                            navigate(.StartPasswordReset)
+                        } label: {
+                            Text("Reset Password").frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(colorScheme == .dark ? .white : .blue)
+                        .zIndex(2.0)
+                        
+                        Button {
+                            navigate(.StartUserRegistration)
+                        } label: {
+                            Text("Register").frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(colorScheme == .dark ? .white : .blue)
+                        .zIndex(2.0)
+                        
+                    case .StartUserRegistration:
+                        TextField("Email", text: $email)
+                            .autocapitalization(.none)
+                            .buttonStyle(.borderless)
+                            .disableAutocorrection(true)
+                            .foregroundColor(.blue)
+                            .frame(maxWidth: 250)
+                            .multilineTextAlignment(.center)
+                            .padding(.top, 25)
+                            .zIndex(2.0)
+                        
+                        TextField("First Name", text: $firstName)
+                            .autocapitalization(.none)
+                            .buttonStyle(.borderless)
+                            .disableAutocorrection(true)
+                            .foregroundColor(.blue)
+                            .frame(maxWidth: 250)
+                            .multilineTextAlignment(.center)
+                            .padding(.top, 25)
+                            .zIndex(2.0)
+                        
+                        TextField("Last Name", text: $lastName)
+                            .autocapitalization(.none)
+                            .buttonStyle(.borderless)
+                            .disableAutocorrection(true)
+                            .foregroundColor(.blue)
+                            .frame(maxWidth: 250)
+                            .multilineTextAlignment(.center)
+                            .padding(.top, 25)
+                            .zIndex(2.0)
+                        
+                        TextField("Username", text: $username)
+                            .autocapitalization(.none)
+                            .buttonStyle(.borderless)
+                            .disableAutocorrection(true)
+                            .foregroundColor(.blue)
+                            .frame(maxWidth: 250)
+                            .multilineTextAlignment(.center)
+                            .padding(.top, 25)
+                            .zIndex(2.0)
+                        
+                        SecureField("Password", text: $password)
+                            .foregroundColor(.blue)
+                            .disableAutocorrection(true)
+                            .multilineTextAlignment(.center)
+                            .buttonStyle(.borderless)
+                            .autocapitalization(.none)
+                            .frame(maxWidth: 250)
+                            .padding(.bottom)
+                            .padding(.top, 25)
+                            .zIndex(2.0)
+                        
+                        Picker(
+                            "OTP Verification Method",
+                            selection: $otpVerificationMethod) {
+                                Text("Email").tag(OtpVerificationMethod.email)
+                                Text("SMS").tag(OtpVerificationMethod.sms)
+                            }
+                            .frame(maxWidth: 250)
+                            .zIndex(2.0)
+
+                        Button {
+                            onRequestOtpForRegistrationTapped()
+                        } label: {
+                            HStack {
+                                Image(systemName: "lock")
+                                Text("Request One-Time-Password")
+                            }.frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(colorScheme == .dark ? .white : .blue)
+                        .zIndex(2.0)
+                        
+                        Button {
+                            layoutReset()
+                        } label: {
+                            Text("Cancel").frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(.red)
+                        .zIndex(2.0)
+
+                    case .CompleteUserRegistration:
+                        TextField("One-Time-Password", text: $otp)
+                            .autocapitalization(.none)
+                            .buttonStyle(.borderless)
+                            .disableAutocorrection(true)
+                            .foregroundColor(.blue)
+                            .frame(maxWidth: 250)
+                            .multilineTextAlignment(.center)
+                            .padding(.top, 25)
+                            .zIndex(2.0)
+
+                        Button {
+                            onCompleteRegistrationTapped()
+                        } label: {
+                            HStack {
+                                Image(systemName: "lock")
+                                Text("Complete Registration")
+                            }.frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(colorScheme == .dark ? .white : .blue)
+                        .zIndex(2.0)
+                        
+                        Button {
+                            layoutReset()
+                        } label: {
+                            Text("Cancel").frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(.red)
+                        .zIndex(2.0)
+                        
+                    case .StartPasswordReset:
+                        // Layout to start password reset.
+                        TextField("Username", text: $username)
+                            .autocapitalization(.none)
+                            .buttonStyle(.borderless)
+                            .disableAutocorrection(true)
+                            .foregroundColor(.blue)
+                            .frame(maxWidth: 250)
+                            .multilineTextAlignment(.center)
+                            .padding(.top, 25)
+                            .zIndex(2.0)
+
+                        Button {
+                            onRequestOtpForResetPasswordTapped()
+                        } label: {
+                            HStack {
+                                Image(systemName: "key.radiowaves.forward")
+                                Text("Request One Time Password")
+                            }.frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(colorScheme == .dark ? .white : .blue)
+                        .zIndex(2.0)
+                        
+                        Button {
+                            layoutReset()
+                        } label: {
+                            Text("Cancel").frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(.red)
+                        .zIndex(2.0)
+                        
+                    case .CompletePasswordReset:
+                        // Layout to complete password reset.
+                        Text($username.wrappedValue)
+                            .foregroundColor(.blue)
+                            .frame(maxWidth: 250)
+                            .multilineTextAlignment(.center)
+                            .padding(.top, 25)
+                            .zIndex(2.0)
+                        
+                        TextField("One-Time-Password", text: $otp)
+                            .autocapitalization(.none)
+                            .buttonStyle(.borderless)
+                            .disableAutocorrection(true)
+                            .foregroundColor(.blue)
+                            .frame(maxWidth: 250)
+                            .multilineTextAlignment(.center)
+                            .padding(.top, 25)
+                            .zIndex(2.0)
+                        
+                        SecureField("New Password", text: $password)
+                            .foregroundColor(.blue)
+                            .disableAutocorrection(true)
+                            .multilineTextAlignment(.center)
+                            .buttonStyle(.borderless)
+                            .autocapitalization(.none)
+                            .frame(maxWidth: 250)
+                            .padding(.bottom)
+                            .padding(.top, 10)
+                            .zIndex(2.0)
+
+                        Button {
+                            onResetPasswordTapped()
+                        } label: {
+                            HStack {
+                                Image(systemName: "lock")
+                                Text("Reset Password")
+                            }.frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(colorScheme == .dark ? .white : .blue)
+                        .zIndex(2.0)
+                        
+                        Button {
+                            layoutReset()
+                        } label: {
+                            Text("Cancel").frame(minWidth: 150)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(.red)
+                        .zIndex(2.0)
+
                     case .InitializePasswordLessLoginViaOtp:
                         // Layout to initialize password-less login by requesting a one-time-passcode.
                         TextField("Username", text: $username)
@@ -218,7 +465,7 @@ struct NativeLoginView: View {
                         .zIndex(2.0)
                         
                         Button {
-                            identityFlowLayoutType = .LoginViaUsernamePassword
+                            layoutReset()
                         } label: {
                             Text("Cancel").frame(minWidth: 150)
                         }
@@ -251,7 +498,7 @@ struct NativeLoginView: View {
                         .zIndex(2.0)
                         
                         Button {
-                            identityFlowLayoutType = .LoginViaUsernamePassword
+                            layoutReset()
                         } label: {
                             Text("Cancel").frame(minWidth: 150)
                         }
@@ -271,14 +518,203 @@ struct NativeLoginView: View {
         }.background(Gradient(colors: [.blue, .cyan, .green]).opacity(0.6))
             .blur(radius: isAuthenticating ? 2.0 : 0.0)
     }
+
+    /// Submits a start registration request to the Salesforce Identity API forgot password endpoint.
+    private func onRequestOtpForRegistrationTapped() {
+        // Reset the message.
+        messageReset()
+        
+        // Show the progress indicator.
+        isAuthenticating = true
+        
+        // Execute for a new reCAPTCHA token.
+        reCaptchaClientObservable.reCaptchaClient?.execute(
+            withAction: .signup
+        ) {reCaptchaExecuteResult, error in
+            
+            // Guard for the new reCAPTCHA token.
+            guard let reCaptchaToken = reCaptchaExecuteResult else {
+                SalesforceLogger.e(AppDelegate.self, message: "Could not obtain a reCAPTCHA signup action token due to error with description '\(error?.localizedDescription ?? "(A description wasn't provided.)")'.")
+                return
+            }
+            
+            // Submit the request and act on the response.
+            Task {
+                // Submit the request.
+                let result = await SalesforceManager.shared.nativeLoginManager()
+                    .startRegistration(
+                        email: email,
+                        firstName: firstName,
+                        lastName: lastName,
+                        username: username,
+                        newPassword: password,
+                        reCaptchaToken: reCaptchaToken,
+                        otpVerificationMethod: otpVerificationMethod)
+                
+                // Clear the progresss indicator.
+                isAuthenticating = false
+                
+                // Act on the response.
+                switch result.nativeLoginResult {
+                    
+                case .invalidCredentials:
+                    errorMessage("Check your username and password.")
+                    break
+                    
+                case .invalidEmail:
+                    errorMessage("Invalid email address.")
+                    break
+                    
+                case .invalidPassword:
+                    errorMessage("Invalid password.")
+                    break
+                    
+                case .invalidUsername:
+                    errorMessage("Invalid username.")
+                    break
+                    
+                case .unknownError:
+                    errorMessage("An error occurred.")
+                    break
+                    
+                case .success:
+                    requestIdentifier = result.requestIdentifier
+                    navigate(.CompleteUserRegistration)
+                }
+            }
+        }
+    }
+    
+    /// Submits a complete registration request to the Salesforce Identity API registration endpoint.
+    private func onCompleteRegistrationTapped() {
+        // Reset the message.
+        messageReset()
+        
+        // Show the progress indicator.
+        isAuthenticating = true
+        
+        // Submit the request and act on the response.
+        Task {
+            // Submit the request.
+            guard let requestIdentifier = requestIdentifier else { return }
+            let result = await SalesforceManager.shared.nativeLoginManager()
+                .completeRegistration(
+                    otp: otp,
+                    requestIdentifier: requestIdentifier,
+                    otpVerificationMethod: otpVerificationMethod)
+            
+            // Clear the progresss indicator.
+            isAuthenticating = false
+            
+            switch result {
+            case .success:
+                layoutReset()
+                break
+            default:
+                errorMessage("An error occurred.")
+            }
+        }
+    }
+
+    
+    /// Submits a start password reset request to the Salesforce Identity API forgot password endpoint.
+    private func onRequestOtpForResetPasswordTapped() {
+        // Reset the message.
+        messageReset()
+        
+        // Show the progress indicator.
+        isAuthenticating = true
+        
+        // Execute for a new reCAPTCHA token.
+        reCaptchaClientObservable.reCaptchaClient?.execute(
+            withAction: .init(customAction: "forgot_password")
+        ) {reCaptchaExecuteResult, error in
+            
+            // Guard for the new reCAPTCHA token.
+            guard let reCaptchaToken = reCaptchaExecuteResult else {
+                SalesforceLogger.e(AppDelegate.self, message: "Could not obtain a reCAPTCHA forgot password action token due to error with description '\(error?.localizedDescription ?? "(A description wasn't provided.)")'.")
+                return
+            }
+            
+            // Submit the request and act on the response.
+            Task {
+                // Submit the request.
+                let result = await SalesforceManager.shared.nativeLoginManager()
+                    .startPasswordReset(
+                        username: username,
+                        reCaptchaToken: reCaptchaToken)
+                
+                // Clear the progresss indicator.
+                isAuthenticating = false
+                
+                // Act on the response.
+                switch result {
+                    
+                case .invalidCredentials:
+                    errorMessage("Check your username and password.")
+                    break
+                    
+                case .invalidEmail:
+                    errorMessage("Invalid email address.")
+                    break
+                    
+                case .invalidPassword:
+                    errorMessage("Invalid password.")
+                    break
+                    
+                case .invalidUsername:
+                    errorMessage("Invalid username.")
+                    break
+                    
+                case .unknownError:
+                    errorMessage("An error occurred.")
+                    break
+                    
+                case .success:
+                    navigate(.CompletePasswordReset)
+                }
+            }
+        }
+    }
+    
+    /// Submits a complete password reset request to the Salesforce Identity API forgot password endpoint.
+    private func onResetPasswordTapped() {
+        // Reset the message.
+        messageReset()
+        
+        // Show the progress indicator.
+        isAuthenticating = true
+        
+        // Submit the request and act on the response.
+        Task {
+            // Submit the request.
+            let result = await SalesforceManager.shared.nativeLoginManager()
+                .completePasswordReset(
+                    username: username,
+                    otp: otp,
+                    newPassword: password)
+            
+            // Clear the progresss indicator.
+            isAuthenticating = false
+            
+            switch result {
+            case .success:
+                layoutReset()
+                message("Password reset successfully.  Log in using the new password.")
+                break
+            default:
+                errorMessage("An error occurred.")
+            }
+        }
+    }
     
     ///
     /// Submits the OTP delivery request when the request button is tapped.  This submits a request to the
     /// `init/passwordless/login`endpoint and opens the submit OTP verification view on success.
     ///
     private func onRequestOtpTapped() {
-        // Reset the error message if needed.
-        errorMessage = ""
+        // Reset the message.
+        messageReset()
         
         // Show the progress indicator.
         isAuthenticating = true
@@ -288,7 +724,7 @@ struct NativeLoginView: View {
             
             // Guard for the new reCAPTCHA token.
             guard let reCaptchaToken = reCaptchaExecuteResult else {
-                SalesforceLogger.e(AppDelegate.self, message: "Could not obtain a reCAPTCHA token due to error with description '\(error?.localizedDescription ?? "(A description wasn't provided.)")'.")
+                SalesforceLogger.e(AppDelegate.self, message: "Could not obtain a reCAPTCHA login action token due to error with description '\(error?.localizedDescription ?? "(A description wasn't provided.)")'.")
                 return
             }
             
@@ -308,19 +744,23 @@ struct NativeLoginView: View {
                 switch result.nativeLoginResult {
                     
                 case .invalidCredentials:
-                    errorMessage = "Check your username and password."
+                    errorMessage("Check your username and password.")
+                    break
+                    
+                case .invalidEmail:
+                    errorMessage("Invalid email address.")
                     break
                     
                 case .invalidPassword:
-                    errorMessage = "Invalid password."
+                    errorMessage("Invalid password.")
                     break
                     
                 case .invalidUsername:
-                    errorMessage = "Invalid username."
+                    errorMessage("Invalid username.")
                     break
                     
                 case .unknownError:
-                    errorMessage = "An error occurred."
+                    errorMessage("An error occurred.")
                     break
                     
                 case .success:
@@ -329,7 +769,7 @@ struct NativeLoginView: View {
                     
                     // Switch to the OTP submission layout.
                     otpIdentifier = otpIdentifierResult
-                    identityFlowLayoutType = .LoginViaUsernameAndOtp
+                    navigate(.LoginViaUsernameAndOtp)
                 }
             }
         }
@@ -347,8 +787,8 @@ struct NativeLoginView: View {
         
         guard let otpIdentifier = otpIdentifier else { return }
         
-        // Reset the error message if needed.
-        errorMessage = ""
+        // Reset the message.
+        messageReset()
         
         // Show the progress indicator.
         isAuthenticating = true
@@ -367,21 +807,73 @@ struct NativeLoginView: View {
             
             switch result {
             case .success:
-                // Switch back to the initial login layout.
-                identityFlowLayoutType = .LoginViaUsernamePassword
+                navigate(.LoginViaUsernamePassword)
                 break
             default:
-                errorMessage = "An error occurred."
+                errorMessage("An error occurred.")
             }
         }
     }
     
+    // mark: Private User Messsaging Utilities
+    
+    /// Sets the error message displayed to the user.
+    private func errorMessage(_ text: String) {
+        messageReset()
+        
+        messageText = text
+        isMessageError = true
+    }
+    
+    /// Resets the message state.
+    private func messageReset() {
+        messageText = ""
+        isMessageError = false
+    }
+    
+    /// Sets the informational message displayed to the user.
+    private func message(_ text: String) {
+        messageReset()
+        
+        messageText = text
+    }
+    
+    // mark: Private Navigation Utilities
+    
+    /// Resets to the initial layout.
+    private func layoutReset() {
+        otp = ""
+        otpIdentifier = ""
+        otpVerificationMethod = .sms
+        password = ""
+        username = ""
+        
+        navigate(.LoginViaUsernamePassword)
+    }
+    
+    /// Navigates to the specified layout.
+    private func navigate(_ identityFlowLayoutType: IdentityFlowLayoutType) {
+        messageReset()
+        self.identityFlowLayoutType = identityFlowLayoutType
+    }
 }
 
 ///
 /// Layouts for the available Salesforce identity flows.
 ///
 enum IdentityFlowLayoutType {
+    
+    /// A layout to start the user registration flow.
+    case StartUserRegistration
+    
+    /// A layout to complete the user registration flow.
+    case CompleteUserRegistration
+    
+    /// A layout to start the password reset flow.
+    case StartPasswordReset
+    
+    /// A layout to complete the password reset flow.
+    case CompletePasswordReset
     
     /// A layout to initialize password-less login via one-time-passcode request.
     case InitializePasswordLessLoginViaOtp

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
@@ -149,25 +149,10 @@ struct NativeLoginView: View {
                         
                     case .Login:
                         TextField("Username", text: $username)
-                            .foregroundColor(.blue)
-                            .disableAutocorrection(true)
-                            .multilineTextAlignment(.center)
-                            .buttonStyle(.borderless)
-                            .autocapitalization(.none)
-                            .frame(maxWidth: 250)
-                            .padding(.top)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         SecureField("Password", text: $password)
-                            .foregroundColor(.blue)
-                            .disableAutocorrection(true)
-                            .multilineTextAlignment(.center)
-                            .buttonStyle(.borderless)
-                            .autocapitalization(.none)
-                            .frame(maxWidth: 250)
-                            .padding(.bottom)
-                            .padding(.top, 10)
-                            .zIndex(2.0)
+                            .loginSecureField()
                         
                         Button {
                             Task {
@@ -224,55 +209,19 @@ struct NativeLoginView: View {
                         
                     case .StartRegistration:
                         TextField("Email", text: $email)
-                            .autocapitalization(.none)
-                            .buttonStyle(.borderless)
-                            .disableAutocorrection(true)
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: 250)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         TextField("First Name", text: $firstName)
-                            .autocapitalization(.none)
-                            .buttonStyle(.borderless)
-                            .disableAutocorrection(true)
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: 250)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         TextField("Last Name", text: $lastName)
-                            .autocapitalization(.none)
-                            .buttonStyle(.borderless)
-                            .disableAutocorrection(true)
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: 250)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         TextField("Username", text: $username)
-                            .autocapitalization(.none)
-                            .buttonStyle(.borderless)
-                            .disableAutocorrection(true)
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: 250)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         SecureField("Password", text: $password)
-                            .foregroundColor(.blue)
-                            .disableAutocorrection(true)
-                            .multilineTextAlignment(.center)
-                            .buttonStyle(.borderless)
-                            .autocapitalization(.none)
-                            .frame(maxWidth: 250)
-                            .padding(.bottom)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginSecureField()
                         
                         Picker(
                             "OTP Verification Method",
@@ -306,14 +255,7 @@ struct NativeLoginView: View {
                         
                     case .CompleteRegistration:
                         TextField("One-Time-Password", text: $otp)
-                            .autocapitalization(.none)
-                            .buttonStyle(.borderless)
-                            .disableAutocorrection(true)
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: 250)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         Button {
                             onCompleteRegistrationTapped()
@@ -339,14 +281,7 @@ struct NativeLoginView: View {
                     case .StartPasswordReset:
                         // Layout to start password reset.
                         TextField("Username", text: $username)
-                            .autocapitalization(.none)
-                            .buttonStyle(.borderless)
-                            .disableAutocorrection(true)
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: 250)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         Button {
                             onRequestOtpForResetPasswordTapped()
@@ -379,25 +314,10 @@ struct NativeLoginView: View {
                             .zIndex(2.0)
                         
                         TextField("One-Time-Password", text: $otp)
-                            .autocapitalization(.none)
-                            .buttonStyle(.borderless)
-                            .disableAutocorrection(true)
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: 250)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         SecureField("New Password", text: $password)
-                            .foregroundColor(.blue)
-                            .disableAutocorrection(true)
-                            .multilineTextAlignment(.center)
-                            .buttonStyle(.borderless)
-                            .autocapitalization(.none)
-                            .frame(maxWidth: 250)
-                            .padding(.bottom)
-                            .padding(.top, 10)
-                            .zIndex(2.0)
+                            .loginSecureField()
                         
                         Button {
                             onResetPasswordTapped()
@@ -423,14 +343,7 @@ struct NativeLoginView: View {
                     case .StartPasswordLessLogin:
                         // Layout to initialize password-less login by requesting a one-time-passcode.
                         TextField("Username", text: $username)
-                            .autocapitalization(.none)
-                            .buttonStyle(.borderless)
-                            .disableAutocorrection(true)
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: 250)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         Picker(
                             "OTP Verification Method",
@@ -465,14 +378,7 @@ struct NativeLoginView: View {
                     case .CompletePasswordLessLogin:
                         // Layout for password-less login by submitting a previously requested one-time-passcode.
                         TextField("One Time Password", text: $otp)
-                            .autocapitalization(.none)
-                            .buttonStyle(.borderless)
-                            .disableAutocorrection(true)
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: 250)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 25)
-                            .zIndex(2.0)
+                            .loginTextField()
                         
                         Button {
                             onSubmitOtpTapped()
@@ -844,6 +750,39 @@ enum IdentityFlowLayoutType {
     /// A layout for authorization code and credentials flow via username and password
     case Login
 }
+
+// MARK: Private SwiftUI Utilities
+
+private struct LoginField: ViewModifier {
+    let paddingTop: CGFloat = 10
+    let paddingBottom: CGFloat = 10
+    
+    func body(content: Content) -> some View {
+        content
+            .foregroundColor(.blue)
+            .disableAutocorrection(true)
+            .multilineTextAlignment(.center)
+            .buttonStyle(.borderless)
+            .autocapitalization(.none)
+            .frame(maxWidth: 250)
+            .padding(.top, paddingTop)
+            .zIndex(2.0)
+    }
+}
+
+extension TextField {
+    func loginTextField() -> some View {
+            modifier(LoginField())
+        }
+}
+
+extension SecureField {
+    func loginSecureField() -> some View {
+            modifier(LoginField())
+        }
+}
+
+// MARK: Previews
 
 #Preview {
     NativeLoginView()

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
@@ -753,17 +753,17 @@ struct NativeLoginView: View {
         isMessageError = true
     }
     
-    /// Resets the message state.
-    private func messageReset() {
-        messageText = ""
-        isMessageError = false
-    }
-    
     /// Sets the informational message displayed to the user.
     private func message(_ text: String) {
         messageReset()
         
         messageText = text
+    }
+    
+    /// Resets the message state.
+    private func messageReset() {
+        messageText = ""
+        isMessageError = false
     }
     
     /// Unwraps a native login result to a success outcome or sets an appropriate error user message.

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
@@ -55,11 +55,6 @@ struct NativeLoginView: View {
     /// Complete Registration:  The request identifier returned by the Salesforce Identity API's initialize registration endpoint
     @State private var requestIdentifier: String? = nil
     
-    // MARK: Password-Less Login Via One-Time-Passcode Properties
-    
-    /// Password-Less Login Via One-Time-Passcode: The user's chosen OTP verification method of email or SMS
-    @State private var otpVerificationMethod = OtpVerificationMethod.sms
-    
     // MARK: User Messaging
     
     /// User Messaging: Indicates if the message displayed to the user is informational or an error.  Note this is used by multiple layout types
@@ -78,6 +73,9 @@ struct NativeLoginView: View {
     
     /// The OTP identifier returned by the Salesforce Identity API's initialize headless login endpoint. Note this is used by multiple layout types
     @State private var otpIdentifier: String? = nil
+    
+    /// Password-Less Login Via One-Time-Passcode: The user's chosen OTP verification method of email or SMS
+    @State private var otpVerificationMethod = OtpVerificationMethod.sms
     
     /// The user's entered password.  Note this is used by multiple layout types
     @State private var password = ""

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
@@ -31,55 +31,61 @@ import SalesforceSDKCore
 struct NativeLoginView: View {
     @Environment(\.colorScheme) var colorScheme
     
+    // MARK: reCAPTCHA Properties
+    
     /// The reCAPTCHA client used to obtain reCAPTCHA tokens when needed for Salesforce Headless Identity API requests
     @EnvironmentObject var reCaptchaClientObservable: ReCaptchaClientObservable
     
     /// The layout type for the user's active identity flow, such as registration, forgot password or login
     @State private var identityFlowLayoutType = IdentityFlowLayoutType.LoginViaUsernamePassword
-
-    // mark: Start Registration
+    
+    // MARK: Start Registration Properties
     
     /// Start Registration: The user's entered first name.
     @State private var firstName = ""
     
-    /// Start Registration: The user's entered last name.
-    @State private var lastName = ""
-    
     /// Start Registration: The user's entered email address.
     @State private var email = ""
     
-    // mark: Complete Registration
+    /// Start Registration: The user's entered last name.
+    @State private var lastName = ""
+    
+    // MARK: Complete Registration
     
     /// Complete Registration:  The request identifier returned by the Salesforce Identity API's initialize registration endpoint
     @State private var requestIdentifier: String? = nil
     
-    // mark: User Messaging
+    // MARK: Password-Less Login Via One-Time-Passcode Properties
     
-    /// Indicates if the message displayed to the user is informational or an error.  Note this is used by multiple layout types
+    /// Password-Less Login Via One-Time-Passcode: The user's chosen OTP verification method of email or SMS
+    @State private var otpVerificationMethod = OtpVerificationMethod.sms
+    
+    // MARK: User Messaging
+    
+    /// User Messaging: Indicates if the message displayed to the user is informational or an error.  Note this is used by multiple layout types
     @State private var isMessageError = false
     
-    /// A message displayed to the user.  Note this is used by multiple layout types
+    /// User Messaging: A message displayed to the user.  Note this is used by multiple layout types
     @State private var messageText = ""
     
-    // mark: Common User Interface State
+    // MARK: Common User Interface State
     
     /// An option to display indicators when an identity action is in progress. Note this is used by multiple layout types
     @State private var isAuthenticating = false
     
-    /// The user's entered username.  Note this is used by multiple layout types
-    @State private var username = ""
+    /// The user's entered one-time-passcode. Note this is used by multiple layout types
+    @State private var otp = ""
+    
+    /// The OTP identifier returned by the Salesforce Identity API's initialize headless login endpoint. Note this is used by multiple layout types
+    @State private var otpIdentifier: String? = nil
     
     /// The user's entered password.  Note this is used by multiple layout types
     @State private var password = ""
     
-    /// Password-Less Login Via One-Time-Passcode: The user's entered one-time-passcode
-    @State private var otp = ""
+    /// The user's entered username.  Note this is used by multiple layout types
+    @State private var username = ""
     
-    /// Password-Less Login Via One-Time-Passcode:  The OTP identifier returned by the Salesforce Identity API's initialize headless login endpoint
-    @State private var otpIdentifier: String? = nil
-    
-    /// Password-Less Login Via One-Time-Passcode: The user's chosen OTP verification method of email or SMS
-    @State private var otpVerificationMethod = OtpVerificationMethod.sms
+    // MARK: Layout
     
     var body: some View {
         VStack {
@@ -293,7 +299,7 @@ struct NativeLoginView: View {
                             }
                             .frame(maxWidth: 250)
                             .zIndex(2.0)
-
+                        
                         Button {
                             onRequestOtpForRegistrationTapped()
                         } label: {
@@ -314,7 +320,7 @@ struct NativeLoginView: View {
                         .buttonStyle(.bordered)
                         .tint(.red)
                         .zIndex(2.0)
-
+                        
                     case .CompleteUserRegistration:
                         TextField("One-Time-Password", text: $otp)
                             .autocapitalization(.none)
@@ -325,7 +331,7 @@ struct NativeLoginView: View {
                             .multilineTextAlignment(.center)
                             .padding(.top, 25)
                             .zIndex(2.0)
-
+                        
                         Button {
                             onCompleteRegistrationTapped()
                         } label: {
@@ -358,7 +364,7 @@ struct NativeLoginView: View {
                             .multilineTextAlignment(.center)
                             .padding(.top, 25)
                             .zIndex(2.0)
-
+                        
                         Button {
                             onRequestOtpForResetPasswordTapped()
                         } label: {
@@ -409,7 +415,7 @@ struct NativeLoginView: View {
                             .padding(.bottom)
                             .padding(.top, 10)
                             .zIndex(2.0)
-
+                        
                         Button {
                             onResetPasswordTapped()
                         } label: {
@@ -430,7 +436,7 @@ struct NativeLoginView: View {
                         .buttonStyle(.bordered)
                         .tint(.red)
                         .zIndex(2.0)
-
+                        
                     case .InitializePasswordLessLoginViaOtp:
                         // Layout to initialize password-less login by requesting a one-time-passcode.
                         TextField("Username", text: $username)
@@ -518,7 +524,9 @@ struct NativeLoginView: View {
         }.background(Gradient(colors: [.blue, .cyan, .green]).opacity(0.6))
             .blur(radius: isAuthenticating ? 2.0 : 0.0)
     }
-
+    
+    // MARK: User Registration Actions
+    
     /// Submits a start registration request to the Salesforce Identity API forgot password endpoint.
     private func onRequestOtpForRegistrationTapped() {
         // Reset the message.
@@ -615,7 +623,8 @@ struct NativeLoginView: View {
             }
         }
     }
-
+    
+    // MARK: Passsword Reset User Actions
     
     /// Submits a start password reset request to the Salesforce Identity API forgot password endpoint.
     private func onRequestOtpForResetPasswordTapped() {
@@ -707,6 +716,8 @@ struct NativeLoginView: View {
             }
         }
     }
+    
+    // MARK: Password-Less Login User Actions
     
     ///
     /// Submits the OTP delivery request when the request button is tapped.  This submits a request to the
@@ -815,7 +826,7 @@ struct NativeLoginView: View {
         }
     }
     
-    // mark: Private User Messsaging Utilities
+    // MARK: Private User Messsaging Utilities
     
     /// Sets the error message displayed to the user.
     private func errorMessage(_ text: String) {
@@ -838,7 +849,7 @@ struct NativeLoginView: View {
         messageText = text
     }
     
-    // mark: Private Navigation Utilities
+    // MARK: Private Navigation Utilities
     
     /// Resets to the initial layout.
     private func layoutReset() {

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
@@ -181,7 +181,7 @@ struct NativeLoginView: View {
                                 
                                 // Act on the response.
                                 unwrapResult(result) {
-                                    password = ""
+                                    layoutReset()
                                 }
                             }
                         } label: {
@@ -735,7 +735,7 @@ struct NativeLoginView: View {
             
             switch result {
             case .success:
-                navigate(.Login)
+                layoutReset()
                 break
             default:
                 errorMessage("An error occurred.")

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
@@ -174,28 +174,13 @@ struct NativeLoginView: View {
                                 messageReset()
                                 isAuthenticating = true
                                 
-                                // Login
+                                // Login.
                                 let result = await SalesforceManager.shared.nativeLoginManager()
                                     .login(username: username, password: password)
-                                self.isAuthenticating = false
+                                isAuthenticating = false
                                 
-                                switch result {
-                                case .invalidCredentials:
-                                    errorMessage("Please check your username and password.")
-                                    break
-                                case .invalidEmail:
-                                    errorMessage("Invalid email address.")
-                                    break
-                                case .invalidUsername:
-                                    errorMessage("Username format is incorrect.")
-                                    break
-                                case .invalidPassword:
-                                    errorMessage("Invalid password.")
-                                    break
-                                case .unknownError:
-                                    errorMessage("An unknown error has occurred.")
-                                    break
-                                case .success:
+                                // Act on the response.
+                                unwrapResult(result) {
                                     password = ""
                                 }
                             }
@@ -561,29 +546,7 @@ struct NativeLoginView: View {
                 isAuthenticating = false
                 
                 // Act on the response.
-                switch result.nativeLoginResult {
-                    
-                case .invalidCredentials:
-                    errorMessage("Check your username and password.")
-                    break
-                    
-                case .invalidEmail:
-                    errorMessage("Invalid email address.")
-                    break
-                    
-                case .invalidPassword:
-                    errorMessage("Invalid password.")
-                    break
-                    
-                case .invalidUsername:
-                    errorMessage("Invalid username.")
-                    break
-                    
-                case .unknownError:
-                    errorMessage("An error occurred.")
-                    break
-                    
-                case .success:
+                unwrapResult(result.nativeLoginResult) {
                     requestIdentifier = result.requestIdentifier
                     navigate(.CompleteUserRegistration)
                 }
@@ -655,29 +618,7 @@ struct NativeLoginView: View {
                 isAuthenticating = false
                 
                 // Act on the response.
-                switch result {
-                    
-                case .invalidCredentials:
-                    errorMessage("Check your username and password.")
-                    break
-                    
-                case .invalidEmail:
-                    errorMessage("Invalid email address.")
-                    break
-                    
-                case .invalidPassword:
-                    errorMessage("Invalid password.")
-                    break
-                    
-                case .invalidUsername:
-                    errorMessage("Invalid username.")
-                    break
-                    
-                case .unknownError:
-                    errorMessage("An error occurred.")
-                    break
-                    
-                case .success:
+                unwrapResult(result) {
                     navigate(.CompletePasswordReset)
                 }
             }
@@ -750,29 +691,7 @@ struct NativeLoginView: View {
                 isAuthenticating = false
                 
                 // Act on the response.
-                switch result.nativeLoginResult {
-                    
-                case .invalidCredentials:
-                    errorMessage("Check your username and password.")
-                    break
-                    
-                case .invalidEmail:
-                    errorMessage("Invalid email address.")
-                    break
-                    
-                case .invalidPassword:
-                    errorMessage("Invalid password.")
-                    break
-                    
-                case .invalidUsername:
-                    errorMessage("Invalid username.")
-                    break
-                    
-                case .unknownError:
-                    errorMessage("An error occurred.")
-                    break
-                    
-                case .success:
+                unwrapResult(result.nativeLoginResult) {
                     // Verify parameters.
                     guard let otpIdentifierResult = result.otpIdentifier else { return }
                     
@@ -845,6 +764,35 @@ struct NativeLoginView: View {
         messageReset()
         
         messageText = text
+    }
+    
+    /// Unwraps a native login result to a success outcome or sets an appropriate error user message.
+    /// - Parameters:
+    ///   - result: The native login result
+    ///   - onSuccess: The success outcome
+    private func unwrapResult(
+        _ result: NativeLoginResult,
+        onSuccess: () -> ())
+    {
+        switch result {
+        case .invalidCredentials:
+            errorMessage("Please check your username and password.")
+            break
+        case .invalidEmail:
+            errorMessage("Invalid email address.")
+            break
+        case .invalidUsername:
+            errorMessage("Username format is incorrect.")
+            break
+        case .invalidPassword:
+            errorMessage("Invalid password.")
+            break
+        case .unknownError:
+            errorMessage("An unknown error has occurred.")
+            break
+        case .success:
+            onSuccess()
+        }
     }
     
     // MARK: Private Navigation Utilities

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
@@ -592,6 +592,9 @@ struct NativeLoginView: View {
         // Reset the message.
         messageReset()
         
+        // Clear the user's previous password entry.
+        password = ""
+        
         // Show the progress indicator.
         isAuthenticating = true
         
@@ -762,8 +765,8 @@ struct NativeLoginView: View {
     
     /// Resets the message state.
     private func messageReset() {
-        messageText = ""
         isMessageError = false
+        messageText = ""
     }
     
     /// Unwraps a native login result to a success outcome or sets an appropriate error user message.

--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/NativeLoginView.swift
@@ -37,7 +37,7 @@ struct NativeLoginView: View {
     @EnvironmentObject var reCaptchaClientObservable: ReCaptchaClientObservable
     
     /// The layout type for the user's active identity flow, such as registration, forgot password or login
-    @State private var identityFlowLayoutType = IdentityFlowLayoutType.LoginViaUsernamePassword
+    @State private var identityFlowLayoutType = IdentityFlowLayoutType.Login
     
     // MARK: Start Registration Properties
     
@@ -147,7 +147,7 @@ struct NativeLoginView: View {
                     // Switch the layout to match the selected identity flow.
                     switch(identityFlowLayoutType) {
                         
-                    case .LoginViaUsernamePassword:
+                    case .Login:
                         TextField("Username", text: $username)
                             .foregroundColor(.blue)
                             .disableAutocorrection(true)
@@ -196,7 +196,7 @@ struct NativeLoginView: View {
                         .padding(.bottom, 25)
                         
                         Button {
-                            navigate(.InitializePasswordLessLoginViaOtp)
+                            navigate(.StartPasswordLessLogin)
                         } label: {
                             Text("Use One Time Password Instead").frame(minWidth: 150)
                         }
@@ -214,7 +214,7 @@ struct NativeLoginView: View {
                         .zIndex(2.0)
                         
                         Button {
-                            navigate(.StartUserRegistration)
+                            navigate(.StartRegistration)
                         } label: {
                             Text("Register").frame(minWidth: 150)
                         }
@@ -222,7 +222,7 @@ struct NativeLoginView: View {
                         .tint(colorScheme == .dark ? .white : .blue)
                         .zIndex(2.0)
                         
-                    case .StartUserRegistration:
+                    case .StartRegistration:
                         TextField("Email", text: $email)
                             .autocapitalization(.none)
                             .buttonStyle(.borderless)
@@ -304,7 +304,7 @@ struct NativeLoginView: View {
                         .tint(.red)
                         .zIndex(2.0)
                         
-                    case .CompleteUserRegistration:
+                    case .CompleteRegistration:
                         TextField("One-Time-Password", text: $otp)
                             .autocapitalization(.none)
                             .buttonStyle(.borderless)
@@ -420,7 +420,7 @@ struct NativeLoginView: View {
                         .tint(.red)
                         .zIndex(2.0)
                         
-                    case .InitializePasswordLessLoginViaOtp:
+                    case .StartPasswordLessLogin:
                         // Layout to initialize password-less login by requesting a one-time-passcode.
                         TextField("Username", text: $username)
                             .autocapitalization(.none)
@@ -462,7 +462,7 @@ struct NativeLoginView: View {
                         .tint(.red)
                         .zIndex(2.0)
                         
-                    case .LoginViaUsernameAndOtp:
+                    case .CompletePasswordLessLogin:
                         // Layout for password-less login by submitting a previously requested one-time-passcode.
                         TextField("One Time Password", text: $otp)
                             .autocapitalization(.none)
@@ -548,7 +548,7 @@ struct NativeLoginView: View {
                 // Act on the response.
                 unwrapResult(result.nativeLoginResult) {
                     requestIdentifier = result.requestIdentifier
-                    navigate(.CompleteUserRegistration)
+                    navigate(.CompleteRegistration)
                 }
             }
         }
@@ -697,7 +697,7 @@ struct NativeLoginView: View {
                     
                     // Switch to the OTP submission layout.
                     otpIdentifier = otpIdentifierResult
-                    navigate(.LoginViaUsernameAndOtp)
+                    navigate(.CompletePasswordLessLogin)
                 }
             }
         }
@@ -735,7 +735,7 @@ struct NativeLoginView: View {
             
             switch result {
             case .success:
-                navigate(.LoginViaUsernamePassword)
+                navigate(.Login)
                 break
             default:
                 errorMessage("An error occurred.")
@@ -805,7 +805,7 @@ struct NativeLoginView: View {
         password = ""
         username = ""
         
-        navigate(.LoginViaUsernamePassword)
+        navigate(.Login)
     }
     
     /// Navigates to the specified layout.
@@ -821,10 +821,10 @@ struct NativeLoginView: View {
 enum IdentityFlowLayoutType {
     
     /// A layout to start the user registration flow.
-    case StartUserRegistration
+    case StartRegistration
     
     /// A layout to complete the user registration flow.
-    case CompleteUserRegistration
+    case CompleteRegistration
     
     /// A layout to start the password reset flow.
     case StartPasswordReset
@@ -833,13 +833,13 @@ enum IdentityFlowLayoutType {
     case CompletePasswordReset
     
     /// A layout to initialize password-less login via one-time-passcode request.
-    case InitializePasswordLessLoginViaOtp
+    case StartPasswordLessLogin
     
     /// A layout for authorization code and credentials flow via username and previously requested one-time-passcode.
-    case LoginViaUsernameAndOtp
+    case CompletePasswordLessLogin
     
     /// A layout for authorization code and credentials flow via username and password
-    case LoginViaUsernamePassword
+    case Login
 }
 
 #Preview {


### PR DESCRIPTION
🤘🏻 _*Ready For Review!_ 🎤

This is a companion to the MSDK implementation in https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3728

The most interesting part of the code is a handful of utility methods in the layout to help keep the code from being repetitive.

Here are a few useful screenshots.

<img width="646" alt="0  Auth Landing" src="https://github.com/forcedotcom/SalesforceMobileSDK-Templates/assets/94090596/865e4d57-acc5-4bdf-b088-6a189d895d6d">
<img width="553" alt="1  Register" src="https://github.com/forcedotcom/SalesforceMobileSDK-Templates/assets/94090596/6070a9cc-b188-468e-bc10-a358ae866727">
<img width="508" alt="2  Reset Password" src="https://github.com/forcedotcom/SalesforceMobileSDK-Templates/assets/94090596/01f4b150-6f74-4b38-b61d-b38b52173b72">
