### PR TITLE
Add consumer skills: add-smartstore-ios and add-mobilesync-ios

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -26,25 +26,28 @@ Use the directory/`SKILL.md` format so the `npx skills` CLI can discover and ins
 
 | Skill | Description |
 |---|---|
-| `add-mobile-sdk-ios/` | Add Mobile SDK authentication to an existing iOS Swift app |
 | `create-ios-app-with-mobile-sdk/` | Create a new iOS Swift app from scratch with Mobile SDK already integrated |
+| `add-mobile-sdk-ios/` | Add Mobile SDK authentication to an existing iOS Swift app |
+| `add-smartstore-ios/` | Add SmartStore (encrypted local database) to an iOS Swift app that already has Mobile SDK |
+| `add-mobilesync-ios/` | Add MobileSync (cloud data sync) to an iOS Swift app that already has SmartStore |
 
 ### SDK developer skills (internal)
 
 Skills intended for **developers working on Mobile SDK itself** (contributors, maintainers). These are hidden from the default skill listing and only loaded by Claude Code when the repo is open locally — the `npx skills` CLI is not the delivery mechanism.
 
-Because they are only ever used via local repo clone, a flat `.md` file is sufficient (no need for a subdirectory):
+They use the same directory/`SKILL.md` format as consumer skills, but include `metadata.internal: true` in their frontmatter:
 
 ```
 .claude/skills/
-  my-sdk-skill.md
+  my-sdk-skill/
+    SKILL.md
 ```
 
 | Skill | Description |
 |---|---|
-| `remove-template.md` | Remove a template from this repository |
-| `test-template.md` | Test templates with `test_template.sh` |
-| `update-ios-deployment-target.md` | Bump the minimum iOS deployment target across all templates |
+| `remove-template/` | Remove a template from this repository |
+| `test-template/` | Test templates with `test_template.sh` |
+| `update-ios-deployment-target/` | Bump the minimum iOS deployment target across all templates |
 
 ## Adding a New Skill
 
@@ -99,7 +102,7 @@ Expected: `** BUILD SUCCEEDED **` and Salesforce login screen on first run.
 
 ---
 
-**SDK developer skill** — create a flat `.md` file with `metadata.internal: true`:
+**SDK developer skill** — create a subdirectory with a `SKILL.md` that includes `metadata.internal: true`:
 
 ```markdown
 ---

--- a/.claude/skills/add-mobile-sdk-ios/SKILL.md
+++ b/.claude/skills/add-mobile-sdk-ios/SKILL.md
@@ -10,11 +10,12 @@ This skill integrates the Salesforce Mobile SDK into an existing iOS Swift appli
 ## What This Skill Does
 
 1. Adds the `SalesforceSDKCore` dependency (CocoaPods **or** Swift Package Manager, matching what the app already uses)
-2. Initializes the SDK in `AppDelegate`
-3. Creates `InitialViewController.swift` — the splash screen shown while the login flow runs
-4. Wires `AuthHelper.loginIfRequired` and user-change notifications into `SceneDelegate`
-5. Adds `bootconfig.plist` with OAuth configuration placeholders
-6. Adds the required `SFDCOAuthLoginHost` key to `Info.plist`
+2. Adds a `LaunchScreen.storyboard` so iOS sizes the window correctly before the SDK presents the login screen
+3. Initializes the SDK in `AppDelegate`
+4. Creates `InitialViewController.swift` — the splash screen shown while the login flow runs
+5. Wires `AuthHelper.loginIfRequired` and user-change notifications into `SceneDelegate`
+6. Adds `bootconfig.plist` with OAuth configuration placeholders
+7. Adds the required `SFDCOAuthLoginHost` and `UILaunchStoryboardName` keys to `Info.plist`
 
 ## Prerequisites
 
@@ -81,7 +82,43 @@ In Xcode:
 
 ---
 
-## Step 2: Create InitialViewController.swift
+## Step 2: Add LaunchScreen.storyboard
+
+Without a launch storyboard, iOS does not properly establish the window's safe-area bounds before the SDK presents its login screen, which causes the login view controller to appear with black bars above and below it.
+
+Create a minimal `LaunchScreen.storyboard` in the app target's source folder:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 9 format" minToolsVersion="9.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>
+```
+
+Add `LaunchScreen.storyboard` to the Xcode target's **Copy Bundle Resources** build phase.
+
+---
+
+## Step 3: Create InitialViewController.swift
 
 Create `InitialViewController.swift` inside the app target's source folder. This is the splash screen that fills the window while the SDK presents the login flow. Using a named subclass instead of a bare `UIViewController` ensures UIKit presents the login screen full-screen rather than as a page sheet, which would leave black bars above and below it.
 
