### PR TITLE
Add biometric authentication consumer skills

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -31,9 +31,11 @@ Use the directory/`SKILL.md` format so the `npx skills` CLI can discover and ins
 | `add-mobile-sdk-ios/` | Add Mobile SDK authentication to an existing iOS Swift app |
 | `add-smartstore-ios/` | Add SmartStore (encrypted local database) to an iOS Swift app that already has Mobile SDK |
 | `add-mobilesync-ios/` | Add MobileSync (cloud data sync) to an iOS Swift app that already has SmartStore |
+| `add-biometric-auth-ios/` | Add biometric authentication (Face ID / Touch ID) to an iOS Swift app that already has Mobile SDK |
 | `add-mobile-sdk-android/` | Add Mobile SDK authentication to an existing Android Kotlin app |
 | `add-smartstore-android/` | Add SmartStore (encrypted local database) to an Android Kotlin app that already has Mobile SDK |
 | `add-mobilesync-android/` | Add MobileSync (cloud data sync) to an Android Kotlin app that already has SmartStore |
+| `add-biometric-auth-android/` | Add biometric authentication (fingerprint / face / iris) to an Android Kotlin app that already has Mobile SDK |
 
 ### SDK developer skills (internal)
 

--- a/.claude/skills/add-biometric-auth-android/SKILL.md
+++ b/.claude/skills/add-biometric-auth-android/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: add-biometric-auth-android
+description: Add biometric authentication (fingerprint / face / iris) to an existing Android Kotlin app that already has Salesforce Mobile SDK integrated. Prompts the user to opt in after login and presents the lock screen on return from background.
+---
+
+# Add Biometric Authentication to an Android Kotlin App
+
+This skill adds Salesforce Mobile SDK biometric authentication to an existing Android Kotlin app that already has the Mobile SDK integrated via the `add-mobile-sdk-android` skill.
+
+## What This Skill Does
+
+1. Adds the `androidx.biometric` dependency to `app/build.gradle.kts`
+2. Adds a post-login opt-in prompt to `MainActivity.kt` via `onPostResume()`
+
+The SDK handles all locking, unlocking, and the native biometric prompt (fingerprint / face / iris) automatically once the user opts in. No additional lifecycle code is needed — the SDK wires foreground/background transitions internally when `MobileSyncSDKManager.initNative()` (or a subclass manager) is called.
+
+## What the SDK Does Automatically
+
+- Locks the app after the admin-configured inactivity timeout
+- Presents the OS `BiometricPrompt` when the app returns from background while locked
+- Falls back to username/password on the Salesforce login screen if biometric fails
+- Shows a native "Use Biometrics" button on the login screen (can be suppressed via `enableNativeBiometricLoginButton(false)`)
+
+## Prerequisites
+
+The app must already have the Mobile SDK integrated. **Check `MainApplication.kt` for `MobileSyncSDKManager.initNative()` (or `SmartStoreSDKManager`) and that `bootconfig.xml` exists.** If not, run `add-mobile-sdk-android` first.
+
+The `BiometricAuthenticationManager.enabled` property is `true` only when the Salesforce org's connected app has `ENABLE_BIOMETRIC_AUTHENTICATION` set. In development you may wire the code and test the build — the opt-in dialog will silently not appear if the feature is not configured in the org.
+
+---
+
+## Step 1: Add the androidx.biometric Dependency
+
+In `app/build.gradle.kts`, add the AndroidX Biometric library. This is needed to call `BiometricManager.canAuthenticate()` to check device capability before prompting.
+
+```kotlin
+dependencies {
+    implementation("com.salesforce.mobilesdk:MobileSync:13.2.0")
+    implementation("androidx.biometric:biometric:1.1.0")
+}
+```
+
+Sync Gradle after editing.
+
+---
+
+## Step 2: Update MainActivity.kt
+
+Add `onPostResume()` to check device biometric capability and present the SDK opt-in dialog if needed.
+
+**Add these imports** (at the top of `MainActivity.kt`):
+
+```kotlin
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
+import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager
+```
+
+**Add `onPostResume()`** (after `onResume(client: RestClient?)`):
+
+```kotlin
+override fun onPostResume() {
+    super.onPostResume()
+
+    val deviceHasBiometrics = BiometricManager.from(this).canAuthenticate(
+        BIOMETRIC_STRONG or BIOMETRIC_WEAK
+    ) == BiometricManager.BIOMETRIC_SUCCESS
+
+    MobileSyncSDKManager.getInstance().biometricAuthenticationManager?.run {
+        if (enabled && deviceHasBiometrics && !hasBiometricOptedIn()) {
+            presentOptInDialog(supportFragmentManager)
+        }
+    }
+}
+```
+
+> **`onPostResume()`** fires after `onResume()` and after the activity window is fully visible — the correct lifecycle point to present a dialog. Using `onResume()` or `onResume(client)` can cause the dialog to appear before the window is attached, leading to a crash.
+
+> **`biometricAuthenticationManager`** is a nullable property on `SalesforceSDKManager` (and all subclasses). It is non-null after a user is authenticated. The `?.run { }` block safely no-ops when no user is logged in.
+
+> **`supportFragmentManager`** requires the activity to extend `FragmentActivity` (which `SalesforceActivity` does). If your activity extends plain `Activity`, switch to `AppCompatActivity` or `SalesforceActivity`.
+
+---
+
+## Step 3: Replace SmartStoreSDKManager reference if needed
+
+If your app uses `SmartStoreSDKManager` instead of `MobileSyncSDKManager`, use the same accessor — it is inherited from `SalesforceSDKManager`:
+
+```kotlin
+import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager
+
+SmartStoreSDKManager.getInstance().biometricAuthenticationManager?.run {
+    if (enabled && deviceHasBiometrics && !hasBiometricOptedIn()) {
+        presentOptInDialog(supportFragmentManager)
+    }
+}
+```
+
+---
+
+## Step 4: Build and Verify
+
+```bash
+./gradlew assembleDebug
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+### Runtime verification (emulator or device)
+
+1. Launch the app — Salesforce login screen appears.
+2. Log in — the SDK opt-in dialog appears: **"Use biometrics to unlock?"** with Enable / Use Password buttons.
+3. Tap **Enable** — biometric authentication is now active for this user.
+4. Background the app, wait for the configured timeout (or call `MobileSyncSDKManager.getInstance().biometricAuthenticationManager?.lock()` to force-lock), then foreground — the OS `BiometricPrompt` appears.
+5. Authenticate successfully — the app unlocks without re-entering credentials.
+
+> **Emulator note:** Fingerprint can be enrolled in the emulator via **Extended controls → Fingerprint**. Use `adb -e emu finger touch 1` to simulate a fingerprint scan. The opt-in dialog will still appear even without enrolled biometrics — only the actual scan step requires enrollment.
+
+---
+
+## Checklist
+
+- [ ] `androidx.biometric:biometric:1.1.0` added to `app/build.gradle.kts`
+- [ ] `BiometricManager` imports added to `MainActivity.kt`
+- [ ] `onPostResume()` added with device capability check and `presentOptInDialog()` call
+- [ ] Project builds without errors
+- [ ] Opt-in dialog appears after first login (requires `ENABLE_BIOMETRIC_AUTHENTICATION` on connected app, or feature is enabled)
+- [ ] Biometric prompt appears after app returns from background (enrolled emulator / device)
+
+---
+
+## Optional: Suppress the Native Login Screen Button
+
+By default the SDK shows a **Use Biometrics** button on the Salesforce login screen. To hide it:
+
+```kotlin
+MobileSyncSDKManager.getInstance().biometricAuthenticationManager
+    ?.enableNativeBiometricLoginButton(false)
+```
+
+Call this once after `initNative()` in `MainApplication.onCreate()`.
+
+---
+
+## Troubleshooting
+
+**Opt-in dialog never appears**
+`enabled` is `false` — the connected app in your org does not have `ENABLE_BIOMETRIC_AUTHENTICATION` set. The dialog correctly does not appear. Set the custom attribute on the connected app or temporarily remove the `enabled &&` check during development.
+
+**`IllegalStateException`: Can not perform this action after onSaveInstanceState**
+The dialog is being presented too early in the lifecycle. Ensure you are calling `presentOptInDialog` from `onPostResume()`, not `onResume()`.
+
+**`Unresolved reference: BiometricManager`**
+The `androidx.biometric:biometric` dependency is missing or Gradle sync didn't complete.
+
+**Biometric prompt does not appear after backgrounding**
+The inactivity timeout has not elapsed. Call `MobileSyncSDKManager.getInstance().biometricAuthenticationManager?.lock()` to force-lock immediately for testing.
+
+**`biometricAuthenticationManager` is null**
+No user is currently authenticated. This is expected before login. The `?.run { }` safe-call handles this correctly.

--- a/.claude/skills/add-biometric-auth-ios/SKILL.md
+++ b/.claude/skills/add-biometric-auth-ios/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: add-biometric-auth-ios
+description: Add biometric authentication (Face ID / Touch ID) to an existing iOS Swift app that already has Salesforce Mobile SDK integrated. Prompts the user to opt in after login and presents the lock screen on return from background.
+---
+
+# Add Biometric Authentication to an iOS Swift App
+
+This skill adds Salesforce Mobile SDK biometric authentication to an existing iOS Swift app that already has `SalesforceSDKCore` integrated via the `add-mobile-sdk-ios` skill.
+
+## What This Skill Does
+
+1. Adds `NSFaceIDUsageDescription` to `Info.plist` (required by App Store / iOS for Face ID access)
+2. Adds a `LocalAuthentication` import and a post-login opt-in prompt to `SceneDelegate.swift`
+
+The SDK handles all locking, unlocking, and the native biometric prompt automatically once the user opts in. No additional background/foreground lifecycle code is needed in app code — the SDK wires that up internally when `SalesforceManager.initializeSDK()` (or a subclass) is called.
+
+## What the SDK Does Automatically
+
+- Locks the app after the admin-configured inactivity timeout
+- Presents the OS biometric prompt (Face ID / Touch ID) when the app returns from background while locked
+- Falls back to username/password on the Salesforce login screen if biometric fails
+- Shows a native "Use Biometrics" button on the login screen (can be suppressed via `enableNativeBiometricLoginButton(enabled: false)`)
+
+## Prerequisites
+
+The app must already have the Mobile SDK integrated. **Check `AppDelegate.swift` for `SalesforceManager.initializeSDK()` (or `SmartStoreSDKManager` / `MobileSyncSDKManager`) and that `bootconfig.plist` exists.** If not, run `add-mobile-sdk-ios` first.
+
+Before starting, confirm:
+- **App target name** (e.g. `MyApp`)
+
+The `BiometricAuthenticationManager.enabled` property is `true` only when the Salesforce org's connected app has `ENABLE_BIOMETRIC_AUTHENTICATION` set. In development you may set `enabled` to always be `true` or just wire the code and test the build — the opt-in dialog will silently do nothing if the feature is not configured in the org.
+
+---
+
+## Step 1: Add NSFaceIDUsageDescription to Info.plist
+
+iOS requires a usage description string before any app can use Face ID. Without it the app crashes on Face ID devices at the moment the biometric prompt is shown.
+
+Add to the app target's `Info.plist`:
+
+```xml
+<key>NSFaceIDUsageDescription</key>
+<string>Use Face ID to unlock the app.</string>
+```
+
+If the project uses `xcodegen` and a `project.yml`, add it under the target's `info.properties` block:
+
+```yaml
+NSFaceIDUsageDescription: Use Face ID to unlock the app.
+```
+
+Then regenerate: `xcodegen generate`.
+
+---
+
+## Step 2: Update SceneDelegate.swift
+
+Add `LocalAuthentication` import and call `presentOptInDialog` after login inside `setupRootViewController()`.
+
+**Before:**
+```swift
+import UIKit
+import SalesforceSDKCore   // or SmartStore / MobileSync
+
+// ...
+
+func setupRootViewController() {
+    // ... your post-login UI setup
+}
+```
+
+**After:**
+```swift
+import UIKit
+import LocalAuthentication
+import SalesforceSDKCore   // or SmartStore / MobileSync — keep whichever is already there
+
+// ...
+
+func setupRootViewController() {
+    // Prompt for biometric opt-in after login if the feature is enabled
+    // and the user hasn't opted in yet.
+    let laContext = LAContext()
+    var laError: NSError?
+    let deviceHasBiometrics = laContext.canEvaluatePolicy(
+        .deviceOwnerAuthenticationWithBiometrics,
+        error: &laError
+    )
+
+    let bioManager = BiometricAuthenticationManagerInternal.shared
+    if bioManager.enabled && deviceHasBiometrics && !bioManager.hasBiometricOptedIn() {
+        if let vc = window?.rootViewController {
+            bioManager.presentOptInDialog(viewController: vc)
+        }
+    }
+
+    // ... your post-login UI setup (keep existing code below this block)
+}
+```
+
+> **`BiometricAuthenticationManagerInternal.shared`** is the concrete singleton that implements the `BiometricAuthenticationManager` protocol. It lives in `SalesforceSDKCore`. No additional import beyond `SalesforceSDKCore` (or its subframework) is needed.
+
+> **When to call `presentOptInDialog`**: Call it every time `setupRootViewController()` runs. The `hasBiometricOptedIn()` guard ensures it only shows once per user. If you already show it and they dismiss without choosing, it will reappear next session — that is correct behaviour.
+
+---
+
+## Step 3: Build and Verify
+
+```bash
+# CocoaPods
+xcodebuild -workspace <AppName>.xcworkspace \
+  -scheme <AppName> \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,id=<SimulatorUDID>' \
+  build
+```
+
+Expected: `** BUILD SUCCEEDED **`
+
+### Runtime verification (device or simulator)
+
+1. Launch the app — Salesforce login screen appears.
+2. Log in — the SDK opt-in dialog appears: **"Use Biometrics to unlock?"** with Enable / Skip buttons.
+3. Tap **Enable** — Face ID / Touch ID is now active for this user.
+4. Background the app, wait for the configured timeout (or call `BiometricAuthenticationManagerInternal.shared.lock()` to force-lock), then foreground — the OS biometric prompt appears.
+5. Authenticate successfully — the app unlocks without re-entering credentials.
+
+> **Simulator note:** Face ID is available in the simulator via **Features → Face ID → Enrolled**. Touch ID is available on older simulators. Biometric prompts can be triggered via **Features → Face ID → Matching Face** (or Trigger Face ID). The opt-in dialog will still appear and can be tapped even on simulators without biometric hardware — only the actual biometric scan step will be skipped.
+
+---
+
+## Checklist
+
+- [ ] `NSFaceIDUsageDescription` added to `Info.plist`
+- [ ] `import LocalAuthentication` added to `SceneDelegate.swift`
+- [ ] `BiometricAuthenticationManagerInternal.shared` opt-in check added in `setupRootViewController()`
+- [ ] Project builds without errors
+- [ ] Opt-in dialog appears after first login
+- [ ] Biometric prompt appears after app returns from background (device / enrolled simulator)
+
+---
+
+## Optional: Suppress the Native Login Screen Button
+
+By default the SDK shows a **Use Biometrics** button on the Salesforce login screen. To hide it (e.g. you want to control the UX entirely from your own UI):
+
+```swift
+BiometricAuthenticationManagerInternal.shared.enableNativeBiometricLoginButton(enabled: false)
+```
+
+Call this once during app startup, before the login screen is shown — `AppDelegate.init()` is a good place.
+
+---
+
+## Troubleshooting
+
+**Build error: `Cannot find type 'BiometricAuthenticationManagerInternal'`**
+`SalesforceSDKCore` is not linked or the import is missing. Verify `pod install` completed and you opened `.xcworkspace`.
+
+**Opt-in dialog never appears**
+`bioManager.enabled` is `false` — the connected app in your org does not have `ENABLE_BIOMETRIC_AUTHENTICATION` set to `true`. The dialog correctly does not appear. Set the custom attribute on the connected app or temporarily bypass the `enabled` check during development.
+
+**`NSFaceIDUsageDescription` crash**
+The key is missing from `Info.plist`. This crash happens at the OS level when Face ID is triggered — add the key as described in Step 1.
+
+**Biometric prompt does not appear after backgrounding**
+The inactivity timeout has not elapsed. Either wait for the configured timeout, or call `BiometricAuthenticationManagerInternal.shared.lock()` programmatically to force-lock the app immediately for testing.

--- a/.claude/skills/add-biometric-auth-ios/SKILL.md
+++ b/.claude/skills/add-biometric-auth-ios/SKILL.md
@@ -87,7 +87,7 @@ func setupRootViewController() {
         error: &laError
     )
 
-    let bioManager = BiometricAuthenticationManagerInternal.shared
+    let bioManager = SalesforceManager.shared.biometricAuthenticationManager()
     if bioManager.enabled && deviceHasBiometrics && !bioManager.hasBiometricOptedIn() {
         if let vc = window?.rootViewController {
             bioManager.presentOptInDialog(viewController: vc)
@@ -98,7 +98,7 @@ func setupRootViewController() {
 }
 ```
 
