### PR TITLE
Add actionable push notification support to iOSNativeSwiftEncryptedNotificationTemplate

### DIFF
--- a/iOSNativeSwiftEncryptedNotificationTemplate/EncryptedNotificationTemplate/AppDelegate.swift
+++ b/iOSNativeSwiftEncryptedNotificationTemplate/EncryptedNotificationTemplate/AppDelegate.swift
@@ -32,8 +32,11 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
     
     override init() {
         super.init()
+        // Set the delegate here in init() rather than later in registerForRemotePushNotifications()
+        // to avoid a race condition where a notification could arrive before the delegate is assigned.
+        UNUserNotificationCenter.current().delegate = self
         MobileSyncSDKManager.initializeSDK()
-        
+
         AuthHelper.registerBlock(forCurrentUserChangeNotifications: {
             self.resetViewState {
                 self.setupRootViewController()
@@ -42,6 +45,21 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
     }
     
     // MARK: - App delegate lifecycle
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Re-fetch notification type definitions from the server each time the app foregrounds.
+        // This keeps action button definitions up to date if they change while the app is backgrounded,
+        // without requiring a full push re-registration.
+        guard UserAccountManager.shared.currentUserAccount != nil else { return }
+        Task {
+            do {
+                try await PushNotificationManager.sharedInstance().fetchAndStoreNotificationTypes()
+            } catch {
+                SalesforceLogger.e(AppDelegate.self, message: "Failed to refresh notification types on foreground: \(error)")
+            }
+        }
+    }
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.initializeAppViewState()
@@ -78,6 +96,17 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
                 switch (result) {
                     case .success:
                         SalesforceLogger.e(AppDelegate.self, message: "Registration for Salesforce notifications succeeded")
+                        Task {
+                            do {
+                                // Fetch notification type definitions from the server and register
+                                // them as UNNotificationCategory objects with iOS. This is what
+                                // enables action buttons to appear on notifications — iOS must know
+                                // the category and its actions before a notification arrives.
+                                try await PushNotificationManager.sharedInstance().fetchAndStoreNotificationTypes()
+                            } catch {
+                                SalesforceLogger.e(AppDelegate.self, message: "Failed to fetch notification types: \(error)")
+                            }
+                        }
                     case .failure(let error):
                         SalesforceLogger.e(AppDelegate.self, message: "Registration for Salesforce notifications failed with error: \(error as Error)")
                 }
@@ -116,5 +145,46 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
             }
         }
         postResetBlock()
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+extension AppDelegate: UNUserNotificationCenterDelegate {
+
+    // Show notifications as banners even when the app is in the foreground
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound, .badge])
+    }
+
+    // Handle action button taps
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        let actionIdentifier = response.actionIdentifier
+        let userInfo = response.notification.request.content.userInfo
+
+        // Skip default tap (opens app) and dismiss — only handle custom action buttons.
+        // nid is nested inside the "sfdc" dictionary in the payload, not at the top level.
+        let sfdc = userInfo["sfdc"] as? [String: Any]
+        guard actionIdentifier != UNNotificationDefaultActionIdentifier,
+              actionIdentifier != UNNotificationDismissActionIdentifier,
+              let nid = sfdc?["nid"] as? String else {
+            completionHandler()
+            return
+        }
+
+        Task {
+            do {
+                _ = try await PushNotificationManager.sharedInstance().invokeServerNotificationAction(
+                    notificationId: nid,
+                    actionIdentifier: actionIdentifier
+                )
+            } catch {
+                SalesforceLogger.e(AppDelegate.self, message: "Failed to invoke notification action: \(error)")
+            }
+            completionHandler()
+        }
     }
 }

--- a/iOSNativeSwiftEncryptedNotificationTemplate/EncryptedNotificationTemplate/AppDelegate.swift
+++ b/iOSNativeSwiftEncryptedNotificationTemplate/EncryptedNotificationTemplate/AppDelegate.swift
@@ -46,20 +46,6 @@ class AppDelegate : UIResponder, UIApplicationDelegate {
     
     // MARK: - App delegate lifecycle
 
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Re-fetch notification type definitions from the server each time the app foregrounds.
-        // This keeps action button definitions up to date if they change while the app is backgrounded,
-        // without requiring a full push re-registration.
-        guard UserAccountManager.shared.currentUserAccount != nil else { return }
-        Task {
-            do {
-                try await PushNotificationManager.sharedInstance().fetchAndStoreNotificationTypes()
-            } catch {
-                SalesforceLogger.e(AppDelegate.self, message: "Failed to refresh notification types on foreground: \(error)")
-            }
-        }
-    }
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.initializeAppViewState()

--- a/iOSNativeSwiftEncryptedNotificationTemplate/template.js
+++ b/iOSNativeSwiftEncryptedNotificationTemplate/template.js
@@ -47,6 +47,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     var templateProjectFile = path.join(templateProjectDir, 'project.pbxproj');
     var templateSchemeFile = path.join(templateAppName + '.xcodeproj', 'xcshareddata', 'xcschemes', templateAppName + '.xcscheme');
     var templateEntitlementsFile = path.join(templateAppName, templateAppName + '.entitlements');
+    var templateExtensionEntitlementsFile = path.join('NotificationServiceExtension', 'NotificationServiceExtension.entitlements');
     var templateBootconfigFile = path.join(templateAppName, 'bootconfig.plist');
     var templateInfoFile = path.join(templateAppName, 'Info.plist');
 
@@ -55,7 +56,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     //
 
     // app name
-    replaceInFiles(templateAppName, config.appname, [templatePodfile, templatePackageJsonFile, templateProjectFile, templateSchemeFile, templateEntitlementsFile]);
+    replaceInFiles(templateAppName, config.appname, [templatePodfile, templatePackageJsonFile, templateProjectFile, templateSchemeFile, templateEntitlementsFile, templateExtensionEntitlementsFile]);
 
     // package name
     replaceInFiles(templatePackageName, config.packagename, [templateProjectFile, templateEntitlementsFile]);


### PR DESCRIPTION
  Summary                                                                                               
                                                                                                        
  - Adds UNUserNotificationCenterDelegate conformance to AppDelegate to handle foreground notification  
  presentation and action button taps
  - Calls fetchAndStoreNotificationTypes() after Salesforce push registration and on each app foreground
   to keep action button definitions current                                                            
  - Calls invokeServerNotificationAction when the user taps an action button, passing the nid from the
  sfdc payload dictionary (not the top level)                                                           
  - Fixes template.js to include NotificationServiceExtension.entitlements in app name substitution —
  without this, the extension's keychain access group would retain the template name after generation,  
  breaking encrypted notification decryption
                                                                                                        
  Test plan                                                                                             
   
  - Generate an app with forceios createwithtemplate using this template                                
  - Verify NotificationServiceExtension.entitlements contains the generated app name (not
  EncryptedNotificationTemplate)                                                                        
  - Deploy to a physical device, register for push, and confirm action buttons appear on lock screen
  notifications                                                                                         
  - Tap an action button and confirm invokeServerNotificationAction is called