@@ -95,7 +132,7 @@ Add the file to the Xcode target (it must be compiled into the app module so `Sc
 
 ---
 
-## Step 3: Update AppDelegate.swift
+## Step 4: Update AppDelegate.swift
 
 The key changes from a plain iOS app:
 - `import SalesforceSDKCore`
@@ -134,7 +171,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 ---
 
-## Step 4: Update SceneDelegate.swift
+## Step 5: Update SceneDelegate.swift
 
 The key Mobile SDK additions:
 - `import SalesforceSDKCore`
@@ -205,7 +242,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 ---
 
-## Step 5: Add bootconfig.plist
+## Step 6: Add bootconfig.plist
 
 Create `bootconfig.plist` inside your app target's source folder (next to `Info.plist`), then add it to the Xcode target via **Add Files to "YourApp"**.
 
@@ -230,13 +267,15 @@ Verify `bootconfig.plist` appears in the **Copy Bundle Resources** build phase f
 
 ---
 
-## Step 6: Update Info.plist
+## Step 7: Update Info.plist
 
-Add the `SFDCOAuthLoginHost` key to the app target's `Info.plist`:
+Add the following keys to the app target's `Info.plist`:
 
 ```xml
 <key>SFDCOAuthLoginHost</key>
 <string>login.salesforce.com</string>
+<key>UILaunchStoryboardName</key>
+<string>LaunchScreen</string>
 ```
 
 Use the login host provided by the user, or `login.salesforce.com` as the default.
@@ -265,13 +304,15 @@ Also ensure the Scene configuration is present (required for `SceneDelegate` to 
 
 ---
 
-## Step 7: Verify the Integration
+## Step 8: Verify the Integration
 
 Build and run. On first launch, the Salesforce login screen should appear. After a successful login, `setupRootViewController()` is called.
 
 ### Checklist
 
 - [ ] SDK dependency added and project builds without errors
+- [ ] `LaunchScreen.storyboard` added and in Copy Bundle Resources
+- [ ] `UILaunchStoryboardName` set to `LaunchScreen` in `Info.plist`
 - [ ] `InitialViewController.swift` created and added to the Xcode target
 - [ ] `SalesforceManager.initializeSDK()` called in `AppDelegate.init()`
 - [ ] `initializeAppViewState()` uses `InitialViewController(nibName: nil, bundle: nil)`
@@ -292,6 +333,9 @@ The import is missing or the framework is not linked. For CocoaPods, verify `pod
 
 **Login screen does not appear**
 Check that `SFDCOAuthLoginHost` is in `Info.plist` and `bootconfig.plist` is included in Copy Bundle Resources.
+
+**Login screen has black bars above and below it**
+`LaunchScreen.storyboard` is missing or not set in `Info.plist` as `UILaunchStoryboardName`. Without it, iOS does not properly establish window bounds before the SDK presents its auth window.
 
 **Login succeeds but app shows blank screen**
 `setupRootViewController()` still has the placeholder `UIViewController()`. Replace it with your app's actual root view controller.

--- a/.claude/skills/add-mobile-sdk-ios/SKILL.md
+++ b/.claude/skills/add-mobile-sdk-ios/SKILL.md
@@ -11,9 +11,10 @@ This skill integrates the Salesforce Mobile SDK into an existing iOS Swift appli
 
 1. Adds the `SalesforceSDKCore` dependency (CocoaPods **or** Swift Package Manager, matching what the app already uses)
 2. Initializes the SDK in `AppDelegate`
-3. Wires `AuthHelper.loginIfRequired` and user-change notifications into `SceneDelegate`
-4. Adds `bootconfig.plist` with OAuth configuration placeholders
-5. Adds the required `SFDCOAuthLoginHost` key to `Info.plist`
+3. Creates `InitialViewController.swift` — the splash screen shown while the login flow runs
+4. Wires `AuthHelper.loginIfRequired` and user-change notifications into `SceneDelegate`
+5. Adds `bootconfig.plist` with OAuth configuration placeholders
+6. Adds the required `SFDCOAuthLoginHost` key to `Info.plist`
 
 ## Prerequisites
 
@@ -80,7 +81,21 @@ In Xcode:
 
 ---
 
-## Step 2: Update AppDelegate.swift
+## Step 2: Create InitialViewController.swift
+
+Create `InitialViewController.swift` inside the app target's source folder. This is the splash screen that fills the window while the SDK presents the login flow. Using a named subclass instead of a bare `UIViewController` ensures UIKit presents the login screen full-screen rather than as a page sheet, which would leave black bars above and below it.
+
+```swift
+import UIKit
+
+class InitialViewController: UIViewController {}
+```
+
+Add the file to the Xcode target (it must be compiled into the app module so `SceneDelegate` can reference it by name).
+
+---
+
+## Step 3: Update AppDelegate.swift
 
 The key changes from a plain iOS app:
 - `import SalesforceSDKCore`
@@ -119,7 +134,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 ---
 
-## Step 3: Update SceneDelegate.swift
+## Step 4: Update SceneDelegate.swift
 
 The key Mobile SDK additions:
 - `import SalesforceSDKCore`
@@ -162,7 +177,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             DispatchQueue.main.async { self.initializeAppViewState() }
             return
         }