-> **`BiometricAuthenticationManagerInternal.shared`** is the concrete singleton that implements the `BiometricAuthenticationManager` protocol. It lives in `SalesforceSDKCore`. No additional import beyond `SalesforceSDKCore` (or its subframework) is needed.
+> **`SalesforceManager.shared.biometricAuthenticationManager()`** returns the biometric authentication manager instance that conforms to the `BiometricAuthenticationManager` protocol. It lives in `SalesforceSDKCore`. No additional import beyond `SalesforceSDKCore` (or its subframework) is needed.
 
 > **When to call `presentOptInDialog`**: Call it every time `setupRootViewController()` runs. The `hasBiometricOptedIn()` guard ensures it only shows once per user. If you already show it and they dismiss without choosing, it will reappear next session — that is correct behaviour.
 
@@ -133,7 +133,7 @@ Expected: `** BUILD SUCCEEDED **`
 
 - [ ] `NSFaceIDUsageDescription` added to `Info.plist`
 - [ ] `import LocalAuthentication` added to `SceneDelegate.swift`
-- [ ] `BiometricAuthenticationManagerInternal.shared` opt-in check added in `setupRootViewController()`
+- [ ] `SalesforceManager.shared.biometricAuthenticationManager()` opt-in check added in `setupRootViewController()`
 - [ ] Project builds without errors
 - [ ] Opt-in dialog appears after first login
 - [ ] Biometric prompt appears after app returns from background (device / enrolled simulator)
