### PR TITLE
@W-16814802: [iOS] Add Deep Link From External QR Code Reader To iOS Native Swift Template QR Code Login

### DIFF
--- a/AndroidNativeKotlinTemplate/app/src/main/AndroidManifest.xml
+++ b/AndroidNativeKotlinTemplate/app/src/main/AndroidManifest.xml
@@ -23,13 +23,13 @@
 
             <!-- Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes -->
             <!-- This declares the app's support for QR code login deep links.  The scheme can be customized by the app to match any scheme used in the QR Code's URL -->
-<!--            <intent-filter>-->
-<!--                <data android:scheme="mobileapp" />-->
-<!--                <action android:name="android.intent.action.VIEW" />-->
+            <intent-filter>
+                <data android:scheme="mobileapp" />
+                <action android:name="android.intent.action.VIEW" />
 
-<!--                <category android:name="android.intent.category.BROWSABLE" />-->
-<!--                <category android:name="android.intent.category.DEFAULT" />-->
-<!--            </intent-filter>-->
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <!-- Login activity -->
@@ -47,22 +47,10 @@
             and 'path' would be "/oauth/done".
         -->
         <!-- Use `android:name="com.salesforce.androidnativekotlintemplate.QrCodeEnabledLoginActivity"` when enabling log in via Salesforce UI Bridge API generated QR codes -->
-<!--        <activity-->
-<!--            android:name="com.salesforce.androidnativekotlintemplate.QrCodeEnabledLoginActivity"-->
-<!--            android:theme="@style/SalesforceSDK"-->
-<!--            android:launchMode="singleTask"-->
-<!--            android:exported="true">-->
-
-<!--            &lt;!&ndash; Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes &ndash;&gt;-->
-<!--            &lt;!&ndash; <intent-filter>&ndash;&gt;-->
-<!--            &lt;!&ndash;     <data&ndash;&gt;-->
-<!--            &lt;!&ndash;         android:host="android"&ndash;&gt;-->
-<!--            &lt;!&ndash;         android:path="/login/qr"&ndash;&gt;-->
-<!--            &lt;!&ndash;         android:scheme="mobileapp" />&ndash;&gt;-->
-<!--            &lt;!&ndash;     <action android:name="android.intent.action.VIEW" />&ndash;&gt;-->
-<!--            &lt;!&ndash;     <category android:name="android.intent.category.BROWSABLE" />&ndash;&gt;-->
-<!--            &lt;!&ndash;     <category android:name="android.intent.category.DEFAULT" />&ndash;&gt;-->
-<!--            &lt;!&ndash; </intent-filter>&ndash;&gt;-->
-<!--        </activity>-->
+        <activity
+            android:name="com.salesforce.androidnativekotlintemplate.QrCodeEnabledLoginActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/SalesforceSDK" />
     </application>
 </manifest>

--- a/AndroidNativeKotlinTemplate/app/src/main/AndroidManifest.xml
+++ b/AndroidNativeKotlinTemplate/app/src/main/AndroidManifest.xml
@@ -23,13 +23,13 @@
 
             <!-- Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes -->
             <!-- This declares the app's support for QR code login deep links.  The scheme can be customized by the app to match any scheme used in the QR Code's URL -->
-            <intent-filter>
-                <data android:scheme="mobileapp" />
-                <action android:name="android.intent.action.VIEW" />
+<!--            <intent-filter>-->
+<!--                <data android:scheme="mobileapp" />-->
+<!--                <action android:name="android.intent.action.VIEW" />-->
 
-                <category android:name="android.intent.category.BROWSABLE" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
+<!--                <category android:name="android.intent.category.BROWSABLE" />-->
+<!--                <category android:name="android.intent.category.DEFAULT" />-->
+<!--            </intent-filter>-->
         </activity>
 
         <!-- Login activity -->
@@ -47,10 +47,10 @@
             and 'path' would be "/oauth/done".
         -->
         <!-- Use `android:name="com.salesforce.androidnativekotlintemplate.QrCodeEnabledLoginActivity"` when enabling log in via Salesforce UI Bridge API generated QR codes -->
-        <activity
-            android:name="com.salesforce.androidnativekotlintemplate.QrCodeEnabledLoginActivity"
-            android:exported="true"
-            android:launchMode="singleTask"
-            android:theme="@style/SalesforceSDK" />
+<!--        <activity-->
+<!--            android:name="com.salesforce.androidsdk.ui.LoginActivity"-->
+<!--            android:exported="true"-->
+<!--            android:launchMode="singleTask"-->
+<!--            android:theme="@style/SalesforceSDK" />-->
     </application>
 </manifest>

--- a/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainActivity.kt
+++ b/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainActivity.kt
@@ -26,6 +26,9 @@
  */
 package com.salesforce.androidnativekotlintemplate
 
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
+import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import android.os.Bundle
@@ -45,9 +48,14 @@ import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestClient.AsyncRequestCallback
 import com.salesforce.androidsdk.rest.RestRequest
 import com.salesforce.androidsdk.rest.RestResponse
-import com.salesforce.androidsdk.ui.LoginActivity.Companion.isQrCodeLoginIntent
-import com.salesforce.androidsdk.ui.LoginActivity.Companion.uiBridgeApiParametersFromQrCodeLoginUrl
+import com.salesforce.androidsdk.ui.LoginActivity
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.EXTRA_KEY_FRONTDOOR_BRIDGE_URL
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.EXTRA_KEY_PKCE_CODE_VERIFIER
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.isQrCodeLoginUrlIntent
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.qrCodeLoginUrlJsonParameterName
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.qrCodeLoginUrlPath
 import com.salesforce.androidsdk.ui.SalesforceActivity
+import com.salesforce.androidsdk.util.SalesforceSDKLogger.e
 import java.io.UnsupportedEncodingException
 import java.util.*
 
@@ -61,11 +69,6 @@ class MainActivity : SalesforceActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        // Check for and use the intent's QR code login URL if applicable.
-        if (isQrCodeLoginIntent(intent)) {
-            useQrCodeLoginUrl()
-        }
 
         // Set Theme
         val idDarkTheme = MobileSyncSDKManager.getInstance().isDarkTheme