-        window?.rootViewController = UIViewController()   // splash/loading screen while login is presented
+        window?.rootViewController = InitialViewController(nibName: nil, bundle: nil)
         window?.makeKeyAndVisible()
     }
 
@@ -190,7 +205,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 ---
 
-## Step 4: Add bootconfig.plist
+## Step 5: Add bootconfig.plist
 
 Create `bootconfig.plist` inside your app target's source folder (next to `Info.plist`), then add it to the Xcode target via **Add Files to "YourApp"**.
 
@@ -215,7 +230,7 @@ Verify `bootconfig.plist` appears in the **Copy Bundle Resources** build phase f
 
 ---
 
-## Step 5: Update Info.plist
+## Step 6: Update Info.plist
 
 Add the `SFDCOAuthLoginHost` key to the app target's `Info.plist`:
 
@@ -250,14 +265,16 @@ Also ensure the Scene configuration is present (required for `SceneDelegate` to 
 
 ---
 
-## Step 6: Verify the Integration
+## Step 7: Verify the Integration
 
 Build and run. On first launch, the Salesforce login screen should appear. After a successful login, `setupRootViewController()` is called.
 
 ### Checklist
 
 - [ ] SDK dependency added and project builds without errors
+- [ ] `InitialViewController.swift` created and added to the Xcode target
 - [ ] `SalesforceManager.initializeSDK()` called in `AppDelegate.init()`
+- [ ] `initializeAppViewState()` uses `InitialViewController(nibName: nil, bundle: nil)`
 - [ ] `AuthHelper.registerBlock(forCurrentUserChangeNotifications:)` called in `scene(_:willConnectTo:)`
 - [ ] `AuthHelper.loginIfRequired` called in `sceneWillEnterForeground`
 - [ ] `bootconfig.plist` is in the target and in Copy Bundle Resources

--- a/.claude/skills/add-mobilesync-ios/SKILL.md
+++ b/.claude/skills/add-mobilesync-ios/SKILL.md
@@ -144,7 +144,7 @@ Create `usersyncs.json` inside the app target's source folder (next to `userstor
       "soupName": "<SoupName>",
       "target": {
         "type": "soql",
-        "query": "SELECT Id, Name FROM <SoupName> LIMIT 100"
+        "query": "SELECT Id, Name FROM <SalesforceObject> LIMIT 100"
       },
       "options": {
         "mergeMode": "LEAVE_IF_CHANGED"
@@ -154,7 +154,11 @@ Create `usersyncs.json` inside the app target's source folder (next to `userstor
 }
 ```
 
-Replace `<SoupName>` with the soup name used in `userstore.json`.
+Replace:
+- `<SoupName>` with the soup name used in `userstore.json` — this is the **local** SmartStore table name
+- `<SalesforceObject>` in the SOQL `FROM` clause with the **Salesforce sObject API name** to sync from (e.g. `Account`, `Contact`, `Opportunity`) — this query runs on the server, not against the local store
+
+> The soup name and the sObject name are often the same (e.g. soup `Account`, query `FROM Account`) but they don't have to be. The soup is a local storage concept; the SOQL target is a server-side Salesforce object.
 
 Then add `usersyncs.json` to the Xcode target:
 - In Xcode, right-click the app target group → **Add Files to "YourApp"**

--- a/.claude/skills/add-mobilesync-ios/SKILL.md
+++ b/.claude/skills/add-mobilesync-ios/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: add-mobilesync-ios
+description: Add Salesforce MobileSync (cloud data sync) to an existing iOS Swift app that already has SmartStore integrated.
+---
+
+# Add MobileSync to an iOS Swift App
+
+This skill adds Salesforce MobileSync to an existing iOS Swift app that already has `SmartStore` integrated via the `add-smartstore-ios` skill.
+
+## What This Skill Does
+
+1. Adds the `MobileSync` dependency (CocoaPods **or** SPM, matching what the app already uses)
+2. Upgrades the SDK manager initializer from `SmartStoreSDKManager` to `MobileSyncSDKManager`
+3. Calls `MobileSyncSDKManager.shared.setupUserSyncsFromDefaultConfig()` after login (alongside the existing store setup)
+4. Creates `usersyncs.json` with placeholder sync definitions and adds it to the Xcode target
+
+## Prerequisites
+
+The app must already have SmartStore integrated. **Check `AppDelegate.swift` for `SmartStoreSDKManager.initializeSDK()` (or `MobileSyncSDKManager`) and `SceneDelegate.swift` for `setupUserStoreFromDefaultConfig()`.** If not present:
+
+1. If the app has no Mobile SDK at all, run `add-mobile-sdk-ios` first.
+2. Then run `add-smartstore-ios`.
+3. Then return here.
+
+Before starting, confirm:
+- **App target name** (e.g. `MyApp`)
+- **Soup name** used in `userstore.json` (the sync will target this soup)
+- Which dependency manager is in use (detected from `Podfile` vs `.xcodeproj` SPM references)
+
+---
+
+## Step 1: Add the MobileSync Dependency
+
+### Option A — CocoaPods (project has a `Podfile`)
+
+Replace the `SmartStore` pod with `MobileSync`. MobileSync depends on SmartStore transitively, so only one pod declaration is needed.
+
+**Before:**
+```ruby
+target 'YourApp' do
+  use_frameworks!
+  pod 'SmartStore'
+end
+```
+
+**After:**
+```ruby
+target 'YourApp' do
+  use_frameworks!
+  pod 'MobileSync'
+end
+```
+
+Then run:
+
+```bash
+pod install
+```
+
+### Option B — Swift Package Manager
+
+In Xcode, add the `MobileSync` product from the existing `SalesforceMobileSDK-iOS-SPM` package to the app target's **Frameworks, Libraries, and Embedded Content**.
+
+---
+
+## Step 2: Upgrade the SDK Manager in AppDelegate.swift
+
+MobileSync requires a richer SDK manager than `SmartStoreSDKManager`. Replace the import and initializer.
+
+**Before:**
+```swift
+import SmartStore
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    override init() {
+        super.init()
+        SmartStoreSDKManager.initializeSDK()
+    }
+    // ...
+}
+```
+
+**After:**
+```swift
+import MobileSync
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    override init() {
+        super.init()
+        MobileSyncSDKManager.initializeSDK()
+    }
+    // ...
+}
+```
+
+> `MobileSyncSDKManager` is a subclass of `SmartStoreSDKManager`. Replacing the initializer is sufficient — no other AppDelegate changes are needed.
+
+---
+
+## Step 3: Add Sync Setup in SceneDelegate.swift
+
+Replace the `SmartStore` import with `MobileSync` and add `setupUserSyncsFromDefaultConfig()` alongside the existing store setup call.
+
+**Before:**
+```swift
+import SmartStore
+
+// ...
+
+func setupRootViewController() {
+    SmartStoreSDKManager.shared.setupUserStoreFromDefaultConfig()
+    window?.rootViewController = UIViewController()
+}
+```
+
+**After:**
+```swift
+import MobileSync
+import SalesforceSDKCore   // keep this — AuthHelper lives here
+
+// ...
+
+func setupRootViewController() {
+    MobileSyncSDKManager.shared.setupUserStoreFromDefaultConfig()
+    MobileSyncSDKManager.shared.setupUserSyncsFromDefaultConfig()
+    window?.rootViewController = UIViewController()
+}
+```
+
+---
+
+## Step 4: Create usersyncs.json
+
+Create `usersyncs.json` inside the app target's source folder (next to `userstore.json`):
+
+```json
+{
+  "syncs": [
+    {
+      "syncName": "syncDown<SoupName>",
+      "syncType": "syncDown",
+      "soupName": "<SoupName>",
+      "target": {
+        "type": "soql",
+        "query": "SELECT Id, Name FROM <SoupName> LIMIT 100"
+      },
+      "options": {
+        "mergeMode": "LEAVE_IF_CHANGED"
+      }
+    }
+  ]
+}
+```
+
+Replace `<SoupName>` with the soup name used in `userstore.json`.
+
+Then add `usersyncs.json` to the Xcode target:
+- In Xcode, right-click the app target group → **Add Files to "YourApp"**
+- Select `usersyncs.json`
+- Ensure it appears in the **Copy Bundle Resources** build phase
+
+---
+
+## Step 5: Build and Verify
+
+```bash
+# CocoaPods
+xcodebuild -workspace <AppName>.xcworkspace \
+  -scheme <AppName> \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  build
+
+# SPM (no workspace)
+xcodebuild -project <AppName>.xcodeproj \
+  -scheme <AppName> \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  build
+```
+
+Expected: `** BUILD SUCCEEDED **`
+
+---
+
+## Checklist
+
+- [ ] `MobileSync` pod added (CocoaPods) or SPM product added (SPM)
+- [ ] `pod install` run (CocoaPods path)
+- [ ] `AppDelegate.swift` imports `MobileSync` and calls `MobileSyncSDKManager.initializeSDK()`
+- [ ] `SceneDelegate.swift` imports `MobileSync` and calls both `setupUserStoreFromDefaultConfig()` and `setupUserSyncsFromDefaultConfig()` in `setupRootViewController()`
+- [ ] `usersyncs.json` created with at least one sync definition targeting the correct soup
+- [ ] `usersyncs.json` is in the **Copy Bundle Resources** build phase
+- [ ] Project builds without errors
+
+---
+
+## Troubleshooting
+
+**Build error: `Cannot find type 'MobileSyncSDKManager'`**
+`MobileSync` is not linked. For CocoaPods, verify `pod install` completed and you opened `.xcworkspace`. For SPM, verify `MobileSync` is in the target's Frameworks.
+
+**`setupUserSyncsFromDefaultConfig()` silently does nothing**
+`usersyncs.json` is missing from Copy Bundle Resources. Open Build Phases and add it.
+
+**Sync fails at runtime with "Soup not found"**
+The `soupName` in `usersyncs.json` must exactly match the `soupName` in `userstore.json`.

--- a/.claude/skills/add-smartstore-ios/SKILL.md
+++ b/.claude/skills/add-smartstore-ios/SKILL.md
@@ -16,7 +16,7 @@ This skill adds the Salesforce SmartStore encrypted local database to an existin
 
 ## Prerequisites
 
-The app must already have the Mobile SDK wired up. **Check `AppDelegate.swift` for `SalesforceManager.initializeSDK()` (or `SmartStoreSDKManager` / `MobileSyncSDKManager`).** If not present, run the `add-mobile-sdk-ios` skill first, then return here.
+The app must already have the Mobile SDK wired up. **Check `AppDelegate.swift` for `SalesforceManager.initializeSDK()` (or `SmartStoreSDKManager` / `MobileSyncSDKManager`) and that `bootconfig.plist` exists in the app target.** If not, run the `add-mobile-sdk-ios` skill first, then return here.
 
 Before starting, confirm:
 - **App target name** (e.g. `MyApp`)

--- a/.claude/skills/add-smartstore-ios/SKILL.md
+++ b/.claude/skills/add-smartstore-ios/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: add-smartstore-ios
+description: Add Salesforce SmartStore (encrypted local database) to an existing iOS Swift app that already has the Mobile SDK integrated.
+---
+
+# Add SmartStore to an iOS Swift App
+
+This skill adds the Salesforce SmartStore encrypted local database to an existing iOS Swift app that already has `SalesforceSDKCore` integrated via the `add-mobile-sdk-ios` skill.
+
+## What This Skill Does
+
+1. Adds the `SmartStore` dependency (CocoaPods **or** SPM, matching what the app already uses)
+2. Upgrades the SDK manager initializer from `SalesforceManager` to `SmartStoreSDKManager`
+3. Calls `SmartStoreSDKManager.shared.setupUserStoreFromDefaultConfig()` after login
+4. Creates `userstore.json` with a placeholder soup and adds it to the Xcode target
+
+## Prerequisites
+
+The app must already have the Mobile SDK wired up. **Check `AppDelegate.swift` for `SalesforceManager.initializeSDK()` (or `SmartStoreSDKManager` / `MobileSyncSDKManager`).** If not present, run the `add-mobile-sdk-ios` skill first, then return here.
+
+Before starting, confirm:
+- **App target name** (e.g. `MyApp`)
+- **Soup name** for the initial store table (default: `Item`)
+- Which dependency manager is in use (detected from `Podfile` vs `.xcodeproj` SPM references)
+
+---
+
+## Step 1: Add the SmartStore Dependency
+
+### Option A — CocoaPods (project has a `Podfile`)
+
+Replace the `SalesforceSDKCore` pod with `SmartStore`. SmartStore depends on SalesforceSDKCore transitively, so only one pod declaration is needed.
+
+**Before:**
+```ruby
+target 'YourApp' do
+  use_frameworks!
+  pod 'SalesforceSDKCore'
+end
+```
+
+**After:**
+```ruby
+target 'YourApp' do
+  use_frameworks!
+  pod 'SmartStore'
+end
+```
+
+Then run:
+
+```bash
+pod install
+```
+
+### Option B — Swift Package Manager
+
+In Xcode:
+1. **File → Add Package Dependencies…** (or open the existing `SalesforceMobileSDK-iOS-SPM` package dependency)
+2. Add the `SmartStore` product to the app target's **Frameworks, Libraries, and Embedded Content**
+
+If `SalesforceMobileSDK-iOS-SPM` is not yet added, add it first:
+- URL: `https://github.com/forcedotcom/SalesforceMobileSDK-iOS-SPM`
+- Branch: `master`
+- Add these products: `SalesforceSDKCore`, `SalesforceAnalytics`, `SalesforceSDKCommon`, `SmartStore`
+
+---
+
+## Step 2: Upgrade the SDK Manager in AppDelegate.swift
+
+SmartStore requires a richer SDK manager than the base `SalesforceManager`. Replace the import and initializer.
+
+**Before:**
+```swift
+import SalesforceSDKCore
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    override init() {
+        super.init()
+        SalesforceManager.initializeSDK()
+    }
+    // ...
+}
+```
+
+**After:**
+```swift
+import SmartStore
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    override init() {
+        super.init()
+        SmartStoreSDKManager.initializeSDK()
+    }
+    // ...
+}
+```
+
+> `SmartStoreSDKManager` is a subclass of `SalesforceManager`. Replacing the initializer is sufficient — no other AppDelegate changes are needed.
+
+---
+
+## Step 3: Set Up the Store After Login in SceneDelegate.swift
+
+Add a `SmartStore` import and call `setupUserStoreFromDefaultConfig()` inside `setupRootViewController()`.
+
+**Before:**
+```swift
+import SalesforceSDKCore
+
+// ...
+
+func setupRootViewController() {
+    window?.rootViewController = UIViewController()
+}
+```
+
+**After:**
+```swift
+import SmartStore
+import SalesforceSDKCore   // keep this — AuthHelper lives here
+
+// ...
+
+func setupRootViewController() {
+    SmartStoreSDKManager.shared.setupUserStoreFromDefaultConfig()
+    window?.rootViewController = UIViewController()
+}
+```
+
+---
+
+## Step 4: Create userstore.json
+
+Create `userstore.json` inside the app target's source folder (next to `AppDelegate.swift`):
+
+```json
+{
+  "soups": [
+    {
+      "soupName": "<SoupName>",
+      "indexes": [
+        { "path": "Id",        "type": "string" },
+        { "path": "Name",      "type": "string" },
+        { "path": "__local__", "type": "string" }
+      ]
+    }
+  ]
+}
+```
+
+Replace `<SoupName>` with the soup name agreed with the user (default: `Item`).
+
+Then add `userstore.json` to the Xcode target:
+- In Xcode, right-click the app target group → **Add Files to "YourApp"**
+- Select `userstore.json`
+- Ensure it appears in the **Copy Bundle Resources** build phase
+
+---
+
+## Step 5: Build and Verify
+
+```bash
+# CocoaPods
+xcodebuild -workspace <AppName>.xcworkspace \
+  -scheme <AppName> \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  build
+
+# SPM (no workspace)
+xcodebuild -project <AppName>.xcodeproj \
+  -scheme <AppName> \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  build
+```
+
+Expected: `** BUILD SUCCEEDED **`
+
+---
+
+## Checklist
+
+- [ ] `SmartStore` pod added (CocoaPods) or SPM product added (SPM)
+- [ ] `pod install` run (CocoaPods path)
+- [ ] `AppDelegate.swift` imports `SmartStore` and calls `SmartStoreSDKManager.initializeSDK()`
+- [ ] `SceneDelegate.swift` imports `SmartStore` and calls `setupUserStoreFromDefaultConfig()` in `setupRootViewController()`
+- [ ] `userstore.json` created with at least one soup
+- [ ] `userstore.json` is in the **Copy Bundle Resources** build phase
+- [ ] Project builds without errors
+
+---
+
+## Troubleshooting
+
+**Build error: `Cannot find type 'SmartStoreSDKManager'`**
+`SmartStore` is not linked. For CocoaPods, verify `pod install` completed and you opened `.xcworkspace`. For SPM, verify `SmartStore` is in the target's Frameworks.
+
+**`setupUserStoreFromDefaultConfig()` silently does nothing**
+`userstore.json` is missing from Copy Bundle Resources. Open Build Phases and add it.
+
+**`pod install` fails with "Unable to find a specification for `SmartStore`"**
+Ensure both sources are declared in the Podfile — `cdn.cocoapods.org` and `github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs`.