@@ -145,7 +145,7 @@ Expected: `** BUILD SUCCEEDED **`
 By default the SDK shows a **Use Biometrics** button on the Salesforce login screen. To hide it (e.g. you want to control the UX entirely from your own UI):
 
 ```swift
-BiometricAuthenticationManagerInternal.shared.enableNativeBiometricLoginButton(enabled: false)
+SalesforceManager.shared.biometricAuthenticationManager().enableNativeBiometricLoginButton(enabled: false)
 ```
 
 Call this once during app startup, before the login screen is shown — `AppDelegate.init()` is a good place.
@@ -154,7 +154,7 @@ Call this once during app startup, before the login screen is shown — `AppDele
 
 ## Troubleshooting
 
-**Build error: `Cannot find type 'BiometricAuthenticationManagerInternal'`**
+**Build error: `Value of type 'SalesforceSDKManager' has no member 'biometricAuthenticationManager'`**
 `SalesforceSDKCore` is not linked or the import is missing. Verify `pod install` completed and you opened `.xcworkspace`.
 
 **Opt-in dialog never appears**
@@ -164,4 +164,4 @@ Call this once during app startup, before the login screen is shown — `AppDele
 The key is missing from `Info.plist`. This crash happens at the OS level when Face ID is triggered — add the key as described in Step 1.
 
 **Biometric prompt does not appear after backgrounding**
