### PR TITLE
Fix GitHub Actions output format with compact JSON

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -111,8 +111,8 @@ jobs:
           if [ "$TEST_ALL" = true ]; then
             echo "test-all=true" >> $GITHUB_OUTPUT
             echo "has-changes=true" >> $GITHUB_OUTPUT
-            # Convert all templates to JSON array
-            TEMPLATES_JSON=$(echo "$TEMPLATES" | jq -R . | jq -s .)
+            # Convert all templates to JSON array (compact format for GitHub Actions)
+            TEMPLATES_JSON=$(echo "$TEMPLATES" | jq -R . | jq -sc .)
             echo "templates=$TEMPLATES_JSON" >> $GITHUB_OUTPUT
             echo "Testing all templates due to core file changes"
           else
@@ -133,9 +133,9 @@ jobs:
 
             echo "test-all=false" >> $GITHUB_OUTPUT
 
-            # Convert to JSON array
+            # Convert to JSON array (compact format for GitHub Actions)
             if [ ${#CHANGED_TEMPLATES[@]} -gt 0 ]; then
-              TEMPLATES_JSON=$(printf '%s\n' "${CHANGED_TEMPLATES[@]}" | jq -R . | jq -s .)
+              TEMPLATES_JSON=$(printf '%s\n' "${CHANGED_TEMPLATES[@]}" | jq -R . | jq -sc .)
               echo "templates=$TEMPLATES_JSON" >> $GITHUB_OUTPUT
               echo "has-changes=true" >> $GITHUB_OUTPUT
               echo "Templates to test: ${CHANGED_TEMPLATES[@]}"


### PR DESCRIPTION
## Summary

Fixes GitHub Actions workflow to output compact JSON arrays instead of pretty-printed JSON with newlines. GitHub Actions requires output values to be single-line strings.

## Changes

- Changed `jq -s .` to `jq -sc .` at two locations in `.github/workflows/pr.yaml`
  - Line 115: When testing all templates
  - Line 138: When testing changed templates only

The `-c` flag produces compact JSON output without newlines, which is compatible with GitHub Actions output format.

## Context

This completes the fix started in PR #481. With both changes applied:
1. Escaped quotes are removed with sed (PR #481)
2. JSON is output in compact format (this PR)

The workflow should now correctly detect and build changed templates.