### PR TITLE
Fix JSON quoting in reusable workflow template passthrough

### DIFF
--- a/.github/workflows/android-reusable-workflow.yaml
+++ b/.github/workflows/android-reusable-workflow.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           if [ -n "${{ inputs.templates }}" ]; then
             # Use provided template list
-            echo "templates=${{ inputs.templates }}" >> $GITHUB_OUTPUT
+            echo 'templates=${{ inputs.templates }}' >> $GITHUB_OUTPUT
           else
             # Generate list from templates.json filtered by Android platform
             TEMPLATES=$(jq -c '[.[] | select(.platforms[] == "android") | .path]' templates.json)

--- a/.github/workflows/ios-reusable-workflow.yaml
+++ b/.github/workflows/ios-reusable-workflow.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           if [ -n "${{ inputs.templates }}" ]; then
             # Use provided template list
-            echo "templates=${{ inputs.templates }}" >> $GITHUB_OUTPUT
+            echo 'templates=${{ inputs.templates }}' >> $GITHUB_OUTPUT
           else
             # Generate list from templates.json filtered by iOS platform
             TEMPLATES=$(jq -c '[.[] | select(.platforms[] == "ios") | .path]' templates.json)


### PR DESCRIPTION
## Summary
- Fixes JSON parsing errors in `ios-reusable-workflow.yaml` and `android-reusable-workflow.yaml`
- Changes echo statement from double quotes to single quotes when passing templates JSON

## Issue
When passing templates JSON from `inputs.templates` like `["AndroidNativeKotlinTemplate","ReactNativeTemplate"]`, the double quotes in the echo command caused shell parsing errors:

```bash
echo "templates=${{ inputs.templates }}" >> $GITHUB_OUTPUT
```

This resulted in malformed output and `fromJson()` failures with errors like:
```
Error from function 'fromJson': Unexpected symbol: 'AndroidNativeKotlinTemplate'. Located at line 1 position 2
```

## Fix
Changed to use single quotes to prevent shell interpretation of the JSON's internal quotes:

```bash
echo 'templates=${{ inputs.templates }}' >> $GITHUB_OUTPUT
```

## Test plan
- [ ] Merge this PR after #484 is merged
- [ ] Rebase test_pr_action branch
- [ ] Verify that templates JSON is properly parsed
- [ ] Verify that matrix jobs execute with correct template values