### PR TITLE
Organize .claude/skills for SDK developers vs SDK consumers

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,72 @@
+# Mobile SDK Skills
+
+This directory contains agent skills for [Claude Code](https://code.claude.com/docs/en/skills) and other compatible AI coding agents.
+
+Skills are installable via the [vercel-labs/skills](https://github.com/vercel-labs/skills) CLI:
+
+```bash
+npx skills add forcedotcom/SalesforceMobileSDK-Templates
+```
+
+## Two Audiences, One Directory
+
+Skills are split into two groups using the `metadata.internal` flag.
+
+### Consumer skills (default)
+
+Skills intended for **developers building apps with Mobile SDK** (SDK consumers). These are visible by default when installing via the CLI above.
+
+Use the directory/`SKILL.md` format so the `npx skills` CLI can discover and install them:
+
+```
+.claude/skills/
+  my-consumer-skill/
+    SKILL.md
+```
+
+_No consumer skills yet — add them here._
+
+### SDK developer skills (internal)
+
+Skills intended for **developers working on Mobile SDK itself** (contributors, maintainers). These are hidden from the default skill listing and only loaded by Claude Code when the repo is open locally — the `npx skills` CLI is not the delivery mechanism.
+
+Because they are only ever used via local repo clone, a flat `.md` file is sufficient (no need for a subdirectory):
+
+```
+.claude/skills/
+  my-sdk-skill.md
+```
+
+| Skill | Description |
+|---|---|
+| `remove-template.md` | Remove a template from this repository |
+| `test-template.md` | Test templates with `test_template.sh` |
+| `update-ios-deployment-target.md` | Bump the minimum iOS deployment target across all templates |
+
+## Adding a New Skill
+
+**Consumer skill** — create a subdirectory with a `SKILL.md`:
+
+```markdown
+---
+name: my-skill
+description: What this skill does and when to use it
+---
+
+# My Skill
+...
+```
+
+**SDK developer skill** — create a flat `.md` file with `metadata.internal: true`:
+
+```markdown
+---
+name: my-skill
+description: What this skill does and when to use it
+metadata:
+  internal: true
+---
+
+# My Skill
+...
+```

--- a/.claude/skills/remove-template.md
+++ b/.claude/skills/remove-template.md
@@ -2,6 +2,8 @@
 name: remove-template
 description: Remove a template from the Templates repository
 type: skill
+metadata:
+  internal: true
 ---
 
 # Remove Template from Templates Repository

--- a/.claude/skills/test-template.md
+++ b/.claude/skills/test-template.md
@@ -2,6 +2,8 @@
 name: test-template
 description: Test templates with test_template.sh script
 type: skill
+metadata:
+  internal: true
 ---
 
 # Test Templates with test_template.sh

--- a/.claude/skills/update-ios-deployment-target.md
+++ b/.claude/skills/update-ios-deployment-target.md
@@ -1,3 +1,10 @@
+---
+name: update-ios-deployment-target
+description: Update the minimum iOS deployment target across all iOS and React Native templates
+metadata:
+  internal: true
+---
+
 # Update iOS Minimum Deployment Target
 
 This skill updates the minimum iOS deployment target across all Salesforce Mobile SDK Templates that support iOS.


### PR DESCRIPTION
- Mark all existing skills as internal (metadata.internal: true) since they are for SDK contributors, not app developers using the SDK
- Convert update-ios-deployment-target from directory/SKILL.md to flat .md format, consistent with other internal skills
- Add .claude/skills/README.md explaining the two-audience convention: internal skills use flat .md files (local Claude Code use only), consumer skills use subdirectory/SKILL.md format (discoverable via npx skills add forcedotcom/SalesforceMobileSDK-Templates)