-The inactivity timeout has not elapsed. Either wait for the configured timeout, or call `BiometricAuthenticationManagerInternal.shared.lock()` programmatically to force-lock the app immediately for testing.
+The inactivity timeout has not elapsed. Either wait for the configured timeout, or call `SalesforceManager.shared.biometricAuthenticationManager().lock()` programmatically to force-lock the app immediately for testing.

--- a/.claude/skills/test-sdk-consumer-skills/SKILL.md
+++ b/.claude/skills/test-sdk-consumer-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-sdk-consumer-skills
-description: End-to-end test harness for all SDK consumer skills. Creates 8 apps (4 iOS, 4 Android) in parallel, one per consumer skill, builds each, and reports results.
+description: End-to-end test harness for all SDK consumer skills. Creates 10 apps (5 iOS, 5 Android) in parallel, one per consumer skill, builds each, and reports results.
 metadata:
   internal: true
 ---
@@ -17,10 +17,12 @@ End-to-end test harness that exercises every consumer skill by creating a fresh 
 | 2 | `SkillTest_iOS_SDK` | iOS (CocoaPods) | `add-mobile-sdk-ios` |
 | 3 | `SkillTest_iOS_SmartStore` | iOS (CocoaPods) | `add-mobile-sdk-ios` + `add-smartstore-ios` |
 | 4 | `SkillTest_iOS_MobileSync` | iOS (CocoaPods) | `add-mobile-sdk-ios` + `add-smartstore-ios` + `add-mobilesync-ios` |