@@ -90,21 +93,38 @@ class MainActivity : SalesforceActivity() {
 
     override fun onResume() {
         // Hide everything until we are logged in
-        findViewById<ViewGroup>(R.id.root).visibility = View.INVISIBLE
+        findViewById<ViewGroup>(root).visibility = View.INVISIBLE
 
         // Create list adapter
         listAdapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, ArrayList())
         findViewById<ListView>(R.id.contacts_list).adapter = listAdapter
 
+        // Check for and use the intent's QR code login URL if applicable.
+        val buildRestClientOnResumePreviousValue = buildRestClientOnResume
+        if (isQrCodeLoginUrlIntent(intent ?: return)) {
+            /*
+             * Temporarily request the Salesforce Mobile SDK REST Client not be
+             * built on resume such that the default login activity will not
+             * display and conflict with the login activity for QR code log in.
+             *
+             * If the display of the default login activity was no longer a
+             * side-effect of getting the REST client, this variable could be
+             * removed.
+             */
+            buildRestClientOnResume = false
+            useQrCodeLogInUrl(intent.data ?: return)
+        }
+
         super.onResume()
+        buildRestClientOnResume = buildRestClientOnResumePreviousValue
     }
 
-    override fun onResume(client: RestClient) {
+    override fun onResume(client: RestClient?) {
         // Keeping reference to rest client
         this.client = client
 
         // Show everything
-        findViewById<ViewGroup>(R.id.root).visibility = View.VISIBLE
+        findViewById<ViewGroup>(root).visibility = View.VISIBLE
     }
 
     /**
@@ -184,12 +204,61 @@ class MainActivity : SalesforceActivity() {
 
     // region QR Code Login Via Salesforce Identity API UI Bridge Public Implementation
 
-    private fun useQrCodeLoginUrl() {
-        val uiBridgeApiParameters = uiBridgeApiParametersFromQrCodeLoginUrl(intent.data.toString())
-        SalesforceSDKManager.getInstance().apply {
-            frontDoorBridgeUrl = uiBridgeApiParameters?.frontdoorBridgeUrl
-            frontDoorBridgeCodeVerifier = uiBridgeApiParameters?.pkceCodeVerifier
+    /**
+     * Validates and uses the intent's QR code log in URL.
+     * @param url The QR code log in URL
+     */
+    private fun useQrCodeLogInUrl(url: Uri) {
+        val app = application as? MainApplication ?: return
+
+        // Use the specified QR code log in URL format.
+        if (app.isQrCodeLoginUsingReferenceUrlFormat) {
+
+            // Log in using `loginWithFrontdoorBridgeUrlFromQrCode` if applicable
+            if (url.scheme != app.qrCodeLoginUrlScheme
+                || url.host != app.qrCodeLoginUrlHost
+                || url.path != qrCodeLoginUrlPath
+                || !url.queryParameterNames.contains(qrCodeLoginUrlJsonParameterName)
+            ) {
+                e(javaClass.name, "Invalid QR code log in URL.")
+                return
+            }
+            startActivity(
+                Intent(
+                    this@MainActivity,
+                    LoginActivity::class.java
+                ).apply {
+                    data = url
+                })
+        } else {
+
+            /*
+             * When using `loginWithFrontdoorBridgeUrl` and an entirely custom
+             * QR code login URL format, set
+             * `isAppExpectedReferenceQrCodeLoginUrlFormat` to `false` (or
+             * remove it entirely) and implement URL handling in this block
+             * before calling `loginWithFrontdoorBridgeUrl`.
+             */
+
+            /* To-do: Implement URL handling to retrieve UI Bridge API parameters */
+            /* To set up QR code log in using `loginWithFrontdoorBridgeUrlFromQrCode`, provide the scheme and host for the expected QR code log in URL format */
+            val frontdoorBridgeUrl = "your-qr-code-login-frontdoor-bridge-url"
+            val pkceCodeVerifier = "your-qr-code-login-pkce-code-verifier"
+            check(frontdoorBridgeUrl != "your-qr-code-login-frontdoor-bridge-url") { "Please implement your app's frontdoor bridge URL retrieval." }
+            check(pkceCodeVerifier != "your-qr-code-login-pkce-code-verifier") { "Please add your app's PKCE code verifier retrieval if web server flow is used." }
+
+            startActivity(Intent(
+                this,
+                LoginActivity::class.java
+            ).apply {
+                putExtra(EXTRA_KEY_FRONTDOOR_BRIDGE_URL, frontdoorBridgeUrl)
+                putExtra(EXTRA_KEY_PKCE_CODE_VERIFIER, pkceCodeVerifier)
+                flags = FLAG_ACTIVITY_SINGLE_TOP
+            })
         }
+
+        // Clear the intent data so that the QR code log in URL is used only once.
+        intent.data = null
     }
 
     // endregion

--- a/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainActivity.kt
+++ b/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainActivity.kt
@@ -192,8 +192,8 @@ class MainActivity : SalesforceActivity() {
     // region QR Code Login Via Salesforce Identity API UI Bridge Public Implementation
 
     /**
-     * Validates and uses the intent's QR code log in URL.
-     * @param url The QR code log in URL
+     * Validates and uses the intent's QR code login URL.
+     * @param url The QR code login URL
      */
     private fun useQrCodeLogInUrl(url: Uri) {
         isBuildRestClientOnResumeEnabled = true
@@ -204,7 +204,7 @@ class MainActivity : SalesforceActivity() {
         // While using a QR Code Login URL, disable the default login activity.
         isBuildRestClientOnResumeEnabled = false
 
-        // Use the specified QR code log in URL format.
+        // Use the specified QR code login URL format.
         if (app.isQrCodeLoginUsingReferenceUrlFormat) {
 
             // Log in using `loginWithFrontdoorBridgeUrlFromQrCode` if applicable
@@ -213,7 +213,7 @@ class MainActivity : SalesforceActivity() {
                 || url.path != qrCodeLoginUrlPath
                 || !url.queryParameterNames.contains(qrCodeLoginUrlJsonParameterName)
             ) {
-                e(javaClass.name, "Invalid QR code log in URL.")
+                e(javaClass.name, "Invalid QR code login URL.")
                 return
             }
             startActivity(
@@ -234,7 +234,7 @@ class MainActivity : SalesforceActivity() {
              */
 
             /* To-do: Implement URL handling to retrieve UI Bridge API parameters */
-            /* To set up QR code log in using `loginWithFrontdoorBridgeUrlFromQrCode`, provide the scheme and host for the expected QR code log in URL format */
+            /* To set up QR code login using `loginWithFrontdoorBridgeUrlFromQrCode`, provide the scheme and host for the expected QR code login URL format */
             val frontdoorBridgeUrl = "your-qr-code-login-frontdoor-bridge-url"
             val pkceCodeVerifier = "your-qr-code-login-pkce-code-verifier"
             check(frontdoorBridgeUrl != "your-qr-code-login-frontdoor-bridge-url") { "Please implement your app's frontdoor bridge URL retrieval." }
@@ -250,7 +250,7 @@ class MainActivity : SalesforceActivity() {
             })
         }
 
-        // Clear the intent data so that the QR code log in URL is used only once.
+        // Clear the intent data so that the QR code login URL is used only once.
         intent.data = null
     }
 

--- a/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainActivity.kt
+++ b/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainActivity.kt
@@ -119,7 +119,7 @@ class MainActivity : SalesforceActivity() {
         buildRestClientOnResume = buildRestClientOnResumePreviousValue
     }
 
-    override fun onResume(client: RestClient?) {
+    override fun onResume(client: RestClient) {
         // Keeping reference to rest client
         this.client = client
 

--- a/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainActivity.kt
+++ b/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainActivity.kt
@@ -100,26 +100,13 @@ class MainActivity : SalesforceActivity() {
         findViewById<ListView>(R.id.contacts_list).adapter = listAdapter
 
         // Check for and use the intent's QR code login URL if applicable.
-        val buildRestClientOnResumePreviousValue = buildRestClientOnResume
-        if (isQrCodeLoginUrlIntent(intent ?: return)) {
-            /*
-             * Temporarily request the Salesforce Mobile SDK REST Client not be
-             * built on resume such that the default login activity will not
-             * display and conflict with the login activity for QR code log in.
-             *
-             * If the display of the default login activity was no longer a
-             * side-effect of getting the REST client, this variable could be
-             * removed.
-             */
-            buildRestClientOnResume = false
-            useQrCodeLogInUrl(intent.data ?: return)
-        }
+        // Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes
+        //intent.data?.let { useQrCodeLogInUrl(it) }
 
         super.onResume()
-        buildRestClientOnResume = buildRestClientOnResumePreviousValue
     }
 
-    override fun onResume(client: RestClient) {
+    override fun onResume(client: RestClient?) {
         // Keeping reference to rest client
         this.client = client
 
@@ -209,7 +196,13 @@ class MainActivity : SalesforceActivity() {
      * @param url The QR code log in URL
      */
     private fun useQrCodeLogInUrl(url: Uri) {
+        isBuildRestClientOnResumeEnabled = true
+
         val app = application as? MainApplication ?: return
+        if (!isQrCodeLoginUrlIntent(intent)) return
+
+        // While using a QR Code Login URL, disable the default login activity.
+        isBuildRestClientOnResumeEnabled = false
 
         // Use the specified QR code log in URL format.
         if (app.isQrCodeLoginUsingReferenceUrlFormat) {

--- a/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainApplication.kt
+++ b/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainApplication.kt
@@ -82,7 +82,7 @@ class MainApplication : Application() {
 
     /**
      * When enabling log in via Salesforce UI Bridge API generated QR codes, choose to use the
-     * Salesforce Mobile SDK reference format for QR code log in URLs or an entirely custom format.
+     * Salesforce Mobile SDK reference format for QR code login URLs or an entirely custom format.
      *
      * If only one of the two formats is used, which is the most likely implementation for apps using this
      * template, this variable and code related to the unused implementation could be removed.
@@ -91,20 +91,20 @@ class MainApplication : Application() {
 
     /**
      * When enabling log in via Salesforce UI Bridge API generated QR codes and using the reference QR
-     * code log in URL format, the scheme for the expected QR code log in URL format.
+     * code log in URL format, the scheme for the expected QR code login URL format.
      */
     internal var qrCodeLoginUrlScheme = "your-qr-code-login-url-scheme"
 
     /**
      * When enabling log in via Salesforce UI Bridge API generated QR codes and using the reference QR
-     * code log in URL format, the host for the expected QR code log in URL format.
+     * code log in URL format, the host for the expected QR code login URL format.
      */
     internal var qrCodeLoginUrlHost = "your-qr-code-login-url-host"
 
     // region QR Code Login Via Salesforce Identity API UI Bridge Private Implementation
 
     /**
-     * Sets up QR code log in.
+     * Sets up QR code login.
      */
     private fun setupQrCodeLogin() {
 
@@ -112,7 +112,7 @@ class MainApplication : Application() {
          * When enabling log in via Salesforce UI Bridge API generated QR codes
          * and using the Salesforce Mobile SDK reference format for QR code log
          * in URLs, specify values for the string placeholders in this method to
-         * control the parsing of QR code log in URLs. The required UI Bridge
+         * control the parsing of QR code login URLs. The required UI Bridge
          * API parameters are the frontdoor URL and, for web server flow, the
          * PKCE code verifier.
          *
@@ -133,7 +133,7 @@ class MainApplication : Application() {
          * SDK will retrieve the required UI Bridge API parameters
          * automatically.
          *
-         * The reference QR code log in URL format uses this structure where the
+         * The reference QR code login URL format uses this structure where the
          * PKCE code verifier must be URL-Safe Base64 encoded and the overall
          * JSON content must be URL encoded:
          * [scheme]://[host]/[path]?[json-parameter-name]={[frontdoor-bridge-url-key]=<>,[pkce-code-verifier-key]=<>}
@@ -143,7 +143,7 @@ class MainApplication : Application() {
          * to follow the latest security practices documented by the app's
          * native platform.
          *
-         * If using an entirely custom format for QR code log in URLs, the
+         * If using an entirely custom format for QR code login URLs, the
          * assignment of these strings can be safely removed.
          */
         // The scheme and host for the expected QR code log in URL format.

--- a/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainApplication.kt
+++ b/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainApplication.kt
@@ -28,6 +28,10 @@ package com.salesforce.androidnativekotlintemplate
 
 import android.app.Application
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.qrCodeLoginUrlJsonFrontdoorBridgeUrlKey
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.qrCodeLoginUrlJsonParameterName
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.qrCodeLoginUrlJsonPkceCodeVerifierKey
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.qrCodeLoginUrlPath
 
 /**
  * Application class for our application.
@@ -37,6 +41,8 @@ class MainApplication : Application() {
     companion object {
         private const val FEATURE_APP_USES_KOTLIN = "KT"
     }
+
+    // region Activity Implementation
 
     override fun onCreate() {
         super.onCreate()
@@ -49,7 +55,8 @@ class MainApplication : Application() {
              *
              */
             // Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes
-            /*QrCodeEnabledLoginActivity::class.java*/)
+            QrCodeEnabledLoginActivity::class.java
+        )
         MobileSyncSDKManager.getInstance().registerUsedAppFeature(FEATURE_APP_USES_KOTLIN)
 
         /*
@@ -67,8 +74,92 @@ class MainApplication : Application() {
 		 */
         // MobileSyncSDKManager.getInstance().pushNotificationReceiver = pnInterface
 
-        // Enable login via Salesforce UI Bridge API generated QR code.
-        // Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes
-        // MobileSyncSDKManager.getInstance().isQrCodeLoginEnabled = true
+        /* Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes. */
+        setupQrCodeLogin()
     }
+
+    // endregion
+    // region QR Code Login Via Salesforce Identity API UI Bridge Public Implementation
+
+    /**
+     * When enabling log in via Salesforce UI Bridge API generated QR codes, choose to use the
+     * Salesforce Mobile SDK reference format for QR code log in URLs or an entirely custom format.
+     *
+     * If only one of the two formats is used, which is the most likely implementation for apps using this
+     * template, this variable and code related to the unused implementation could be removed.
+     */
+    internal var isQrCodeLoginUsingReferenceUrlFormat = true
+
+    /**
+     * When enabling log in via Salesforce UI Bridge API generated QR codes and using the reference QR
+     * code log in URL format, the scheme for the expected QR code log in URL format.
+     */
+    internal var qrCodeLoginUrlScheme = "mobileapp" //"your-qr-code-login-url-scheme"
+
+    /**
+     * When enabling log in via Salesforce UI Bridge API generated QR codes and using the reference QR
+     * code log in URL format, the host for the expected QR code log in URL format.
+     */
+    internal var qrCodeLoginUrlHost = "android" //"your-qr-code-login-url-host"
+
+    // region QR Code Login Via Salesforce Identity API UI Bridge Private Implementation
+
+    /**
+     * Sets up QR code log in.
+     */
+    private fun setupQrCodeLogin() {
+
+        /*
+         * When enabling log in via Salesforce UI Bridge API generated QR codes
+         * and using the Salesforce Mobile SDK reference format for QR code log
+         * in URLs, specify values for the string placeholders in this method to
+         * control the parsing of QR code log in URLs. The required UI Bridge
+         * API parameters are the frontdoor URL and, for web server flow, the
+         * PKCE code verifier.
+         *
+         * Salesforce Mobile SDK doesn't require a specific format for the QR
+         * code log in URL.  The server-side code, such as an APEX class and
+         * Visualforce page, must generate a QR code URL that the app is
+         * prepared to be opened by and be able to parse the UI Bridge API
+         * parameters from.
+         *
+         * Apps may receive and parse an entirely custom URL format so long as
+         * the UI Bridge API parameters are delivered to the
+         * `loginWithFrontdoorBridgeUrl` method.
+         *
+         * As a convenience, Salesforce Mobile SDK accepts a reference QR code
+         * log in URL format.  URLs matching that format and using string values
+         * provided by the app can be provided to the
+         * `loginWithFrontdoorBridgeUrlFromQrCode` method and Salesforce Mobile
+         * SDK will retrieve the required UI Bridge API parameters
+         * automatically.
+         *
+         * The reference QR code log in URL format uses this structure where the
+         * PKCE code verifier must be URL-Safe Base64 encoded and the overall
+         * JSON content must be URL encoded:
+         * [scheme]://[host]/[path]?[json-parameter-name]={[frontdoor-bridge-url-key]=<>,[pkce-code-verifier-key]=<>}
+         *
+         * Any URL link scheme supported by the native platform may be used.
+         * This includes Android App Links and iOS Universal Links. Be certain
+         * to follow the latest security practices documented by the app's
+         * native platform.
+         *
+         * If using an entirely custom format for QR code log in URLs, the
+         * assignment of these strings can be safely removed.
+         */
+        // The scheme and host for the expected QR code log in URL format.
+        check(qrCodeLoginUrlScheme != "your-qr-code-login-url-scheme") { "Please add your login QR code URL's scheme." }
+        check(qrCodeLoginUrlHost != "your-qr-code-login-url-host") { "Please add your login QR code URL's host." }
+        // The path, parameter names and JSON keys for the expected QR code log in URL format.
+//        qrCodeLoginUrlPath = "your-qr-code-login-url-path"
+//        qrCodeLoginUrlJsonParameterName = "your-qr-code-login-url-json-parameter-name"
+//        qrCodeLoginUrlJsonFrontdoorBridgeUrlKey = "your-qr-code-login-url-json-frontdoor-bridge-url-key"
+//        qrCodeLoginUrlJsonPkceCodeVerifierKey = "your-qr-code-login-url-json-pkce-code-verifier-key"
+        check(qrCodeLoginUrlPath != "your-qr-code-login-url-path") { "Please add your login QR code URL's path." }
+        check(qrCodeLoginUrlJsonParameterName != "your-qr-code-login-url-json-parameter-name") { "Please add your login QR code URL's UI Bridge API JSON query string parameter name." }
+        check(qrCodeLoginUrlJsonFrontdoorBridgeUrlKey != "your-qr-code-login-url-json-frontdoor-bridge-url-key") { "Please add your login QR code URL's UI Bridge API JSON frontdoor bridge URL key." }
+        check(qrCodeLoginUrlJsonPkceCodeVerifierKey != "your-qr-code-login-url-json-pkce-code-verifier-key") { "Please add your login QR code URL's UI Bridge API JSON PKCE code verifier key." }
+    }
+
+    // endregion
 }

--- a/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainApplication.kt
+++ b/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/MainApplication.kt
@@ -52,10 +52,9 @@ class MainApplication : Application() {
             /*
              * Enable login via Salesforce UI Bridge API generated QR code using
              * a custom log in activity.
-             *
              */
             // Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes
-            QrCodeEnabledLoginActivity::class.java
+            /*QrCodeEnabledLoginActivity::class.java*/
         )
         MobileSyncSDKManager.getInstance().registerUsedAppFeature(FEATURE_APP_USES_KOTLIN)
 
@@ -75,7 +74,7 @@ class MainApplication : Application() {
         // MobileSyncSDKManager.getInstance().pushNotificationReceiver = pnInterface
 
         /* Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes. */
-        setupQrCodeLogin()
+        //setupQrCodeLogin()
     }
 
     // endregion
@@ -94,13 +93,13 @@ class MainApplication : Application() {
      * When enabling log in via Salesforce UI Bridge API generated QR codes and using the reference QR
      * code log in URL format, the scheme for the expected QR code log in URL format.
      */
-    internal var qrCodeLoginUrlScheme = "mobileapp" //"your-qr-code-login-url-scheme"
+    internal var qrCodeLoginUrlScheme = "your-qr-code-login-url-scheme"
 
     /**
      * When enabling log in via Salesforce UI Bridge API generated QR codes and using the reference QR
      * code log in URL format, the host for the expected QR code log in URL format.
      */
-    internal var qrCodeLoginUrlHost = "android" //"your-qr-code-login-url-host"
+    internal var qrCodeLoginUrlHost = "your-qr-code-login-url-host"
 
     // region QR Code Login Via Salesforce Identity API UI Bridge Private Implementation
 
@@ -151,10 +150,10 @@ class MainApplication : Application() {
         check(qrCodeLoginUrlScheme != "your-qr-code-login-url-scheme") { "Please add your login QR code URL's scheme." }
         check(qrCodeLoginUrlHost != "your-qr-code-login-url-host") { "Please add your login QR code URL's host." }
         // The path, parameter names and JSON keys for the expected QR code log in URL format.
-//        qrCodeLoginUrlPath = "your-qr-code-login-url-path"
-//        qrCodeLoginUrlJsonParameterName = "your-qr-code-login-url-json-parameter-name"
-//        qrCodeLoginUrlJsonFrontdoorBridgeUrlKey = "your-qr-code-login-url-json-frontdoor-bridge-url-key"
-//        qrCodeLoginUrlJsonPkceCodeVerifierKey = "your-qr-code-login-url-json-pkce-code-verifier-key"
+        qrCodeLoginUrlPath = "your-qr-code-login-url-path"
+        qrCodeLoginUrlJsonParameterName = "your-qr-code-login-url-json-parameter-name"
+        qrCodeLoginUrlJsonFrontdoorBridgeUrlKey = "your-qr-code-login-url-json-frontdoor-bridge-url-key"
+        qrCodeLoginUrlJsonPkceCodeVerifierKey = "your-qr-code-login-url-json-pkce-code-verifier-key"
         check(qrCodeLoginUrlPath != "your-qr-code-login-url-path") { "Please add your login QR code URL's path." }
         check(qrCodeLoginUrlJsonParameterName != "your-qr-code-login-url-json-parameter-name") { "Please add your login QR code URL's UI Bridge API JSON query string parameter name." }
         check(qrCodeLoginUrlJsonFrontdoorBridgeUrlKey != "your-qr-code-login-url-json-frontdoor-bridge-url-key") { "Please add your login QR code URL's UI Bridge API JSON frontdoor bridge URL key." }

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
@@ -36,7 +36,7 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
         MobileSyncSDKManager.initializeSDK()
         
         // Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes.
-        // self.setupQrCodeLogin()
+        self.setupQrCodeLogin()
     }
     
     // MARK: UISceneSession Lifecycle
@@ -76,14 +76,7 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
             }
         }
     }
-    
-    private func setupQrCodeLogin() {
-        MobileSyncSDKManager.shared.isQrCodeLoginEnabled = true
-        UserAccountManager.shared.loginViewControllerConfig.loginViewControllerCreationBlock = {
-            return LoginTypeSelectionViewController()
-        }
-    }
-    
+        
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         // Uncomment the code below to register your device token with the push notification manager
 //        didRegisterForRemoteNotifications(deviceToken)
@@ -116,4 +109,96 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
     func enableIDPLoginFlowForURL(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         return  UserAccountManager.shared.handleIdentityProviderResponse(from: url, with: options)
     }
+    
+    // MARK: - QR Code Login Via Salesforce Identity API UI Bridge Public Implementation
+    
+    /**
+     * When enabling log in via Salesforce UI Bridge API generated QR codes, choose to use the
+     * Salesforce Mobile SDK reference format for QR code log in URLs or an entirely custom format.
+     *
+     * If only one of the two formats is used, which is the most likely implementation for apps using this
+     * template, this variable and code related to the unused implementation could be removed.
+     */
+    let isQrCodeLoginUsingReferenceUrlFormat = true
+    
+    /**
+     * When enabling log in via Salesforce UI Bridge API generated QR codes and using the reference QR
+     * code log in URL format, the scheme for the expected QR code log in URL format.
+     */
+    let qrCodeLoginUrlScheme = "your-qr-code-login-url-scheme"
+    
+    /**
+     * When enabling log in via Salesforce UI Bridge API generated QR codes and using the reference QR
+     * code log in URL format, the host for the expected QR code log in URL format.
+     */
+    let qrCodeLoginUrlHost = "your-qr-code-login-url-host"
+    
+    
+    // MARK: - QR Code Login Via Salesforce Identity API UI Bridge Private Implementation
+    
+    /**
+     * Sets up QR code log in.
+     */
+    private func setupQrCodeLogin() {
+        
+        // Enable QR code log in.
+        MobileSyncSDKManager.shared.isQrCodeLoginEnabled = true
+        
+        // Specify a custom Salesforce Mobile SDK log in view controller which is a subclass of the default log in view and enables navigation to the log in QR code scan view.
+        UserAccountManager.shared.loginViewControllerConfig.loginViewControllerCreationBlock = {
+            return LoginTypeSelectionViewController()
+        }
+        
+        /*
+         * When enabling log in via Salesforce UI Bridge API generated QR codes
+         * and using the Salesforce Mobile SDK reference format for QR code log
+         * in URLs, specify values for the string placeholders in this method to
+         * control the parsing of QR code log in URLs. The required UI Bridge
+         * API parameters are the frontdoor URL and, for web server flow, the
+         * PKCE code verifier.
+         *
+         * Salesforce Mobile SDK doesn't require a specific format for the QR
+         * code log in URL.  The server-side code, such as an APEX class and
+         * Visualforce page, must generate a QR code URL that the app is
+         * prepared to be opened by and be able to parse the UI Bridge API
+         * parameters from.
+         *
+         * Apps may receive and parse an entirely custom URL format so long as
+         * the UI Bridge API parameters are delivered to the
+         * `loginWithFrontdoorBridgeUrl` method.
+         *
+         * As a convenience, Salesforce Mobile SDK accepts a reference QR code
+         * log in URL format.  URLs matching that format and using string values
+         * provided by the app can be provided to the
+         * `loginWithFrontdoorBridgeUrlFromQrCode` method and Salesforce Mobile
+         * SDK will retrieve the required UI Bridge API parameters
+         * automatically.
+         *
+         * The reference QR code log in URL format uses this structure where the
+         * PKCE code verifier must be URL-Safe Base64 encoded and the overall
+         * JSON content must be URL encoded:
+         * [scheme]://[host]/[path]?[json-parameter-name]={[frontdoor-bridge-url-key]=<>,[pkce-code-verifier-key]=<>}
+         *
+         * Any URL link scheme supported by the native platform may be used.
+         * This includes Android App Links and iOS Universal Links. Be certain
+         * to follow the latest security practices documented by the app's
+         * native platform.
+         *
+         * If using an entirely custom format for QR code log in URLs, the
+         * assignment of these strings can be safely removed.
+         */
+        // The scheme and host for the expected QR code log in URL format.
+        assert(qrCodeLoginUrlScheme != "your-qr-code-login-url-scheme", "Please add your login QR code URL's scheme.")
+        assert(qrCodeLoginUrlHost != "your-qr-code-login-url-host", "Please add your login QR code URL's host.")
+        // The path, parameter names and JSON keys for the expected QR code log in URL format.
+        SalesforceLoginViewController.qrCodeLoginUrlPath = "your-qr-code-login-url-path"
+        SalesforceLoginViewController.qrCodeLoginUrlJsonParameterName = "your-qr-code-login-url-json-parameter-name"
+        SalesforceLoginViewController.qrCodeLoginUrlJsonFrontdoorBridgeUrlKey = "your-qr-code-login-url-json-frontdoor-bridge-url-key"
+        SalesforceLoginViewController.qrCodeLoginUrlJsonPkceCodeVerifierKey = "your-qr-code-login-url-json-pkce-code-verifier-key"
+        assert(SalesforceLoginViewController.qrCodeLoginUrlPath != "your-qr-code-login-url-path", "Please add your login QR code URL's path.")
+        assert(SalesforceLoginViewController.qrCodeLoginUrlJsonParameterName != "your-qr-code-login-url-json-parameter-name", "Please add your login QR code URL's UI Bridge API JSON query string parameter name.")
+        assert(SalesforceLoginViewController.qrCodeLoginUrlJsonFrontdoorBridgeUrlKey != "your-qr-code-login-url-json-frontdoor-bridge-url-key", "Please add your login QR code URL's UI Bridge API JSON frontdoor bridge URL key.")
+        assert(SalesforceLoginViewController.qrCodeLoginUrlJsonPkceCodeVerifierKey != "your-qr-code-login-url-json-pkce-code-verifier-key", "Please add your login QR code URL's UI Bridge API JSON PKCE code verifier key.")
+    }
+    
 }

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/AppDelegate.swift
@@ -36,7 +36,7 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
         MobileSyncSDKManager.initializeSDK()
         
         // Uncomment when enabling log in via Salesforce UI Bridge API generated QR codes.
-        self.setupQrCodeLogin()
+        // self.setupQrCodeLogin()
     }
     
     // MARK: UISceneSession Lifecycle

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/LoginTypeSelectionViewController.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/LoginTypeSelectionViewController.swift
@@ -92,13 +92,13 @@ class LoginTypeSelectionViewController: SalesforceLoginViewController {
     
     @objc
     func loginWithQrCodeButtonTapped(_: Any?) {
-
+        
         // Present a QR code scan controller to capture the log in QR code.
         let qrCodeScanController = QrCodeScanController()
-        qrCodeScanController.onQrCodeCaptured = { qrCodePayloadString in
-         
-            // Login using the QR code payload.
-            let _ = self.loginFromQrCode(loginQrCodeContent: qrCodePayloadString)
+        qrCodeScanController.onQrCodeCaptured = { qrCodeLoginUrl in
+            
+            // Use the QR code login URL.
+            let _ = LoginTypeSelectionViewController.loginWithFrontdoorBridgeUrlFromQrCode(qrCodeLoginUrl)
         }
         present(qrCodeScanController, animated: true)
     }

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/SceneDelegate.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/SceneDelegate.swift
@@ -149,24 +149,97 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
      */
     private func useQrCodeLogInUrl(_ url: URL) {
         
-        // Use login QR code if applicable
+        /*
+         * When enabling log in via Salesforce UI Bridge API generated QR codes,
+         * customize the template content of this method to receive the URL and
+         * provide Salesforce Mobile SDK with the log in parameters. The
+         * required UI Bridge API parameters are the frontdoor URL and, for web
+         * server flow, the PKCE code verifier.
+         *
+         * Salesforce Mobile SDK doesn't require a specific format for the QR
+         * code log in URL.  The server-side code, such as an APEX class and
+         * Visualforce page, must generate a QR code URL that the app is
+         * prepared to be opened by and be able to parse the UI Bridge API
+         * parameters from.
+         *
+         * Apps may receive and parse an entirely custom URL format so long as
+         * the UI Bridge API parameters are delivered to the
+         * `loginWithFrontdoorBridgeUrl` method.
+         *
+         * As a convenience, Salesforce Mobile SDK accepts a reference QR code
+         * log in URL format.  URLs matching that format and using string values
+         * provided by the app can be provided to the
+         * `loginWithFrontdoorBridgeUrlFromQrCode` method and Salesforce Mobile
+         * SDK will retrieve the required UI Bridge API parameters
+         * automatically.
+         *
+         * The reference QR code log in URL format uses this structure where the
+         * PKCE code verifier must be URL-Safe Base64 encoded and the overall
+         * JSON content must be URL encoded:
+         * [scheme]://[host]/[path]?[json-parameter-name]={[frontdoor-bridge-url-key]=<>,[pkce-code-verifier-key]=<>}
+         *
+         * Any URL link scheme supported by the native platform may be used.
+         * This includes Android App Links and iOS Universal Links. Be certain
+         * to follow the latest security practices documented by the app's
+         * native platform.
+         */
         
-        // Validate the URL is a valid QR code login URL.
-        guard let components = NSURLComponents(
-            url: url,
-            resolvingAgainstBaseURL: true),
-              let scheme = components.scheme,
-              scheme == "mobileapp",
-              let host = components.host,
-              host == "android",
-              let path = components.path,
-              path == SalesforceLoginViewController.qrCodeLoginUrlPath,
-              let queryItems = components.queryItems,
-              let _ = queryItems.first(where: { $0.name == SalesforceLoginViewController.qrCodeLoginUrlJsonParameterName })?.value else {
-            print("Invalid QR code log in URL.")
-            return
+        // Choose to use the reference QR code log in URL format for an entirely custom format.
+        let isAppExpectedReferenceQrCodeLoginUrlFormat = true /* To-do: An app will likely use on of the two options, so this variable may be removed. */
+        if (isAppExpectedReferenceQrCodeLoginUrlFormat) {
+            
+            // When using `loginWithFrontdoorBridgeUrlFromQrCode` and the reference QR code log in URL format, validate the potential QR code log in URL matches the app's expections.
+            /* To set up QR code log in using `loginWithFrontdoorBridgeUrlFromQrCode`, provide the scheme and host for the expected QR code log in URL format */
+            let expectedScheme = "your-qr-code-login-url-scheme"
+            let expectedHost = "your-qr-code-login-url-host"
+            assert(expectedScheme != "your-qr-code-login-url-scheme", "Please add your login QR code URL's scheme.")
+            assert(expectedHost != "your-qr-code-login-url-host", "Please add your login QR code URL's host.")
+            /* To set up QR code log in using `loginWithFrontdoorBridgeUrlFromQrCode`, provide the path, parameter names and JSON keys for the expected QR code log in URL format */
+            SalesforceLoginViewController.qrCodeLoginUrlPath = "your-qr-code-login-url-path"
+            SalesforceLoginViewController.qrCodeLoginUrlJsonParameterName = "your-qr-code-login-url-json-parameter-name"
+            SalesforceLoginViewController.qrCodeLoginUrlJsonFrontdoorBridgeUrlKey = "your-qr-code-login-url-json-frontdoor-bridge-url-key"
+            SalesforceLoginViewController.qrCodeLoginUrlJsonPkceCodeVerifierKey = "your-qr-code-login-url-json-pkce-code-verifier-key"
+            assert(SalesforceLoginViewController.qrCodeLoginUrlPath != "your-qr-code-login-url-path", "Please add your login QR code URL's path.")
+            assert(SalesforceLoginViewController.qrCodeLoginUrlJsonParameterName != "your-qr-code-login-url-json-parameter-name", "Please add your login QR code URL's UI Bridge API JSON query string parameter name.")
+            assert(SalesforceLoginViewController.qrCodeLoginUrlJsonFrontdoorBridgeUrlKey != "your-qr-code-login-url-json-frontdoor-bridge-url-key", "Please add your login QR code URL's UI Bridge API JSON frontdoor bridge URL key.")
+            assert(SalesforceLoginViewController.qrCodeLoginUrlJsonPkceCodeVerifierKey != "your-qr-code-login-url-json-pkce-code-verifier-key", "Please add your login QR code URL's UI Bridge API JSON PKCE code verifier key.")
+            
+            // Log in using `loginWithFrontdoorBridgeUrlFromQrCode` if applicable
+            guard let components = NSURLComponents(
+                url: url,
+                resolvingAgainstBaseURL: true),
+                  let scheme = components.scheme,
+                  scheme == expectedScheme,
+                  let host = components.host,
+                  host == expectedHost,
+                  let path = components.path,
+                  path == SalesforceLoginViewController.qrCodeLoginUrlPath,
+                  let queryItems = components.queryItems,
+                  let _ = queryItems.first(where: { $0.name == SalesforceLoginViewController.qrCodeLoginUrlJsonParameterName })?.value else {
+                SFSDKCoreLogger().e(classForCoder, message: "Invalid QR code log in URL.")
+                return
+            }
+            let _ = LoginTypeSelectionViewController.loginWithFrontdoorBridgeUrlFromQrCode(url.absoluteString)
+        } else {
+            
+            /*
+             * When using `loginWithFrontdoorBridgeUrl` and an entirely custom
+             * QR code login URL format, set
+             * `isAppExpectedReferenceQrCodeLoginUrlFormat` to `false` (or
+             * remove it entirely) and implement URL handling in this block
+             * before calling `loginWithFrontdoorBridgeUrl`.
+             */
+            
+            /* To-do: Implement URL handling to retrieve UI Bridge API parameters */
+            /* To set up QR code log in using `loginWithFrontdoorBridgeUrlFromQrCode`, provide the scheme and host for the expected QR code log in URL format */
+            let frontdoorBridgeUrl = "your-qr-code-login-frontdoor-bridge-url"
+            let pkceCodeVerifier = "your-qr-code-login-pkce-code-verifier"
+            assert(frontdoorBridgeUrl != "your-qr-code-login-frontdoor-bridge-url", "Please implement your app's frontdoor bridge URL retrieval.")
+            assert(pkceCodeVerifier != "your-qr-code-login-pkce-code-verifier", "Please add your app's PKCE code verifier retrieval if web server flow is used.")
+            let _ = LoginTypeSelectionViewController.loginWithFrontdoorBridgeUrl(
+                frontdoorBridgeUrl,
+                pkceCodeVerifier: pkceCodeVerifier
+            )
         }
-        
-        let _ = LoginTypeSelectionViewController.loginWithFrontdoorBridgeUrlFromQrCode(url.absoluteString)
     }
 }

--- a/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/SceneDelegate.swift
+++ b/iOSNativeSwiftTemplate/iOSNativeSwiftTemplate/SceneDelegate.swift
@@ -148,70 +148,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
      *   - url: The URL to validate and use as a QR code log in URL
      */
     private func useQrCodeLogInUrl(_ url: URL) {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         
-        /*
-         * When enabling log in via Salesforce UI Bridge API generated QR codes,
-         * customize the template content of this method to receive the URL and
-         * provide Salesforce Mobile SDK with the log in parameters. The
-         * required UI Bridge API parameters are the frontdoor URL and, for web
-         * server flow, the PKCE code verifier.
-         *
-         * Salesforce Mobile SDK doesn't require a specific format for the QR
-         * code log in URL.  The server-side code, such as an APEX class and
-         * Visualforce page, must generate a QR code URL that the app is
-         * prepared to be opened by and be able to parse the UI Bridge API
-         * parameters from.
-         *
-         * Apps may receive and parse an entirely custom URL format so long as
-         * the UI Bridge API parameters are delivered to the
-         * `loginWithFrontdoorBridgeUrl` method.
-         *
-         * As a convenience, Salesforce Mobile SDK accepts a reference QR code
-         * log in URL format.  URLs matching that format and using string values
-         * provided by the app can be provided to the
-         * `loginWithFrontdoorBridgeUrlFromQrCode` method and Salesforce Mobile
-         * SDK will retrieve the required UI Bridge API parameters
-         * automatically.
-         *
-         * The reference QR code log in URL format uses this structure where the
-         * PKCE code verifier must be URL-Safe Base64 encoded and the overall
-         * JSON content must be URL encoded:
-         * [scheme]://[host]/[path]?[json-parameter-name]={[frontdoor-bridge-url-key]=<>,[pkce-code-verifier-key]=<>}
-         *
-         * Any URL link scheme supported by the native platform may be used.
-         * This includes Android App Links and iOS Universal Links. Be certain
-         * to follow the latest security practices documented by the app's
-         * native platform.
-         */
-        
-        // Choose to use the reference QR code log in URL format for an entirely custom format.
-        let isAppExpectedReferenceQrCodeLoginUrlFormat = true /* To-do: An app will likely use on of the two options, so this variable may be removed. */
-        if (isAppExpectedReferenceQrCodeLoginUrlFormat) {
-            
-            // When using `loginWithFrontdoorBridgeUrlFromQrCode` and the reference QR code log in URL format, validate the potential QR code log in URL matches the app's expections.
-            /* To set up QR code log in using `loginWithFrontdoorBridgeUrlFromQrCode`, provide the scheme and host for the expected QR code log in URL format */
-            let expectedScheme = "your-qr-code-login-url-scheme"
-            let expectedHost = "your-qr-code-login-url-host"
-            assert(expectedScheme != "your-qr-code-login-url-scheme", "Please add your login QR code URL's scheme.")
-            assert(expectedHost != "your-qr-code-login-url-host", "Please add your login QR code URL's host.")
-            /* To set up QR code log in using `loginWithFrontdoorBridgeUrlFromQrCode`, provide the path, parameter names and JSON keys for the expected QR code log in URL format */
-            SalesforceLoginViewController.qrCodeLoginUrlPath = "your-qr-code-login-url-path"
-            SalesforceLoginViewController.qrCodeLoginUrlJsonParameterName = "your-qr-code-login-url-json-parameter-name"
-            SalesforceLoginViewController.qrCodeLoginUrlJsonFrontdoorBridgeUrlKey = "your-qr-code-login-url-json-frontdoor-bridge-url-key"
-            SalesforceLoginViewController.qrCodeLoginUrlJsonPkceCodeVerifierKey = "your-qr-code-login-url-json-pkce-code-verifier-key"
-            assert(SalesforceLoginViewController.qrCodeLoginUrlPath != "your-qr-code-login-url-path", "Please add your login QR code URL's path.")
-            assert(SalesforceLoginViewController.qrCodeLoginUrlJsonParameterName != "your-qr-code-login-url-json-parameter-name", "Please add your login QR code URL's UI Bridge API JSON query string parameter name.")
-            assert(SalesforceLoginViewController.qrCodeLoginUrlJsonFrontdoorBridgeUrlKey != "your-qr-code-login-url-json-frontdoor-bridge-url-key", "Please add your login QR code URL's UI Bridge API JSON frontdoor bridge URL key.")
-            assert(SalesforceLoginViewController.qrCodeLoginUrlJsonPkceCodeVerifierKey != "your-qr-code-login-url-json-pkce-code-verifier-key", "Please add your login QR code URL's UI Bridge API JSON PKCE code verifier key.")
+        // Use the specified QR code log in URL format.
+        if (appDelegate.isQrCodeLoginUsingReferenceUrlFormat) {
             
             // Log in using `loginWithFrontdoorBridgeUrlFromQrCode` if applicable
             guard let components = NSURLComponents(
                 url: url,
                 resolvingAgainstBaseURL: true),
                   let scheme = components.scheme,
-                  scheme == expectedScheme,
+                  scheme == appDelegate.qrCodeLoginUrlScheme,
                   let host = components.host,
-                  host == expectedHost,
+                  host == appDelegate.qrCodeLoginUrlHost,
                   let path = components.path,
                   path == SalesforceLoginViewController.qrCodeLoginUrlPath,
                   let queryItems = components.queryItems,


### PR DESCRIPTION
🤘🏻 _*Ready For Review!*_ 🎸

  This is a parallel to https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/426.  The key change for the template is updating the naming conventions, documentation and a few customization options to match the public API for QR Code Log In we just finished for Android.

  Thanks, as always, for reading along ⭐️