### PR TITLE
Fix release configuration Android build issue with react-native-vector-icons.

### DIFF
--- a/MobileSyncExplorerReactNative/android/app/build.gradle
+++ b/MobileSyncExplorerReactNative/android/app/build.gradle
@@ -110,3 +110,8 @@ dependencies {
 }
 
 apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
+
+afterEvaluate {
+    tasks.findByName("generateReleaseLintVitalReportModel")
+        ?.mustRunAfter("copyReactNativeVectorIconFonts")
+}


### PR DESCRIPTION
This is a known bug tracked in [oblador/react-native-vector-icons#1584](https://github.com/oblador/react-native-vector-icons/issues/1584). The upstream fix belongs in fonts.gradle itself (generateReportTask.dependsOn(fontCopyTask)), but until that's released, the template needs to declare the ordering explicitly. If/when the react-native-vector-icons package ships the fix, this block can be removed.