### PR TITLE
Add Biometric Authentication to Native Login Template

### DIFF
--- a/AndroidNativeLoginTemplate/app/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/app/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 
 dependencies {
     implementation("com.salesforce.mobilesdk:MobileSync:13.2.0")
-    implementation("com.google.android.material:material:1.12.0")
+    implementation("com.google.android.material:material:1.13.0")
+    implementation("androidx.biometric:biometric:1.1.0")
 
     val composeBom = platform("androidx.compose:compose-bom:2024.02.00")
     implementation(composeBom)

--- a/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/MainActivity.kt
+++ b/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/MainActivity.kt
@@ -26,9 +26,13 @@
  */
 package com.salesforce.androidnativelogintemplate
 
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import android.os.Bundle
+import android.service.autofill.Validators.or
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
@@ -100,6 +104,20 @@ class MainActivity : SalesforceActivity() {
 
         // Show everything
         findViewById<ViewGroup>(R.id.root).visibility = View.VISIBLE
+    }
+
+    override fun onPostResume() {
+        super.onPostResume()
+
+        // Check if we should prompt for biometric opt-in
+        val deviceHasBiometrics = BiometricManager.from(this).canAuthenticate(
+            /* authenticators = */ BIOMETRIC_STRONG or BIOMETRIC_WEAK
+        ) == BiometricManager.BIOMETRIC_SUCCESS
+        MobileSyncSDKManager.getInstance().biometricAuthenticationManager?.run {
+            if (enabled && deviceHasBiometrics && !hasBiometricOptedIn()) {
+                presentOptInDialog(supportFragmentManager)
+            }
+        }
     }
 
     /**

--- a/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/MainApplication.kt
+++ b/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/MainApplication.kt
@@ -68,7 +68,7 @@ class MainApplication : Application() {
          * To setup Password-less login:
          *
          * Un-comment the code block below and fill in the values from the
-         * the Google Cloud project reCAPTCHA settings.  Note that only enterprise
+         * Google Cloud project reCAPTCHA settings.  Note that only enterprise
          * reCAPTCHA requires the reCAPTCHA Site Key Id and Google Cloud Project Id.
          *
          * When using non-enterprise reCAPTCHA, set reCAPTCHA Site Key Id and
@@ -113,6 +113,9 @@ class MainApplication : Application() {
 
         /** The reCAPTCHA client used to obtain reCAPTCHA tokens when needed for Salesforce Headless Identity API requests. */
         private var recaptchaClient: RecaptchaClient? = null
+
+        /** Whether reCAPTCHA has been configured and is available for use. */
+        val isReCaptchaEnabled: Boolean get() = recaptchaClient != null
 
         /**
          * Initializes the Google reCAPTCHA client.

--- a/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/NativeLogin.kt
+++ b/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/NativeLogin.kt
@@ -34,7 +34,6 @@ import android.os.Bundle
 import android.widget.Toast
 import android.widget.Toast.LENGTH_LONG
 import android.window.OnBackInvokedDispatcher.PRIORITY_DEFAULT
-import androidx.activity.ComponentActivity
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -58,8 +57,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults.buttonColors
 import androidx.compose.material3.CardDefaults
@@ -99,6 +99,7 @@ import androidx.compose.ui.text.input.KeyboardType.Companion.Password
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
 import com.google.android.recaptcha.RecaptchaAction.Companion.LOGIN
 import com.google.android.recaptcha.RecaptchaAction.Companion.SIGNUP
 import com.google.android.recaptcha.RecaptchaAction.Companion.custom
@@ -131,7 +132,7 @@ import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
-class NativeLogin : ComponentActivity() {
+class NativeLogin : FragmentActivity() {
 
     private val viewModel: NativeLoginViewModel by viewModels()
 
@@ -151,6 +152,7 @@ class NativeLogin : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         nativeLoginManager = SalesforceSDKManager.getInstance().nativeLoginManager!!
+        val bioUsername = nativeLoginManager.biometricAuthenticationUsername
 
         setContentView(
             ComposeView(this).apply {
@@ -168,13 +170,24 @@ class NativeLogin : ComponentActivity() {
                                 password
                             ).mapResultTo(
                                 success = true,
-                                failure = false
+                                failure = false,
                             )
                         },
                         handleWebviewFallbackResult = handleWebviewFallbackResult,
                         webviewLoginIntent = nativeLoginManager.getFallbackWebAuthenticationIntent(),
                         shouldShowBack = nativeLoginManager.shouldShowBackButton,
-                        backAction = { finish() },
+                        backAction = {
+                            if (bioUsername != null) {
+                                moveTaskToBack(true)
+                            } else {
+                                finish()
+                            }
+                        },
+                        biometricAuthenticationUsername = bioUsername,
+                        reCaptchaEnabled = MainApplication.isReCaptchaEnabled,
+                        onBiometricLogin = if (bioUsername != null) {
+                            { nativeLoginManager.presentBiometricAuth(this@NativeLogin) }
+                        } else null,
                     )
                 }
             }
@@ -184,13 +197,36 @@ class NativeLogin : ComponentActivity() {
             onBackInvokedDispatcher.registerOnBackInvokedCallback(
                 PRIORITY_DEFAULT
             ) {
-                if (nativeLoginManager.shouldShowBackButton) {
+                if (nativeLoginManager.biometricAuthenticationUsername != null) {
+                    moveTaskToBack(true)
+                } else if (nativeLoginManager.shouldShowBackButton) {
                     when (SalesforceSDKManager.getInstance().userAccountManager.authenticatedUsers) {
                         null -> moveTaskToBack(false)
                         else -> finish()
                     }
                 }
             }
+        }
+    }
+
+    @SuppressLint("GestureBackNavigation")
+    @Deprecated("Deprecated in Java")
+    override fun onBackPressed() {
+        if (nativeLoginManager.biometricAuthenticationUsername != null) {
+            moveTaskToBack(true)
+        } else if (nativeLoginManager.shouldShowBackButton) {
+            when (SalesforceSDKManager.getInstance().userAccountManager.authenticatedUsers) {
+                null -> moveTaskToBack(false)
+                else -> super.onBackPressed()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (nativeLoginManager.biometricAuthenticationUsername != null) {
+            // Show bio auth button or auto-present
+            nativeLoginManager.presentBiometricAuth(this)
         }
     }
 
@@ -429,6 +465,9 @@ class NativeLogin : ComponentActivity() {
         webviewLoginIntent: Intent,
         shouldShowBack: Boolean = false,
         backAction: () -> Unit,
+        biometricAuthenticationUsername: String? = null,
+        reCaptchaEnabled: Boolean = true,
+        onBiometricLogin: (() -> Unit)? = null,
         identityFlowLayoutType: IdentityFlowLayoutType? = null
     ) {
 
@@ -465,14 +504,15 @@ class NativeLogin : ComponentActivity() {
                     }
                 },
             ) { innerPadding ->
-                LazyColumn(
-                    horizontalAlignment = CenterHorizontally,
+                Box(
+                    contentAlignment = Center,
                     modifier = Modifier
                         .consumeWindowInsets(innerPadding)
-                        .fillMaxSize(),
-                    contentPadding = innerPadding
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .verticalScroll(rememberScrollState())
                 ) {
-                    items(count = 1) {
+                    Column(horizontalAlignment = CenterHorizontally) {
                         ElevatedCard(
                             modifier = Modifier
                                 .padding(16.dp)
@@ -497,7 +537,7 @@ class NativeLogin : ComponentActivity() {
 
                                 CompletePasswordReset -> CompletePasswordResetInput()
 
-                                Login -> UserNamePasswordInput(login)
+                                Login -> UserNamePasswordInput(login, biometricAuthenticationUsername, onBiometricLogin)
 
                                 StartPasswordLessLogin -> StartPasswordLessLoginInput()
 
@@ -507,29 +547,31 @@ class NativeLogin : ComponentActivity() {
                             // Layout navigation buttons between the available identity flow layouts according to the current layout.
                             when (identityFlowLayoutTypeActive) {
                                 Login -> {
-                                    // Allow the user to switch to login via username and OTP.
-                                    Button(
-                                        onClick = {
-                                            viewModel.identifyFlowlayoutType.value = StartPasswordLessLogin
-                                        },
-                                        modifier = Modifier.align(CenterHorizontally)
-                                    ) { Text(text = "Use One Time Password Instead") }
+                                    if (reCaptchaEnabled) {
+                                        // Allow the user to switch to login via username and OTP.
+                                        Button(
+                                            onClick = {
+                                                viewModel.identifyFlowlayoutType.value = StartPasswordLessLogin
+                                            },
+                                            modifier = Modifier.align(CenterHorizontally)
+                                        ) { Text(text = "Use One Time Password Instead") }
 
-                                    // Allow the user to switch to reset password via username and OTP.
-                                    Button(
-                                        onClick = {
-                                            viewModel.identifyFlowlayoutType.value = StartPasswordReset
-                                        },
-                                        modifier = Modifier.align(CenterHorizontally)
-                                    ) { Text(text = "Reset Password") }
+                                        // Allow the user to switch to reset password via username and OTP.
+                                        Button(
+                                            onClick = {
+                                                viewModel.identifyFlowlayoutType.value = StartPasswordReset
+                                            },
+                                            modifier = Modifier.align(CenterHorizontally)
+                                        ) { Text(text = "Reset Password") }
 
-                                    // Allow the user to switch to registration
-                                    Button(
-                                        onClick = {
-                                            viewModel.identifyFlowlayoutType.value = StartRegistration
-                                        },
-                                        modifier = Modifier.align(CenterHorizontally)
-                                    ) { Text(text = "Register") }
+                                        // Allow the user to switch to registration
+                                        Button(
+                                            onClick = {
+                                                viewModel.identifyFlowlayoutType.value = StartRegistration
+                                            },
+                                            modifier = Modifier.align(CenterHorizontally)
+                                        ) { Text(text = "Register") }
+                                    }
                                 }
 
                                 else -> {
@@ -550,7 +592,6 @@ class NativeLogin : ComponentActivity() {
                             }
                             Spacer(modifier = Modifier.height(25.dp))
                         }
-
 
                         // Fallback to web based authentication.
                         TextButton(
@@ -1058,9 +1099,11 @@ class NativeLogin : ComponentActivity() {
 
     @Composable
     fun UserNamePasswordInput(
-        login: suspend (String, String) -> Boolean
+        login: suspend (String, String) -> Boolean,
+        biometricAuthenticationUsername: String? = null,
+        onBiometricLogin: (() -> Unit)? = null
     ) {
-        var username by remember { mutableStateOf("") }
+        var username by remember { mutableStateOf(biometricAuthenticationUsername ?: "") }
         var password by remember { mutableStateOf("") }
         val scope = rememberCoroutineScope()
         var loading by remember { mutableStateOf(false) }
@@ -1118,6 +1161,16 @@ class NativeLogin : ComponentActivity() {
                 }
             }
             )
+
+            if (onBiometricLogin != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = { onBiometricLogin() },
+                    modifier = Modifier.testTag("BiometricLogin"),
+                ) {
+                    Text(text = "Login with Biometrics")
+                }
+            }
         }
     }
 

--- a/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/NativeLogin.kt
+++ b/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/NativeLogin.kt
@@ -26,8 +26,12 @@
  */
 package com.salesforce.androidnativelogintemplate
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Build.VERSION.SDK_INT
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import android.os.Build.VERSION_CODES.S
 import android.os.Build.VERSION_CODES.TIRAMISU
 import android.os.Bundle
@@ -148,6 +152,19 @@ class NativeLogin : FragmentActivity() {
         }
     }
 