-| 5 | `SkillTest_Android_Full` | Android (Gradle) | `create-android-app-with-mobile-sdk` |
-| 6 | `SkillTest_Android_SDK` | Android (Gradle) | `add-mobile-sdk-android` |
-| 7 | `SkillTest_Android_SmartStore` | Android (Gradle) | `add-mobile-sdk-android` + `add-smartstore-android` |
-| 8 | `SkillTest_Android_MobileSync` | Android (Gradle) | `add-mobile-sdk-android` + `add-smartstore-android` + `add-mobilesync-android` |
+| 5 | `SkillTest_iOS_Biometric` | iOS (CocoaPods) | `add-mobile-sdk-ios` + `add-biometric-auth-ios` |
+| 6 | `SkillTest_Android_Full` | Android (Gradle) | `create-android-app-with-mobile-sdk` |
+| 7 | `SkillTest_Android_SDK` | Android (Gradle) | `add-mobile-sdk-android` |
+| 8 | `SkillTest_Android_SmartStore` | Android (Gradle) | `add-mobile-sdk-android` + `add-smartstore-android` |
+| 9 | `SkillTest_Android_MobileSync` | Android (Gradle) | `add-mobile-sdk-android` + `add-smartstore-android` + `add-mobilesync-android` |
+| 10 | `SkillTest_Android_Biometric` | Android (Gradle) | `add-mobile-sdk-android` + `add-biometric-auth-android` |
 
 ## Prerequisites
 
