### PR TITLE
@W-18648586: Gradle upgrade

### DIFF
--- a/AndroidIDPTemplate/app/build.gradle.kts
+++ b/AndroidIDPTemplate/app/build.gradle.kts
@@ -10,10 +10,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.salesforceandroididptemplateapp"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
     }
 

--- a/AndroidIDPTemplate/app/build.gradle.kts
+++ b/AndroidIDPTemplate/app/build.gradle.kts
@@ -10,10 +10,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.salesforceandroididptemplateapp"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
     }
 

--- a/AndroidIDPTemplate/build.gradle.kts
+++ b/AndroidIDPTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 

--- a/AndroidIDPTemplate/build.gradle.kts
+++ b/AndroidIDPTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/AndroidIDPTemplate/build.gradle.kts
+++ b/AndroidIDPTemplate/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.8.2")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }

--- a/AndroidIDPTemplate/buildSrc/build.gradle.kts
+++ b/AndroidIDPTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidIDPTemplate/buildSrc/build.gradle.kts
+++ b/AndroidIDPTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidIDPTemplate/buildSrc/build.gradle.kts
+++ b/AndroidIDPTemplate/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:8.8.2")
+    implementation("com.android.tools.build:gradle:8.10.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidIDPTemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidIDPTemplate/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/AndroidNativeKotlinTemplate/app/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/app/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
 android {
     namespace = "com.salesforce.androidnativekotlintemplate"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
     }
 

--- a/AndroidNativeKotlinTemplate/app/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/app/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
 android {
     namespace = "com.salesforce.androidnativekotlintemplate"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
     }
 

--- a/AndroidNativeKotlinTemplate/app/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation("com.salesforce.mobilesdk:MobileSync:13.1.0")
-    implementation("androidx.compose.runtime:runtime-android:1.7.7")
+    implementation("androidx.compose.runtime:runtime-android:1.8.2")
     // Comment when disabling log in via Salesforce UI Bridge API generated QR codes
     implementation("com.google.zxing:core:3.5.3")
     // Comment when disabling log in via Salesforce UI Bridge API generated QR codes

--- a/AndroidNativeKotlinTemplate/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 

--- a/AndroidNativeKotlinTemplate/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/AndroidNativeKotlinTemplate/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.8.2")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }

--- a/AndroidNativeKotlinTemplate/buildSrc/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidNativeKotlinTemplate/buildSrc/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidNativeKotlinTemplate/buildSrc/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:8.8.2")
+    implementation("com.android.tools.build:gradle:8.10.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidNativeKotlinTemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidNativeKotlinTemplate/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/AndroidNativeLoginTemplate/app/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/app/build.gradle.kts
@@ -1,45 +1,35 @@
 plugins {
     android
     `kotlin-android`
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21"
 }
 
 dependencies {
-    val composeVersion = "1.8.2"
-
     implementation("com.salesforce.mobilesdk:MobileSync:13.1.0")
     implementation("com.google.android.material:material:1.12.0")
 
-    implementation("androidx.activity:activity-ktx:1.10.1")
-
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
-    implementation("com.google.android.recaptcha:recaptcha:18.7.1")
-
-    // Note: Compose dependencies are synchronized with the content in the Compose set up guide for easier migration to new versions.
-    val composeBom = platform("androidx.compose:compose-bom:2025.05.00")
+    val composeBom = platform("androidx.compose:compose-bom:2024.02.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
-    implementation("androidx.compose.material3:material3:1.3.2")
+    implementation("androidx.activity:activity-ktx:1.10.1")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.foundation:foundation")
 
-    implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
+    // Android Studio Preview support
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation("androidx.compose.ui:ui-tooling")
 
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
-
-    implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1")
-    implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("com.google.android.recaptcha:recaptcha:18.6.1") // Update requires Kotlin 2.
 }
 
 android {
     namespace = "com.salesforce.androidnativelogintemplate"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
     }
 
@@ -60,6 +50,11 @@ android {
         aidl = true
         buildConfig = true
         compose = true
+    }
+
+    @Suppress("UnstableApiUsage")
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.9"
     }
 }
 

--- a/AndroidNativeLoginTemplate/app/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/app/build.gradle.kts
@@ -36,10 +36,10 @@ dependencies {
 android {
     namespace = "com.salesforce.androidnativelogintemplate"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
     }
 

--- a/AndroidNativeLoginTemplate/app/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/app/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
-    implementation("androidx.activity:activity-ktx:1.10.0")
+    implementation("androidx.activity:activity-ktx:1.10.1")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.foundation:foundation")
 
@@ -20,7 +20,7 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
-    implementation("com.google.android.recaptcha:recaptcha:18.6.1")
+    implementation("com.google.android.recaptcha:recaptcha:18.6.1") // Update requires Kotlin 2.
 }
 
 android {
@@ -52,6 +52,7 @@ android {
         compose = true
     }
 
+    @Suppress("UnstableApiUsage")
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.9"
     }

--- a/AndroidNativeLoginTemplate/app/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/app/build.gradle.kts
@@ -1,26 +1,36 @@
 plugins {
     android
     `kotlin-android`
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21"
 }
 
 dependencies {
+    val composeVersion = "1.8.2"
+
     implementation("com.salesforce.mobilesdk:MobileSync:13.1.0")
     implementation("com.google.android.material:material:1.12.0")
 
-    val composeBom = platform("androidx.compose:compose-bom:2024.02.00")
+    implementation("androidx.activity:activity-ktx:1.10.1")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("com.google.android.recaptcha:recaptcha:18.7.1")
+
+    // Note: Compose dependencies are synchronized with the content in the Compose set up guide for easier migration to new versions.
+    val composeBom = platform("androidx.compose:compose-bom:2025.05.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
-    implementation("androidx.activity:activity-ktx:1.10.1")
-    implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material3:material3:1.3.2")
 
-    // Android Studio Preview support
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    debugImplementation("androidx.compose.ui:ui-tooling")
+    implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
+    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
-    implementation("com.google.android.recaptcha:recaptcha:18.6.1") // Update requires Kotlin 2.
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
+
+    implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1")
+    implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
 }
 
 android {
@@ -50,11 +60,6 @@ android {
         aidl = true
         buildConfig = true
         compose = true
-    }
-
-    @Suppress("UnstableApiUsage")
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.9"
     }
 }
 

--- a/AndroidNativeLoginTemplate/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 

--- a/AndroidNativeLoginTemplate/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.8.2")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
     }
 }

