### PR TITLE
@W-18598929 Migrate Salesforce SDK imports to use @import directive

### DIFF
--- a/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/AppDelegate.m
+++ b/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/AppDelegate.m
@@ -26,16 +26,10 @@
 #import "InitialViewController.h"
 #import <React/RCTRootView.h>
 #import <React/RCTBundleURLProvider.h>
-#import <SalesforceSDKCore/SFSDKAppConfig.h>
-#import <SalesforceSDKCore/SFPushNotificationManager.h>
-#import <SalesforceSDKCore/SFDefaultUserManagementViewController.h>
-#import <SalesforceSDKCore/SalesforceSDKManager.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <SalesforceReact/SalesforceReactSDKManager.h>
-#import <SalesforceSDKCore/SFLoginViewController.h>
-#import <SalesforceReact/SFSDKReactLogger.h>
-#import <SalesforceSDKCore/SFSDKAuthHelper.h>
 #import <UserNotifications/UserNotifications.h>
+
+@import SalesforceReact;
+@import SalesforceSDKCore;
 
 @implementation AppDelegate
 

--- a/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/AppDelegate.m
+++ b/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/AppDelegate.m
@@ -26,16 +26,10 @@
 #import "InitialViewController.h"
 #import <React/RCTRootView.h>
 #import <React/RCTBundleURLProvider.h>
-#import <SalesforceSDKCore/SFSDKAppConfig.h>
-#import <SalesforceSDKCore/SFPushNotificationManager.h>
-#import <SalesforceSDKCore/SFDefaultUserManagementViewController.h>
-#import <SalesforceSDKCore/SalesforceSDKManager.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <SalesforceReact/SalesforceReactSDKManager.h>
-#import <SalesforceSDKCore/SFLoginViewController.h>
-#import <SalesforceReact/SFSDKReactLogger.h>
-#import <SalesforceSDKCore/SFSDKAuthHelper.h>
 #import <UserNotifications/UserNotifications.h>
+
+@import SalesforceReact;
+@import SalesforceSDKCore;
 
 @implementation AppDelegate
 

--- a/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.m
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.m
@@ -26,16 +26,10 @@
 #import "InitialViewController.h"
 #import <React/RCTRootView.h>
 #import <React/RCTBundleURLProvider.h>
-#import <SalesforceSDKCore/SFSDKAppConfig.h>
-#import <SalesforceSDKCore/SFPushNotificationManager.h>
-#import <SalesforceSDKCore/SFDefaultUserManagementViewController.h>
-#import <SalesforceSDKCore/SalesforceSDKManager.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <SalesforceReact/SalesforceReactSDKManager.h>
-#import <SalesforceSDKCore/SFLoginViewController.h>
-#import <SalesforceReact/SFSDKReactLogger.h>
-#import <SalesforceSDKCore/SFSDKAuthHelper.h>
 #import <UserNotifications/UserNotifications.h>
+
+@import SalesforceReact;
+@import SalesforceSDKCore;
 
 @implementation AppDelegate
 

--- a/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/AppDelegate.m
+++ b/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/AppDelegate.m
@@ -26,16 +26,10 @@
 #import "InitialViewController.h"
 #import <React/RCTRootView.h>
 #import <React/RCTBundleURLProvider.h>
-#import <SalesforceSDKCore/SFSDKAppConfig.h>
-#import <SalesforceSDKCore/SFPushNotificationManager.h>
-#import <SalesforceSDKCore/SFDefaultUserManagementViewController.h>
-#import <SalesforceSDKCore/SalesforceSDKManager.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <SalesforceReact/SalesforceReactSDKManager.h>
-#import <SalesforceSDKCore/SFLoginViewController.h>
-#import <SalesforceReact/SFSDKReactLogger.h>
-#import <SalesforceSDKCore/SFSDKAuthHelper.h>
 #import <UserNotifications/UserNotifications.h>
+
+@import SalesforceReact;
+@import SalesforceSDKCore;
 
 @implementation AppDelegate
 

--- a/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
+++ b/iOSNativeTemplate/iOSNativeTemplate/AppDelegate.m
@@ -26,16 +26,9 @@
 #import "AppDelegate.h"
 #import "InitialViewController.h"
 #import "RootViewController.h"
-#import <SalesforceSDKCore/SFSDKAppConfig.h>
-#import <SalesforceSDKCore/SFPushNotificationManager.h>
-#import <SalesforceSDKCore/SFDefaultUserManagementViewController.h>
-#import <SalesforceSDKCore/SalesforceSDKManager.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <MobileSync/MobileSyncSDKManager.h>
-#import <MobileSync/SFSDKMobileSyncLogger.h>
-#import <SalesforceSDKCore/SFLoginViewController.h>
-#import <SalesforceSDKCore/SFSDKLoginViewControllerConfig.h>
-#import <SalesforceSDKCore/SFSDKAuthHelper.h>
+
+@import SalesforceSDKCore;
+@import MobileSync;
 
 @interface AppDelegate ()
 

--- a/iOSNativeTemplate/iOSNativeTemplate/RootViewController.h
+++ b/iOSNativeTemplate/iOSNativeTemplate/RootViewController.h
@@ -23,7 +23,8 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <SalesforceSDKCore/SFRestAPI.h>
+
+@import SalesforceSDKCore;
 
 @interface RootViewController : UITableViewController <SFRestRequestDelegate> {
     

--- a/iOSNativeTemplate/iOSNativeTemplate/RootViewController.m
+++ b/iOSNativeTemplate/iOSNativeTemplate/RootViewController.m
@@ -24,10 +24,6 @@
 
 #import "RootViewController.h"
 
-#import <SalesforceSDKCommon/SFLogger.h>
-#import <SalesforceSDKCore/SFRestAPI.h>
-#import <SalesforceSDKCore/SFRestRequest.h>
-
 @implementation RootViewController
 
 @synthesize dataRows;


### PR DESCRIPTION
This update modernizes Salesforce SDK header inclusion in all iOS template projects by replacing multiple #import statements with a single @import SalesforceSDKCore.

# Changes

 = Replace #import <SalesforceSDKCore/…> headers with @import SalesforceSDKCore; in the following templates:
	•	MobileSyncExplorerReactNative
	•	ReactNativeDeferredTemplate
	•	ReactNativeTemplate
	•	ReactNativeTypeScriptTemplate
	•	iOSNativeTemplate
	•	Replaced #import <SalesforceSDKCore/SFRestAPI.h> in RootViewController.h with @import SalesforceSDKCore.

Benefits
	•	Reduces boilerplate and potential import conflicts
	•	Aligns with modern Objective-C best practices for module imports
	•	Improves maintainability and consistency across all templates

Notes

Ensure that CLANG_ENABLE_MODULES = YES is set in Xcode build settings if not already.