@@ -37,7 +39,7 @@ which xcodegen && which pod && echo $ANDROID_HOME && java -version
 
 ## Step 1: Choose an Output Directory
 
-All 8 apps are created under a single parent directory. Default: `/tmp/SdkSkillsTest_<timestamp>`.
+All 10 apps are created under a single parent directory. Default: `/tmp/SdkSkillsTest_<timestamp>`.
 
 ```bash
 BASE=/tmp/SdkSkillsTest_$(date +%Y%m%d_%H%M%S)
@@ -297,7 +299,14 @@ The `create-ios-app-with-mobile-sdk` skill handles scaffolding + SDK wiring in o
 4. Apply `add-mobilesync-ios` (soup: `Item`, sObject: `Contact`)
 5. `pod install`
 
-### App 5 — Android Full (create-android-app-with-mobile-sdk)
+### App 5 — iOS Biometric (add-mobile-sdk-ios → add-biometric-auth-ios)
+
+1. Run `scaffold_ios SkillTest_iOS_Biometric com.skilltest.ios.biometric $BASE`
+2. Apply `add-mobile-sdk-ios` (CocoaPods path, placeholders for OAuth)
+3. Apply `add-biometric-auth-ios`
+4. `pod install`
+
+### App 6 — Android Full (create-android-app-with-mobile-sdk)
 
 The `create-android-app-with-mobile-sdk` skill handles scaffolding + SDK wiring. Invoke it with:
 - App name: `SkillTest_Android_Full`
@@ -305,21 +314,26 @@ The `create-android-app-with-mobile-sdk` skill handles scaffolding + SDK wiring.
 - Output directory: `$BASE`
 - Consumer key / callback URL / login host: leave as placeholders
 
-### App 6 — Android SDK only (add-mobile-sdk-android)
+### App 7 — Android SDK only (add-mobile-sdk-android)
 
 1. Run `scaffold_android SkillTest_Android_SDK com.skilltest.android.sdk $BASE`
 2. App is fully wired by the scaffold (the scaffold already includes the SDK wiring from `add-mobile-sdk-android`)
 
-### App 7 — Android SmartStore (add-mobile-sdk-android → add-smartstore-android)
+### App 8 — Android SmartStore (add-mobile-sdk-android → add-smartstore-android)
 
 1. Run `scaffold_android SkillTest_Android_SmartStore com.skilltest.android.smartstore $BASE`
 2. Apply `add-smartstore-android` (soup name: `Item`)
 
-### App 8 — Android MobileSync (add-mobile-sdk-android → add-smartstore-android → add-mobilesync-android)
+### App 9 — Android MobileSync (add-mobile-sdk-android → add-smartstore-android → add-mobilesync-android)
 
 1. Run `scaffold_android SkillTest_Android_MobileSync com.skilltest.android.mobilesync $BASE`
 2. Apply `add-smartstore-android` (soup name: `Item`)
 3. Apply `add-mobilesync-android` (soup: `Item`, sObject: `Contact`)
+
+### App 10 — Android Biometric (add-mobile-sdk-android → add-biometric-auth-android)
+
+1. Run `scaffold_android SkillTest_Android_Biometric com.skilltest.android.biometric $BASE`
+2. Apply `add-biometric-auth-android`
 
 ## Step 4: Build All Apps
 
@@ -336,7 +350,7 @@ echo "Using simulator: $SIM_ID"
 Then build:
 
 ```bash