--- a/AndroidNativeLoginTemplate/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
     }
 }
 

--- a/AndroidNativeLoginTemplate/buildSrc/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidNativeLoginTemplate/buildSrc/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidNativeLoginTemplate/buildSrc/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:8.8.2")
+    implementation("com.android.tools.build:gradle:8.10.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidNativeLoginTemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidNativeLoginTemplate/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/AndroidNativeTemplate/app/build.gradle.kts
+++ b/AndroidNativeTemplate/app/build.gradle.kts
@@ -10,10 +10,10 @@ dependencies {
 android {
     namespace = "com.salesforce.androidnativetemplate"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
     }
 

--- a/AndroidNativeTemplate/app/build.gradle.kts
+++ b/AndroidNativeTemplate/app/build.gradle.kts
@@ -10,10 +10,10 @@ dependencies {
 android {
     namespace = "com.salesforce.androidnativetemplate"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
     }
 

--- a/AndroidNativeTemplate/build.gradle.kts
+++ b/AndroidNativeTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 

--- a/AndroidNativeTemplate/build.gradle.kts
+++ b/AndroidNativeTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/AndroidNativeTemplate/build.gradle.kts
+++ b/AndroidNativeTemplate/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.8.2")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }

--- a/AndroidNativeTemplate/buildSrc/build.gradle.kts
+++ b/AndroidNativeTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidNativeTemplate/buildSrc/build.gradle.kts
+++ b/AndroidNativeTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidNativeTemplate/buildSrc/build.gradle.kts
+++ b/AndroidNativeTemplate/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:8.8.2")
+    implementation("com.android.tools.build:gradle:8.10.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/AndroidNativeTemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidNativeTemplate/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
@@ -1,12 +1,16 @@
 plugins {
     android
     `kotlin-android`
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21"
 }
 
 dependencies {
-    val composeVersion = "1.8.2"
-
+    implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.compose.material:material:1.8.2")
+    implementation("androidx.compose.material:material-android:1.8.2")
+    implementation("androidx.compose.material:material-icons-core-android:1.7.8")
+    implementation("androidx.compose.runtime:runtime-android:1.8.2")
+    implementation("androidx.compose.ui:ui:1.8.2")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.8.2")
     implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.9.1")
     implementation("androidx.window:window:1.4.0")
@@ -16,36 +20,20 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.8.2")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.8.2")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:1.8.2")
     implementation("androidx.core:core-ktx:1.16.0")
-
-    // Note: Compose dependencies are synchronized with the content in the Compose set up guide for easier migration to new versions.
-    val composeBom = platform("androidx.compose:compose-bom:2025.05.00")
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
-
-    implementation("androidx.compose.material:material:$composeVersion")
-
-    implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
-
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
-
-    implementation("androidx.compose.material:material-icons-core")
-
-    implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1")
-    implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
 }
 
 android {
     namespace = "com.salesforce.mobilesyncexplorerkotlintemplate"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.salesforce.mobilesyncexplorerkotlintemplate"
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
         versionCode = 1
         versionName = "1.0"
@@ -79,6 +67,11 @@ android {
         buildConfig = true
     }
 
+    @Suppress("UnstableApiUsage")
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.5"
+    }
+
     packaging {
         resources {
             excludes += setOf("/META-INF/{AL2.0,LGPL2.1}", "META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
@@ -88,8 +81,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src/main/java")
-            resources.srcDir("src/main/java")
+            java.srcDirs(arrayOf("src/main/java"))
+            resources.srcDirs(arrayOf("src/main/java"))
             aidl.srcDirs(arrayOf("src/main"))
             renderscript.srcDirs(arrayOf("src/main"))
             res.srcDirs(arrayOf("src/main/res"))

--- a/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
@@ -4,26 +4,26 @@ plugins {
 }
 
 dependencies {
-    implementation("androidx.activity:activity-compose:1.10.0")
-    implementation("androidx.compose.material:material:1.7.7")
-    implementation("androidx.compose.material:material-android:1.7.7")
-    implementation("androidx.compose.material:material-icons-core-android:1.7.7")
-    implementation("androidx.compose.runtime:runtime-android:1.7.7")
-    implementation("androidx.compose.ui:ui:1.7.7")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.7.7")
-    implementation("androidx.core:core-ktx:1.15.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
-    implementation("androidx.window:window:1.3.0")
+    implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.compose.material:material:1.8.2")
+    implementation("androidx.compose.material:material-android:1.8.2")
+    implementation("androidx.compose.material:material-icons-core-android:1.7.8")
+    implementation("androidx.compose.runtime:runtime-android:1.8.2")
+    implementation("androidx.compose.ui:ui:1.8.2")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.8.2")
+    implementation("androidx.core:core-ktx:1.16.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.9.1")
+    implementation("androidx.window:window:1.4.0")
 
     implementation("com.salesforce.mobilesdk:MobileSync:13.1.0")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.7.7")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.7.7")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.7.7")
-    implementation("androidx.core:core-ktx:1.15.0")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.8.2")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.8.2")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:1.8.2")
+    implementation("androidx.core:core-ktx:1.16.0")
 }
 
 android {
@@ -67,6 +67,7 @@ android {
         buildConfig = true
     }
 
+    @Suppress("UnstableApiUsage")
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.5"
     }

--- a/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
@@ -1,16 +1,12 @@
 plugins {
     android
     `kotlin-android`
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21"
 }
 
 dependencies {
-    implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.compose.material:material:1.8.2")
-    implementation("androidx.compose.material:material-android:1.8.2")
-    implementation("androidx.compose.material:material-icons-core-android:1.7.8")
-    implementation("androidx.compose.runtime:runtime-android:1.8.2")
-    implementation("androidx.compose.ui:ui:1.8.2")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.8.2")
+    val composeVersion = "1.8.2"
+
     implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.9.1")
     implementation("androidx.window:window:1.4.0")
@@ -20,10 +16,26 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.8.2")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.8.2")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.8.2")
     implementation("androidx.core:core-ktx:1.16.0")
+
+    // Note: Compose dependencies are synchronized with the content in the Compose set up guide for easier migration to new versions.
+    val composeBom = platform("androidx.compose:compose-bom:2025.05.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.compose.material:material:$composeVersion")
+
+    implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
+    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
+
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
+
+    implementation("androidx.compose.material:material-icons-core")
+
+    implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1")
+    implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
 }
 
 android {
@@ -67,11 +79,6 @@ android {
         buildConfig = true
     }
 
-    @Suppress("UnstableApiUsage")
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.5"
-    }
-
     packaging {
         resources {
             excludes += setOf("/META-INF/{AL2.0,LGPL2.1}", "META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
@@ -81,8 +88,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src/main/java"))
-            resources.srcDirs(arrayOf("src/main/java"))
+            java.srcDir("src/main/java")
+            resources.srcDir("src/main/java")
             aidl.srcDirs(arrayOf("src/main"))
             renderscript.srcDirs(arrayOf("src/main"))
             res.srcDirs(arrayOf("src/main/res"))

--- a/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
@@ -41,11 +41,11 @@ dependencies {
 android {
     namespace = "com.salesforce.mobilesyncexplorerkotlintemplate"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.salesforce.mobilesyncexplorerkotlintemplate"
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
         versionCode = 1
         versionName = "1.0"

--- a/MobileSyncExplorerKotlinTemplate/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     }
 }
 

--- a/MobileSyncExplorerKotlinTemplate/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.8.2")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     }
 }

--- a/MobileSyncExplorerKotlinTemplate/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 

--- a/MobileSyncExplorerKotlinTemplate/buildSrc/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/MobileSyncExplorerKotlinTemplate/buildSrc/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/MobileSyncExplorerKotlinTemplate/buildSrc/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:8.8.2")
+    implementation("com.android.tools.build:gradle:8.10.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/MobileSyncExplorerKotlinTemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/MobileSyncExplorerKotlinTemplate/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -12,9 +12,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 28
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 28
-        compileSdkVersion = 36
-        targetSdkVersion = 36
+        compileSdkVersion = 35
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/MobileSyncExplorerReactNative/android/gradle/wrapper/gradle-wrapper.properties
+++ b/MobileSyncExplorerReactNative/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -12,9 +12,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 28
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 28
-        compileSdkVersion = 36
-        targetSdkVersion = 36
+        compileSdkVersion = 35
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/ReactNativeDeferredTemplate/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ReactNativeDeferredTemplate/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -12,9 +12,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 28
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 28
-        compileSdkVersion = 36
-        targetSdkVersion = 36
+        compileSdkVersion = 35
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/ReactNativeTemplate/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ReactNativeTemplate/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -12,9 +12,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 28
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 28
-        compileSdkVersion = 36
-        targetSdkVersion = 36
+        compileSdkVersion = 35
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
 }
 

--- a/ReactNativeTypeScriptTemplate/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ReactNativeTypeScriptTemplate/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
🎸 _*Ready For Review!*_ 🥁

This updates all the MSDK Android Templates to the latest Gradle and Android Gradle Plugin plus a few other dependency updates.  However, it doesn't take the next two steps of updating to Kotlin 2 and the Kotlin Compose Compiler Gradle Plugin or Android API 36.

Note: There are two really valuable "future" commits on this branch history that actually have working code for the two deferred steps.  We can cherry pick those in when the time comes for some serious effort reduction since that's completed.