--- a/.claude/skills/create-ios-app-with-mobile-sdk/SKILL.md
+++ b/.claude/skills/create-ios-app-with-mobile-sdk/SKILL.md
@@ -82,6 +82,34 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 }
 ```
 
+Create `<AppName>/LaunchScreen.storyboard`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 9 format" minToolsVersion="9.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>
+```
+
 ---
 
 ## Step 2: Create project.yml
@@ -102,9 +130,12 @@ targets:
     platform: iOS
     sources:
       - <AppName>
+    resources:
+      - <AppName>/LaunchScreen.storyboard
     info:
       path: <AppName>/Info.plist
       properties:
+        UILaunchStoryboardName: LaunchScreen
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
           UISceneConfigurations:
@@ -113,7 +144,7 @@ targets:
                 UISceneDelegateClassName: $(PRODUCT_MODULE_NAME).SceneDelegate
 ```
 
-> **Note:** `UILaunchStoryboardName` is intentionally omitted. Apps created with this skill use a programmatic window setup and do not require a launch storyboard.
+> **Note:** `UILaunchStoryboardName` is required. Without a launch storyboard, iOS does not properly establish the window's bounds before the SDK presents its login screen, resulting in black bars above and below the login UI.
 
 ---
 
@@ -179,7 +210,8 @@ Run on the simulator — the Salesforce login screen should appear on first laun
 
 - [ ] Project directory created with `<AppName>` subdirectory for sources
 - [ ] `AppDelegate.swift` and `SceneDelegate.swift` created
-- [ ] `project.yml` created with correct bundle ID and deployment target
+- [ ] `LaunchScreen.storyboard` created
+- [ ] `project.yml` created with correct bundle ID, deployment target, and `UILaunchStoryboardName`
 - [ ] `xcodegen generate` completed without errors
 - [ ] `add-mobile-sdk-ios` skill applied
 - [ ] `pod install` run (CocoaPods path) or SPM package added in Xcode (SPM path)


### PR DESCRIPTION
## Summary

- Adds `add-smartstore-ios` skill: adds SmartStore encrypted local database to an existing iOS app that already has Mobile SDK — upgrades to `SmartStoreSDKManager`, creates `userstore.json`
- Adds `add-mobilesync-ios` skill: adds MobileSync to an existing iOS app that already has SmartStore — upgrades to `MobileSyncSDKManager`, creates `usersyncs.json`
- Both skills check prerequisites and direct to the prior skill in the chain if needed (`add-mobile-sdk-ios` → `add-smartstore-ios` → `add-mobilesync-ios`)
- Fixes `add-mobile-sdk-ios` and `create-ios-app-with-mobile-sdk`: adds `LaunchScreen.storyboard` and `UILaunchStoryboardName` to `Info.plist` — without this, the SDK login screen has black bars above and below it due to iOS not establishing window bounds before the auth window is presented
- Fixes `add-mobile-sdk-ios`: adds `InitialViewController.swift` used as the splash screen in `initializeAppViewState()`