### PR TITLE
Fix React Native Android First Time Login Crash.

### DIFF
--- a/ReactNativeDeferredTemplate/android/app/src/main/java/com/salesforce/reactnativedeferredtemplate/MainActivity.java
+++ b/ReactNativeDeferredTemplate/android/app/src/main/java/com/salesforce/reactnativedeferredtemplate/MainActivity.java
@@ -26,9 +26,16 @@
  */
 package com.salesforce.reactnativedeferredtemplate;
 
+import android.os.Bundle;
 import com.salesforce.androidsdk.reactnative.ui.SalesforceReactActivity;
 
 public class MainActivity extends SalesforceReactActivity {
+
+	//react-native-screens override
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(null);
+	}
 
     /**
      *

--- a/ReactNativeTemplate/android/app/src/main/java/com/salesforce/reactnativetemplate/MainActivity.java
+++ b/ReactNativeTemplate/android/app/src/main/java/com/salesforce/reactnativetemplate/MainActivity.java
@@ -26,9 +26,16 @@
  */
 package com.salesforce.reactnativetemplate;
 
+import android.os.Bundle;
 import com.salesforce.androidsdk.reactnative.ui.SalesforceReactActivity;
 
 public class MainActivity extends SalesforceReactActivity {
+
+	//react-native-screens override
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(null);
+	}
 
     /**
      *

--- a/ReactNativeTypeScriptTemplate/android/app/src/main/java/com/salesforce/reactnativetypescripttemplate/MainActivity.java
+++ b/ReactNativeTypeScriptTemplate/android/app/src/main/java/com/salesforce/reactnativetypescripttemplate/MainActivity.java
@@ -26,9 +26,16 @@
  */
 package com.salesforce.reactnativetypescripttemplate;
 
+import android.os.Bundle;
 import com.salesforce.androidsdk.reactnative.ui.SalesforceReactActivity;
 
 public class MainActivity extends SalesforceReactActivity {
+
+	//react-native-screens override
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(null);
+	}
 
     /**
      *


### PR DESCRIPTION
This was already done for the Android MobileSync React Native template with #432, but I discovered today it is needed for all templates.  

No need to patch or anything since this only affects debug builds.