-for APP in SkillTest_iOS_Full SkillTest_iOS_SDK SkillTest_iOS_SmartStore SkillTest_iOS_MobileSync; do
+for APP in SkillTest_iOS_Full SkillTest_iOS_SDK SkillTest_iOS_SmartStore SkillTest_iOS_MobileSync SkillTest_iOS_Biometric; do
   (
     cd "$BASE/$APP"
     xcodebuild \
@@ -356,7 +370,7 @@ wait
 ### Android builds (run in parallel)
 
 ```bash
-for APP in SkillTest_Android_Full SkillTest_Android_SDK SkillTest_Android_SmartStore SkillTest_Android_MobileSync; do
+for APP in SkillTest_Android_Full SkillTest_Android_SDK SkillTest_Android_SmartStore SkillTest_Android_MobileSync SkillTest_Android_Biometric; do
   (
     cd "$BASE/$APP"
     ./gradlew assembleDebug \
@@ -370,19 +384,19 @@ wait
 
 ## Step 5: Report Results
 
-Print a summary and the locations of all 8 apps:
+Print a summary and the locations of all 10 apps:
 
 ```bash
 echo ""
 echo "=== SDK Consumer Skills Test Results ==="
 echo ""
 echo "iOS apps (open .xcworkspace in Xcode to run on simulator):"
-for APP in SkillTest_iOS_Full SkillTest_iOS_SDK SkillTest_iOS_SmartStore SkillTest_iOS_MobileSync; do
+for APP in SkillTest_iOS_Full SkillTest_iOS_SDK SkillTest_iOS_SmartStore SkillTest_iOS_MobileSync SkillTest_iOS_Biometric; do
   echo "  $BASE/$APP/${APP}.xcworkspace"
 done
 echo ""
 echo "Android apps (open directory in Android Studio to run on emulator):"
-for APP in SkillTest_Android_Full SkillTest_Android_SDK SkillTest_Android_SmartStore SkillTest_Android_MobileSync; do
+for APP in SkillTest_Android_Full SkillTest_Android_SDK SkillTest_Android_SmartStore SkillTest_Android_MobileSync SkillTest_Android_Biometric; do
   echo "  $BASE/$APP"
 done
 echo ""
@@ -399,10 +413,12 @@ For each app, open it in Xcode / Android Studio and run it on a simulator/emulat
 | `SkillTest_iOS_SDK` | Same as above |
 | `SkillTest_iOS_SmartStore` | Salesforce login screen; "SmartStore ready" after login |
 | `SkillTest_iOS_MobileSync` | Salesforce login screen; "SmartStore + MobileSync ready" after login |
+| `SkillTest_iOS_Biometric` | Salesforce login screen; biometric opt-in dialog after login |
 | `SkillTest_Android_Full` | Salesforce login screen on first launch; "Mobile SDK ready" after login |
 | `SkillTest_Android_SDK` | Same as above |
 | `SkillTest_Android_SmartStore` | Salesforce login screen; "SmartStore ready" after login |
 | `SkillTest_Android_MobileSync` | Salesforce login screen; "SmartStore + MobileSync ready" after login |
+| `SkillTest_Android_Biometric` | Salesforce login screen; biometric opt-in dialog after login |
 
 ## Troubleshooting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -612,6 +612,8 @@ Available consumer skills:
 - `add-smartstore-android` - Add SmartStore to an Android app
 - `add-mobilesync-ios` - Add MobileSync (cloud data sync) to an iOS app
 - `add-mobilesync-android` - Add MobileSync to an Android app
+- `add-biometric-auth-ios` - Add biometric authentication (Face ID / Touch ID) to an iOS app
+- `add-biometric-auth-android` - Add biometric authentication (fingerprint / face / iris) to an Android app
 
 ### SDK Developer Skills (Internal)
 


### PR DESCRIPTION
## Summary
Add two new consumer skills for integrating biometric authentication into Mobile SDK apps, covering both iOS (Face ID / Touch ID) and Android (fingerprint / face / iris).

## Changes
- **New skill: `add-biometric-auth-ios`**
  - Adds `NSFaceIDUsageDescription` to Info.plist
  - Imports `LocalAuthentication` framework
  - Adds biometric opt-in dialog via `BiometricAuthenticationManagerInternal` in `setupRootViewController()`
  
- **New skill: `add-biometric-auth-android`**
  - Adds `androidx.biometric:biometric` dependency to build.gradle
  - Adds biometric opt-in dialog in `onPostResume()` via `MobileSyncSDKManager.biometricAuthenticationManager`

- **Documentation updates**
  - Added both skills to `.claude/skills/README.md`
  - Added both skills to `CLAUDE.md` skills section
  
- **Testing infrastructure**
  - Updated `test-sdk-consumer-skills` to test all 10 consumer skills
  - Adds `SkillTest_iOS_Biometric` (App 5)
  - Adds `SkillTest_Android_Biometric` (App 10)
  - Renumbers Android test apps accordingly

## Test plan
- [x] Verified skills README is in sync with actual skills (10 consumer + 4 internal)
- [x] Verified CLAUDE.md documents all consumer skills
- [x] Both skills follow the established pattern of iOS/Android consumer skills
- [ ] End-to-end testing with `test-sdk-consumer-skills` skill (creates 10 apps, builds all in parallel)