### PR TITLE
Fixing issues in MobileSyncExplorerSwift

### DIFF
--- a/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SObjects/Contacts.swift
+++ b/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SObjects/Contacts.swift
@@ -42,12 +42,33 @@ enum ContactConstants {
 class ContactSObjectData: SObjectData, Identifiable, Equatable {
     static func == (lhs: ContactSObjectData, rhs: ContactSObjectData) -> Bool {
         return lhs.firstName == rhs.firstName &&
-               lhs.lastName == rhs.lastName &&
-               lhs.title == rhs.title &&
-               lhs.mobilePhone == rhs.mobilePhone &&
-               lhs.email == rhs.email &&
-               lhs.department == rhs.department &&
-               lhs.homePhone == rhs.homePhone
+            lhs.lastName == rhs.lastName &&
+            lhs.title == rhs.title &&
+            lhs.mobilePhone == rhs.mobilePhone &&
+            lhs.email == rhs.email &&
+            lhs.department == rhs.department &&
+            lhs.homePhone == rhs.homePhone &&
+            lhs.locallyCreatd == rhs.locallyCreatd &&
+            lhs.locallyDeleted == rhs.locallyDeleted &&
+            lhs.locallyUpdated == rhs.locallyUpdated
+    }
+    
+    var locallyCreatd: Bool {
+        get {
+            return SObjectDataManager.dataLocallyCreated(self)
+        }
+    }
+
+    var locallyDeleted: Bool {
+        get {
+            return SObjectDataManager.dataLocallyDeleted(self)
+        }
+    }
+    
+    var locallyUpdated: Bool {
+        get {
+            return SObjectDataManager.dataLocallyUpdated(self)
+        }
     }
     
     var firstName: String? {

--- a/MobileSyncExplorerSwift/MobileSyncExplorerSwift/UI/ContactList/ContactList.swift
+++ b/MobileSyncExplorerSwift/MobileSyncExplorerSwift/UI/ContactList/ContactList.swift
@@ -146,14 +146,14 @@ struct ContactCell: View {
                     .foregroundColor(.secondaryLabelText)
             }
             Spacer()
-            if SObjectDataManager.dataLocallyUpdated(contact) {
+            if contact.locallyUpdated {
                 Image(systemName: "arrow.2.circlepath").foregroundColor(.appBlue)
             }
-            if SObjectDataManager.dataLocallyCreated(contact) {
+            if contact.locallyCreatd {
                 Image(systemName: "plus")
                     .foregroundColor(.green)
             }
-            if SObjectDataManager.dataLocallyDeleted(contact) {
+            if contact.locallyDeleted {
                 Image(systemName: "trash").foregroundColor(.red)
             }
         }


### PR DESCRIPTION
Contacts in list were not showing correct local status:
- edit -> list -> sync would still show contact as locally edited
- delete -> list would not show contact as locally deleted

The problem was that the == method on ContactSObject did not compare locally created/updated or deleted fields