+    private val deviceHasBiometrics by lazy {
+        BiometricManager.from(this).canAuthenticate(
+            /* authenticators = */ BIOMETRIC_STRONG or BIOMETRIC_WEAK
+        ) == BiometricManager.BIOMETRIC_SUCCESS
+    }
+
+    private val shouldShowBiometricPrompt: Boolean
+        get() {
+            return SalesforceSDKManager.getInstance().biometricAuthenticationManager?.run {
+                locked && deviceHasBiometrics && hasBiometricOptedIn()
+            } ?: false
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
@@ -185,7 +202,7 @@ class NativeLogin : FragmentActivity() {
                         },
                         biometricAuthenticationUsername = bioUsername,
                         reCaptchaEnabled = MainApplication.isReCaptchaEnabled,
-                        onBiometricLogin = if (bioUsername != null) {
+                        onBiometricLogin = if (shouldShowBiometricPrompt) {
                             { nativeLoginManager.presentBiometricAuth(this@NativeLogin) }
                         } else null,
                     )
@@ -224,8 +241,7 @@ class NativeLogin : FragmentActivity() {
 
     override fun onResume() {
         super.onResume()
-        if (nativeLoginManager.biometricAuthenticationUsername != null) {
-            // Show bio auth button or auto-present
+        if (shouldShowBiometricPrompt) {
             nativeLoginManager.presentBiometricAuth(this)
         }
     }


### PR DESCRIPTION
- Detects if Bio Auth is enabled on login and prompts the user to opt-in to Bio Prompt.
- Automatically fills username on lock.
- Automatically prompts biometric is on lock if device is setup and user has opted in.
   - Shows "Login with Biometric" button if the above is true to re-prompt.
- Centers expandable card UI.
- Hides One Time Password, Reset Password and Register User buttons if ReCAPTCHA is not set.

This work **_requires_**: https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2854 for the `presentBiometricAuth` function. 

<img width="360" height="800" alt="Screenshot_20260326_115131" src="https://github.com/user-attachments/assets/7d882b20-0ff4-4f76-b850-e6c11eca7932" />
<img width="360" height="800" alt="Screenshot_20260326_115105" src="https://github.com/user-attachments/assets/2ce5f0ad-853d-47a5-8749-ca5db10d02a8" />

UI Centering:
<img width="822" height="464" alt="Screenshot 2026-03-26 at 12 02 42 PM" src="https://github.com/user-attachments/assets/da747709-9407-4cc0-b896-813254aaa0d7" />
