### PR TITLE
Remove invalid strategy blocks from reusable workflow calls

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -149,8 +149,6 @@ jobs:
   ios-pr:
     needs: detect-changed-templates
     if: needs.detect-changed-templates.outputs.has-changes == 'true'
-    strategy:
-      fail-fast: false
     uses: ./.github/workflows/ios-reusable-workflow.yaml
     with:
       is_pr: true
@@ -159,8 +157,6 @@ jobs:
   android-pr:
     needs: detect-changed-templates
     if: needs.detect-changed-templates.outputs.has-changes == 'true'
-    strategy:
-      fail-fast: false
     uses: ./.github/workflows/android-reusable-workflow.yaml
     with:
       is_pr: true


### PR DESCRIPTION
## Summary
- Removes invalid `strategy:` blocks from `ios-pr` and `android-pr` jobs in the PR workflow
- These jobs call reusable workflows using `uses:`, which don't support `strategy` at the caller level
- The matrix strategy is correctly defined inside the reusable workflows themselves

## Issue
The invalid `strategy:` syntax was causing GitHub Actions to fail these jobs before execution, preventing the actual test matrix jobs from running. This resulted in:
- ✅ `detect-changed-templates` working correctly
- ✅ `generate-template-list` working correctly
- ❌ Matrix test jobs never appearing/running
- ❌ `pr-summary` reporting failures

## Test plan
- [ ] Rebase test_pr_action branch after this PR is merged
- [ ] Verify that ios-pr and android-pr matrix jobs now appear and execute
- [ ] Verify that test_template.sh runs for each changed template