### PR TITLE
Add comprehensive React Native templates documentation

### DIFF
--- a/docs/react-native-templates/MobileSyncExplorerReactNative.md
+++ b/docs/react-native-templates/MobileSyncExplorerReactNative.md
@@ -2,6 +2,8 @@
 
 The complete sample application demonstrating offline data synchronization with the Salesforce Mobile SDK.
 
+> **API style note:** The `react-native-force` SDK uses callback-based APIs (`fn(args, successCallback, errorCallback)`). Promise-style code in this guide is illustrative; use `forceUtil.promiser(fn)` for actual promise wrappers. This sample also depends on `react-native-elements` and `react-native-vector-icons` (not present in other React Native templates).
+
 ## Overview
 
 `MobileSyncExplorerReactNative` is a **full-featured reference application** that showcases best practices for building offline-first mobile apps with React Native and Salesforce Mobile SDK.

--- a/docs/react-native-templates/MobileSyncExplorerReactNative.md
+++ b/docs/react-native-templates/MobileSyncExplorerReactNative.md
@@ -1,0 +1,878 @@
+# MobileSyncExplorerReactNative
+
+The complete sample application demonstrating offline data synchronization with the Salesforce Mobile SDK.
+
+## Overview
+
+`MobileSyncExplorerReactNative` is a **full-featured reference application** that showcases best practices for building offline-first mobile apps with React Native and Salesforce Mobile SDK.
+
+Key features:
+
+- **Complete CRUD operations** (Create, Read, Update, Delete) for Contacts
+- **Offline data storage** with SmartStore
+- **Bidirectional sync** with MobileSync (download and upload)
+- **Conflict resolution** for concurrent edits
+- **Search functionality** with full-text search
+- **Real-world UI patterns** with React Navigation
+- **Event-driven architecture** for sync state management
+- **Production-ready code structure**
+
+## When to Use This Template
+
+**Use MobileSyncExplorerReactNative if:**
+
+- You're learning the Mobile SDK and want a complete example
+- You need to understand offline data synchronization
+- You're building an offline-first application
+- You want to see best practices for CRUD operations
+- You need a reference for SmartStore and MobileSync usage
+
+**Don't use as a starting point if:**
+
+- You're starting a new app from scratch → Use [ReactNativeTemplate](./ReactNativeTemplate.md)
+- You don't need offline sync → Use [ReactNativeTemplate](./ReactNativeTemplate.md)
+- You want a minimal template → This is a full sample app, not a minimal template
+
+## Creating the Sample App
+
+```bash
+forcereact create \
+  --appname MobileSyncExplorer \
+  --packagename com.mycompany.mobilesyncexplorer \
+  --organization "My Company" \
+  --templatename MobileSyncExplorerReactNative
+```
+
+## What This Sample Demonstrates
+
+### 1. Offline-First Architecture
+
+```mermaid
+flowchart LR
+    A[React Native UI] --> B[StoreMgr]
+    B --> C{Data Source}
+    
+    C -->|Offline| D[SmartStore]
+    C -->|Online| E[MobileSync]
+    
+    E --> F[Salesforce REST API]
+    E --> D
+    
+    D --> B
+    F --> E
+```
+
+### 2. Sync Operations
+
+| Operation | Description | When to Use |
+|-----------|-------------|-------------|
+| **syncDown** | Download records from Salesforce to SmartStore | Initial load, refresh data |
+| **syncUp** | Upload local changes to Salesforce | Save offline edits |
+| **reSync** | Re-run previous syncDown | Pull latest changes |
+
+### 3. CRUD Workflow
+
+```mermaid
+sequenceDiagram
+    participant UI as React UI
+    participant Store as StoreMgr
+    participant SS as SmartStore
+    participant Sync as MobileSync
+    participant SF as Salesforce
+
+    UI->>Store: Create Contact
+    Store->>SS: upsertSoupEntries (mark as __locally_created__)
+    Store-->>UI: Contact saved locally
+    
+    UI->>Store: syncUp()
+    Store->>Sync: syncUp()
+    Sync->>SS: Get locally modified records
+    SS-->>Sync: Return dirty records
+    Sync->>SF: Create/Update/Delete records
+    SF-->>Sync: Success
+    Sync->>SS: Update records, clear dirty flags
+    Sync-->>Store: Sync complete
+    Store-->>UI: Update UI
+```
+
+## Project Structure
+
+```
+MobileSyncExplorerReactNative/
+├── package.json                 # Dependencies and SDK references
+├── index.js                     # React Native entry point
+├── metro.config.js              # Metro bundler configuration
+├── babel.config.js              # Babel configuration
+├── js/                          # JavaScript source code
+│   ├── App.js                   # Main application component
+│   ├── SearchScreen.js          # Contact list and search
+│   ├── ContactScreen.js         # Contact detail and edit
+│   ├── StoreMgr.js              # SmartStore and MobileSync manager
+│   ├── events.js                # Event emitter for state management
+│   ├── ContactCell.js           # Contact list item component
+│   ├── ContactBadge.js          # Contact avatar component
+│   ├── Field.js                 # Form field component
+│   ├── NavImgButton.js          # Navigation button component
+│   └── Styles.js                # Shared styles
+├── ios/                         # iOS native project
+└── android/                     # Android native project
+```
+
+## Key Files
+
+### js/App.js
+
+Main application component with navigation setup.
+
+```javascript
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import SearchScreen from './SearchScreen';
+import ContactScreen from './ContactScreen';
+
+const Stack = createStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Search">
+        <Stack.Screen 
+          name="Search" 
+          component={SearchScreen}
+          options={{ title: 'Mobile Sync Explorer' }}
+        />
+        <Stack.Screen 
+          name="Contact" 
+          component={ContactScreen}
+          options={{ title: 'Contact Details' }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+```
+
+### js/StoreMgr.js
+
+The heart of the application - manages SmartStore and MobileSync operations.
+
+**Key functions:**
+
+```javascript
+// Register SmartStore soup (table)
+function firstTimeSyncData() {
+    return registerSoup(false, 'contacts', [
+        { path: 'Id', type: 'string' },
+        { path: 'FirstName', type: 'full_text' },
+        { path: 'LastName', type: 'full_text' },
+        { path: '__local__', type: 'string' }
+    ]);
+}
+
+// Download contacts from Salesforce
+function syncDownContacts() {
+    const fieldlist = ['Id', 'FirstName', 'LastName', 'Title', 'Email', 
+                       'MobilePhone', 'Department', 'LastModifiedDate'];
+    const target = {
+        type: 'soql',
+        query: `SELECT ${fieldlist.join(',')} FROM Contact LIMIT 10000`
+    };
+    
+    return syncDown(
+        false,              // isGlobalStore
+        target,             // sync target
+        'contacts',         // soupName
+        { mergeMode: mobilesync.MERGE_MODE.OVERWRITE },
+        'mobileSyncExplorerSyncDown' // syncName
+    );
+}
+
+// Upload local changes to Salesforce
+function syncUpContacts() {
+    const fieldlist = ['FirstName', 'LastName', 'Title', 'Email', 
+                       'MobilePhone', 'Department'];
+    
+    return syncUp(
+        false,              // isGlobalStore
+        {},                 // options
+        'contacts',         // soupName
+        { 
+            mergeMode: mobilesync.MERGE_MODE.OVERWRITE,
+            fieldlist: fieldlist
+        }
+    );
+}
+
+// Search contacts locally
+function searchContacts(query) {
+    const querySpec = query
+        ? { // Full-text search
+            queryType: 'match',
+            indexPath: 'LastName',
+            matchKey: query,
+            order: 'ascending',
+            pageSize: 100
+          }
+        : { // Get all contacts
+            queryType: 'range',
+            indexPath: 'LastName',
+            order: 'ascending',
+            pageSize: 100
+          };
+    
+    return smartstore.querySoup(false, 'contacts', querySpec);
+}
+
+// Save contact locally (marks as dirty for sync)
+function saveContact(contact) {
+    contact.__local__ = true;
+    contact.__locally_created__ = !contact.Id;
+    contact.__locally_updated__ = !!contact.Id;
+    contact.__locally_deleted__ = false;
+    
+    return smartstore.upsertSoupEntries(false, 'contacts', [contact]);
+}
+
+// Delete contact locally (marks as dirty for sync)
+function deleteContact(contact) {
+    if (contact.__locally_created__) {
+        // Never synced to server, just remove from local store
+        return smartstore.removeSoupEntries(false, 'contacts', [contact._soupEntryId]);
+    } else {
+        // Mark for deletion on next sync
+        contact.__local__ = true;
+        contact.__locally_deleted__ = true;
+        return smartstore.upsertSoupEntries(false, 'contacts', [contact]);
+    }
+}
+```
+
+**Event-driven state management:**
+
+```javascript
+const eventEmitter = new EventEmitter();
+const SMARTSTORE_CHANGED = 'smartstoreChanged';
+
+function emitSmartStoreChanged() {
+    eventEmitter.emit(SMARTSTORE_CHANGED, {});
+}
+
+// Components subscribe to changes
+StoreMgr.addStoreChangeListener((event) => {
+    this.fetchData();
+});
+```
+
+### js/SearchScreen.js
+
+Contact list with search functionality.
+
+**Key features:**
+
+- Full-text search across FirstName and LastName
+- Pull-to-refresh (triggers syncDown)
+- Sync status indicator
+- Navigate to contact details
+
+```javascript
+export default class SearchScreen extends React.Component {
+  state = {
+    contacts: [],
+    searchText: '',
+    syncing: false
+  };
+
+  componentDidMount() {
+    StoreMgr.addStoreChangeListener(this.onStoreChange);
+    this.fetchData();
+  }
+
+  componentWillUnmount() {
+    StoreMgr.removeStoreChangeListener(this.onStoreChange);
+  }
+
+  onStoreChange = () => {
+    this.fetchData();
+  }
+
+  fetchData = () => {
+    StoreMgr.searchContacts(this.state.searchText)
+      .then(result => {
+        this.setState({ contacts: result.currentPageOrderedEntries });
+      });
+  }
+
+  syncDown = () => {
+    this.setState({ syncing: true });
+    StoreMgr.syncDownContacts()
+      .then(() => {
+        this.setState({ syncing: false });
+        this.fetchData();
+      });
+  }
+
+  render() {
+    return (
+      <View>
+        <SearchBar
+          value={this.state.searchText}
+          onChangeText={text => {
+            this.setState({ searchText: text });
+            this.fetchData();
+          }}
+        />
+        
+        <FlatList
+          data={this.state.contacts}
+          keyExtractor={item => item._soupEntryId.toString()}
+          renderItem={({ item }) => (
+            <ContactCell
+              contact={item}
+              onPress={() => this.props.navigation.navigate('Contact', { contact: item })}
+            />
+          )}
+          refreshing={this.state.syncing}
+          onRefresh={this.syncDown}
+        />
+      </View>
+    );
+  }
+}
+```
+
+### js/ContactScreen.js
+
+Contact detail and edit screen.
+
+**Key features:**
+
+- View contact details
+- Edit mode with inline forms
+- Save changes locally (automatically marked as dirty)
+- Delete contact
+- Visual indicators for local changes
+
+```javascript
+export default class ContactScreen extends React.Component {
+  state = {
+    contact: this.props.route.params.contact,
+    editing: false
+  };
+
+  save = () => {
+    StoreMgr.saveContact(this.state.contact)
+      .then(() => {
+        this.setState({ editing: false });
+        // Trigger sync to upload changes
+        StoreMgr.syncUpContacts();
+      });
+  }
+
+  delete = () => {
+    Alert.alert(
+      'Delete Contact',
+      'Are you sure?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Delete', style: 'destructive', onPress: () => {
+          StoreMgr.deleteContact(this.state.contact)
+            .then(() => {
+              this.props.navigation.goBack();
+              // Trigger sync to delete on server
+              StoreMgr.syncUpContacts();
+            });
+        }}
+      ]
+    );
+  }
+
+  render() {
+    const { contact, editing } = this.state;
+
+    return (
+      <ScrollView>
+        <ContactBadge name={`${contact.FirstName} ${contact.LastName}`} />
+        
+        {/* Show local change indicators */}
+        {contact.__locally_created__ && <Badge>New (not synced)</Badge>}
+        {contact.__locally_updated__ && <Badge>Modified (not synced)</Badge>}
+        {contact.__locally_deleted__ && <Badge>Deleted (not synced)</Badge>}
+
+        {editing ? (
+          <View>
+            <Field
+              label="First Name"
+              value={contact.FirstName}
+              onChangeText={text => this.setState({ 
+                contact: { ...contact, FirstName: text }
+              })}
+            />
+            <Field
+              label="Last Name"
+              value={contact.LastName}
+              onChangeText={text => this.setState({ 
+                contact: { ...contact, LastName: text }
+              })}
+            />
+            {/* More fields... */}
+            
+            <Button title="Save" onPress={this.save} />
+            <Button title="Cancel" onPress={() => this.setState({ editing: false })} />
+          </View>
+        ) : (
+          <View>
+            <Text>Name: {contact.FirstName} {contact.LastName}</Text>
+            <Text>Title: {contact.Title}</Text>
+            <Text>Email: {contact.Email}</Text>
+            {/* More fields... */}
+            
+            <Button title="Edit" onPress={() => this.setState({ editing: true })} />
+            <Button title="Delete" onPress={this.delete} color="red" />
+          </View>
+        )}
+      </ScrollView>
+    );
+  }
+}
+```
+
+## SmartStore Concepts
+
+### Soups (Tables)
+
+SmartStore stores data in "soups" (similar to tables in a database).
+
+**Register a soup:**
+
+```javascript
+smartstore.registerSoup(
+  false,           // isGlobalStore (false = user-specific, true = shared)
+  'contacts',      // soupName
+  [                // indexes for efficient queries
+    { path: 'Id', type: 'string' },
+    { path: 'FirstName', type: 'full_text' },  // Full-text search
+    { path: 'LastName', type: 'full_text' },
+    { path: '__local__', type: 'string' }      // Local change flag
+  ]
+);
+```
+
+**Index types:**
+
+- `string` - Exact match queries
+- `integer` - Numeric queries
+- `floating` - Decimal queries
+- `full_text` - Full-text search (supports partial matches)
+- `json1` - JSON column queries
+
+### Soup Entries
+
+Each entry in a soup has:
+
+- User fields (e.g., `Id`, `FirstName`, `LastName`)
+- `_soupEntryId` - Unique local ID (auto-assigned)
+- `_soupLastModifiedDate` - Last modification timestamp
+
+**MobileSync adds these fields:**
+
+- `__local__` - Entry has local changes
+- `__locally_created__` - Entry created locally
+- `__locally_updated__` - Entry updated locally
+- `__locally_deleted__` - Entry deleted locally
+
+### Query Types
+
+```javascript
+// 1. Exact match
+smartstore.querySoup(false, 'contacts', {
+  queryType: 'exact',
+  indexPath: 'Id',
+  matchKey: '003xx000003DGb0'
+});
+
+// 2. Range query (all contacts, alphabetically)
+smartstore.querySoup(false, 'contacts', {
+  queryType: 'range',
+  indexPath: 'LastName',
+  order: 'ascending',
+  pageSize: 100
+});
+
+// 3. Like query (SQL LIKE)
+smartstore.querySoup(false, 'contacts', {
+  queryType: 'like',
+  indexPath: 'LastName',
+  likeKey: 'Smith%',
+  order: 'ascending'
+});
+
+// 4. Full-text search
+smartstore.querySoup(false, 'contacts', {
+  queryType: 'match',
+  indexPath: 'LastName',  // Must be full_text index
+  matchKey: 'john',       // Matches "John", "Johnny", "Johnson"
+  order: 'ascending'
+});
+
+// 5. Smart SQL (raw SQL query)
+smartstore.querySoup(false, 'contacts', {
+  queryType: 'smart',
+  smartSql: `SELECT {contacts:FirstName}, {contacts:LastName} 
+             FROM {contacts} 
+             WHERE {contacts:Title} = 'VP' 
+             ORDER BY {contacts:LastName}`
+});
+```
+
+## MobileSync Concepts
+
+### Sync Targets
+
+Define what data to sync:
+
+```javascript
+// SOQL query target
+const target = {
+  type: 'soql',
+  query: 'SELECT Id, Name, Email FROM Contact LIMIT 10000'
+};
+
+// SOSL search target
+const target = {
+  type: 'sosl',
+  query: 'FIND {John} IN NAME FIELDS RETURNING Contact(Id, Name, Email)'
+};
+
+// MRU (Most Recently Used) target
+const target = {
+  type: 'mru',
+  sobjectType: 'Contact',
+  fieldlist: ['Id', 'Name', 'Email']
+};
+```
+
+### Merge Modes
+
+Control how server data merges with local data:
+
+```javascript
+// OVERWRITE - Server data always wins
+syncDown(false, target, 'contacts', { 
+  mergeMode: mobilesync.MERGE_MODE.OVERWRITE 
+}, syncName);
+
+// LEAVE_IF_CHANGED - Keep local changes, don't overwrite
+syncDown(false, target, 'contacts', { 
+  mergeMode: mobilesync.MERGE_MODE.LEAVE_IF_CHANGED 
+}, syncName);
+```
+
+### Sync Status
+
+Check sync progress:
+
+```javascript
+mobilesync.getSyncStatus(false, syncName)
+  .then(syncStatus => {
+    console.log('Status:', syncStatus.status);  // NEW, RUNNING, DONE, FAILED
+    console.log('Progress:', syncStatus.progress);  // 0-100
+    console.log('Total Size:', syncStatus.totalSize);
+  });
+```
+
+## Offline-First Workflow
+
+### Initial Setup
+
+```mermaid
+flowchart TD
+    A[App Launch] --> B{SmartStore initialized?}
+    B -->|No| C[Register soups]
+    B -->|Yes| D[Check for existing data]
+    C --> E[First-time syncDown]
+    D --> F{Data exists?}
+    F -->|No| E
+    F -->|Yes| G[Load from SmartStore]
+    E --> G
+    G --> H[Display UI]
+```
+
+### User Makes Changes
+
+```mermaid
+flowchart TD
+    A[User edits contact] --> B[Save to SmartStore]
+    B --> C[Mark as __locally_updated__]
+    C --> D[Update UI immediately]
+    D --> E{Online?}
+    E -->|Yes| F[syncUp in background]
+    E -->|No| G[Queue for next syncUp]
+    F --> H[Upload to Salesforce]
+    H --> I[Clear __local__ flags]
+    I --> J[Update UI]
+```
+
+### Conflict Resolution
+
+When the same record is modified locally and on the server:
+
+**OVERWRITE mode:**
+- Server data wins
+- Local changes are lost
+- Use for read-mostly data
+
+**LEAVE_IF_CHANGED mode:**
+- Local changes win
+- Server changes are not applied
+- Use when local edits are critical
+
+**Custom conflict resolution:**
+```javascript
+// After syncDown with LEAVE_IF_CHANGED
+const conflictedRecords = await smartstore.querySoup(false, 'contacts', {
+  queryType: 'exact',
+  indexPath: '__local__',
+  matchKey: 'true'
+});
+
+// Let user resolve conflicts
+conflictedRecords.forEach(record => {
+  showConflictDialog(record, serverVersion, localVersion);
+});
+```
+
+## Advanced Patterns
+
+### Incremental Sync
+
+Only sync records modified since last sync:
+
+```javascript
+// First sync - get all records
+const target = {
+  type: 'soql',
+  query: 'SELECT Id, Name, LastModifiedDate FROM Contact'
+};
+
+// Subsequent syncs - only get changes
+const lastSyncDate = await getLastSyncDate();
+const target = {
+  type: 'soql',
+  query: `SELECT Id, Name, LastModifiedDate FROM Contact 
+          WHERE LastModifiedDate > ${lastSyncDate}`
+};
+```
+
+### Multi-Soup Sync
+
+Sync related objects:
+
+```javascript
+async function syncAll() {
+  // 1. Sync accounts first
+  await syncDown(false, {
+    type: 'soql',
+    query: 'SELECT Id, Name FROM Account LIMIT 1000'
+  }, 'accounts', { mergeMode: OVERWRITE }, 'accountSync');
+
+  // 2. Sync contacts for those accounts
+  const accounts = await querySoup(false, 'accounts', { queryType: 'range' });
+  const accountIds = accounts.currentPageOrderedEntries.map(a => a.Id).join("','");
+  
+  await syncDown(false, {
+    type: 'soql',
+    query: `SELECT Id, Name, AccountId FROM Contact 
+            WHERE AccountId IN ('${accountIds}')`
+  }, 'contacts', { mergeMode: OVERWRITE }, 'contactSync');
+}
+```
+
+### Sync Queue
+
+Queue sync operations and execute when online:
+
+```javascript
+class SyncQueue {
+  queue = [];
+
+  add(operation) {
+    this.queue.push(operation);
+    this.processQueue();
+  }
+
+  async processQueue() {
+    if (this.queue.length === 0) return;
+    
+    const isOnline = await checkNetworkConnectivity();
+    if (!isOnline) return;
+
+    while (this.queue.length > 0) {
+      const operation = this.queue.shift();
+      try {
+        await operation();
+      } catch (error) {
+        console.error('Sync failed:', error);
+        // Re-queue on failure
+        this.queue.unshift(operation);
+        break;
+      }
+    }
+  }
+}
+
+// Usage
+const syncQueue = new SyncQueue();
+syncQueue.add(() => StoreMgr.syncUpContacts());
+syncQueue.add(() => StoreMgr.syncDownContacts());
+```
+
+## Testing
+
+### Manual Testing Scenarios
+
+1. **Offline create**
+   - Enable airplane mode
+   - Create a new contact
+   - Verify it shows "New (not synced)" badge
+   - Disable airplane mode
+   - Pull to refresh (triggers syncUp)
+   - Verify contact appears on server
+   - Verify badge disappears
+
+2. **Offline edit**
+   - Load contact list
+   - Enable airplane mode
+   - Edit a contact
+   - Verify it shows "Modified (not synced)" badge
+   - Disable airplane mode
+   - Pull to refresh
+   - Verify changes appear on server
+
+3. **Offline delete**
+   - Enable airplane mode
+   - Delete a contact
+   - Verify it shows "Deleted (not synced)" badge
+   - Disable airplane mode
+   - Pull to refresh
+   - Verify contact deleted on server
+
+4. **Conflict resolution**
+   - Load contact on device
+   - Modify same contact on server (via web)
+   - Modify contact on device
+   - Sync down
+   - Verify behavior based on merge mode
+
+5. **Full-text search**
+   - Search for "john"
+   - Verify matches "John", "Johnny", "Johnson"
+   - Search for "smi"
+   - Verify matches "Smith", "Smitty"
+
+## Running the Sample
+
+```bash
+# Install dependencies
+npm install
+cd ios && pod install && cd ..
+
+# Start Metro
+npm start
+
+# Run on iOS
+npm run ios
+
+# Run on Android
+npm run android
+```
+
+## Learning Path
+
+### 1. Start Here: Understand the UI
+
+Open `js/App.js`, `js/SearchScreen.js`, `js/ContactScreen.js`
+
+- See how navigation works
+- Understand the screen flow
+- Notice how components subscribe to store changes
+
+### 2. Study StoreMgr.js
+
+This is the most important file:
+
+- `firstTimeSyncData()` - How to set up SmartStore
+- `syncDownContacts()` - How to download from Salesforce
+- `syncUpContacts()` - How to upload local changes
+- `searchContacts()` - How to query SmartStore
+- `saveContact()` - How to mark records as dirty
+- Event emitter pattern for state management
+
+### 3. Trace a Complete Flow
+
+Follow a single operation end-to-end:
+
+```
+User taps "Save"
+  ↓
+ContactScreen.save()
+  ↓
+StoreMgr.saveContact()
+  ↓
+smartstore.upsertSoupEntries() - Save locally
+  ↓
+emitSmartStoreChanged() - Notify listeners
+  ↓
+StoreMgr.syncUpContacts() - Upload to Salesforce
+  ↓
+mobilesync.syncUp() - Execute sync
+  ↓
+Salesforce REST API - Create/update record
+  ↓
+emitSmartStoreChanged() - Notify UI
+  ↓
+SearchScreen.onStoreChange() - Refresh list
+```
+
+### 4. Experiment
+
+- Add a new field to contacts
+- Add a new search filter
+- Implement a different merge mode
+- Add sync status indicators
+- Implement batch operations
+
+## Next Steps
+
+### Use as Reference
+
+This sample is best used as a reference when building your own app:
+
+- Copy patterns (not entire files) into your app
+- Adapt `StoreMgr.js` for your data model
+- Reuse UI components like `Field.js`, `ContactCell.js`
+- Follow the event-driven architecture
+
+### Build Your Own App
+
+Start with [ReactNativeTemplate](./ReactNativeTemplate.md) and add offline sync:
+
+1. Set up SmartStore (register soups)
+2. Implement syncDown for initial data load
+3. Implement CRUD operations with local save
+4. Implement syncUp for uploading changes
+5. Add conflict resolution
+6. Add search functionality
+
+## Related Documentation
+
+- [TEMPLATE_ANATOMY.md](./TEMPLATE_ANATOMY.md) - Template structure
+- [ReactNativeTemplate.md](./ReactNativeTemplate.md) - Basic template
+- [SmartStore Developer Guide](https://developer.salesforce.com/docs/platform/mobile-sdk/guide/smartstore.html)
+- [MobileSync Developer Guide](https://developer.salesforce.com/docs/platform/mobile-sdk/guide/mobilesync.html)
+
+## Additional Resources
+
+- [SalesforceMobileSDK-ReactNative Repository](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative)
+- [React Native Documentation](https://reactnative.dev/)
+- [Salesforce Mobile SDK Documentation](https://developer.salesforce.com/docs/platform/mobile-sdk/guide)

--- a/docs/react-native-templates/README.md
+++ b/docs/react-native-templates/README.md
@@ -1,0 +1,375 @@
+# React Native Templates Guide
+
+This guide covers all React Native templates in the Salesforce Mobile SDK Templates repository.
+
+## Overview
+
+The Salesforce Mobile SDK provides four React Native templates that serve different use cases:
+
+| Template | Language | Use Case | Authentication |
+|----------|----------|----------|----------------|
+| **ReactNativeTemplate** | JavaScript | Basic starting point for React Native apps | Required on launch |
+| **ReactNativeTypeScriptTemplate** | TypeScript | Type-safe React Native development | Required on launch |
+| **ReactNativeDeferredTemplate** | JavaScript | Apps with guest mode / login-on-demand | Deferred (optional) |
+| **MobileSyncExplorerReactNative** | JavaScript | Full sample app with offline sync | Required on launch |
+
+## Choosing the Right Template
+
+### Start with ReactNativeTemplate if:
+- You're building a new app from scratch
+- You prefer JavaScript over TypeScript
+- Your app requires immediate authentication
+- You want a minimal starting point to customize
+
+### Use ReactNativeTypeScriptTemplate if:
+- You want TypeScript's type safety and IDE support
+- You're building a large-scale application
+- Your team prefers strongly-typed code
+- You need better refactoring and autocomplete
+
+### Use ReactNativeDeferredTemplate if:
+- Your app should work without immediate login
+- You want to provide a "guest mode" or "try before login"
+- Authentication should only happen when accessing Salesforce data
+- Users should be able to log out and continue using the app
+
+### Use MobileSyncExplorerReactNative if:
+- You're learning the Mobile SDK and want a complete example
+- You need to understand offline data synchronization
+- You want to see CRUD operations with SmartStore
+- You're building an app with similar offline-first requirements
+
+## Quick Start
+
+### Creating a New App
+
+Using the Salesforce CLI tools:
+
+```bash
+# JavaScript template
+forcereact create --appname MyApp --packagename com.mycompany.myapp --organization "My Company"
+
+# TypeScript template
+forcereact create --appname MyApp --packagename com.mycompany.myapp --organization "My Company" --templatename ReactNativeTypeScriptTemplate
+
+# Deferred login template
+forcereact create --appname MyApp --packagename com.mycompany.myapp --organization "My Company" --templatename ReactNativeDeferredTemplate
+
+# Sample app (for learning)
+forcereact create --appname MyApp --packagename com.mycompany.myapp --organization "My Company" --templatename MobileSyncExplorerReactNative
+```
+
+### Running the Generated App
+
+**iOS:**
+```bash
+cd ios
+pod install
+cd ..
+npm start
+# In another terminal:
+npm run ios
+```
+
+**Android:**
+```bash
+npm start
+# In another terminal:
+npm run android
+```
+
+## Template Structure
+
+All React Native templates share a common structure:
+
+```
+<TemplateName>/
+├── package.json                 # Dependencies and SDK references
+├── template.js                  # Template customization script
+├── installios.js                # iOS SDK installation
+├── installandroid.js            # Android SDK installation
+├── app.js or app.tsx            # Main React Native application
+├── index.js                     # Entry point
+├── metro.config.js              # Metro bundler configuration
+├── babel.config.js              # Babel configuration
+├── tsconfig.json                # TypeScript configuration (TS template only)
+├── ios/                         # iOS native project
+│   ├── Podfile                  # CocoaPods dependencies
+│   ├── <AppName>.xcodeproj/     # Xcode project
+│   └── <AppName>/               # iOS app directory
+│       ├── AppDelegate.swift    # App lifecycle and SDK initialization
+│       ├── bootconfig.plist     # OAuth configuration
+│       └── Info.plist           # App metadata
+└── android/                     # Android native project
+    ├── build.gradle             # Root Gradle configuration
+    ├── settings.gradle          # Project structure
+    └── app/                     # Android app module
+        ├── build.gradle         # App-level Gradle configuration
+        └── src/main/
+            ├── AndroidManifest.xml
+            ├── java/            # Kotlin source files
+            │   └── <package>/
+            │       ├── MainActivity.kt
+            │       └── MainApplication.kt
+            └── res/             # Android resources
+                ├── values/
+                │   ├── bootconfig.xml
+                │   └── strings.xml
+                └── xml/
+                    └── servers.xml
+```
+
+## Key Concepts
+
+### Authentication Modes
+
+**Immediate Authentication (Default):**
+- App requires login before showing any content
+- iOS: `AuthHelper.loginIfRequired()` in AppDelegate
+- Android: `shouldAuthenticate() = true` in MainActivity
+- Used by: ReactNativeTemplate, ReactNativeTypeScriptTemplate, MobileSyncExplorerReactNative
+
+**Deferred Authentication:**
+- App loads without requiring login
+- User can explore the app as a guest
+- Login only occurs when explicitly requested
+- iOS: `AuthHelper.loginIfRequired()` still called, but app handles unauthenticated state
+- Android: `shouldAuthenticate() = false` in MainActivity
+- Used by: ReactNativeDeferredTemplate
+
+### OAuth Configuration
+
+OAuth settings are configured during app generation and stored in platform-specific files:
+
+**iOS (bootconfig.plist):**
+```xml
+<key>remoteAccessConsumerKey</key>
+<string>your-consumer-key</string>
+<key>oauthRedirectURI</key>
+<string>your-callback-url</string>
+<key>shouldAuthenticate</key>
+<true/>
+```
+
+**Android (bootconfig.xml):**
+```xml
+<string name="remoteAccessConsumerKey">your-consumer-key</string>
+<string name="oauthRedirectURI">your-callback-url</string>
+```
+
+### SDK Dependencies
+
+React Native templates depend on three SDK components:
+
+1. **SalesforceMobileSDK-iOS** - iOS native SDK (Podfile reference)
+2. **SalesforceMobileSDK-Android** - Android native SDK (Gradle composite build)
+3. **SalesforceMobileSDK-ReactNative** - React Native bridge (npm package `react-native-force`)
+
+These are specified in `package.json`:
+
+```json
+{
+  "sdkDependencies": {
+    "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev",
+    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev"
+  },
+  "dependencies": {
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
+  }
+}
+```
+
+### Template Generation Process
+
+When you run `forcereact create`, the following happens:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as forcereact CLI
+    participant Template as template.js
+    participant InstallIOS as installios.js
+    participant InstallAndroid as installandroid.js
+    participant Git
+    participant CocoaPods
+    participant Gradle
+
+    User->>CLI: forcereact create --appname MyApp
+    CLI->>Template: Call prepare(config)
+    
+    alt iOS Platform
+        Template->>Template: Replace placeholders (app name, package, OAuth)
+        Template->>Template: Rename files and directories
+        Template->>InstallIOS: require('./installios')
+        InstallIOS->>Git: Clone SalesforceMobileSDK-iOS
+        InstallIOS->>CocoaPods: pod update
+        InstallIOS-->>Template: Done
+    end
+    
+    alt Android Platform
+        Template->>Template: Replace placeholders (app name, package, OAuth)
+        Template->>Template: Move Java/Kotlin files to package structure
+        Template->>InstallAndroid: require('./installandroid')
+        InstallAndroid->>Git: Clone SalesforceMobileSDK-Android
+        InstallAndroid-->>Template: Done (Gradle uses composite build)
+    end
+    
+    Template-->>CLI: Return workspace paths
+    CLI-->>User: App created successfully
+```
+
+## Common Tasks
+
+### Customizing OAuth Settings
+
+Edit the bootconfig files after generation:
+
+**iOS:** `ios/<AppName>/bootconfig.plist`
+**Android:** `android/app/src/main/res/values/bootconfig.xml`
+
+### Changing Login Server
+
+**iOS:** Edit `Info.plist` and change `SFDCDefaultLoginHost`
+**Android:** Edit `android/app/src/main/res/xml/servers.xml`
+
+### Adding New Screens
+
+1. Create a new React component in your app
+2. Use `@react-navigation/stack` or `@react-navigation/native` for navigation
+3. All templates include React Navigation by default
+
+### Accessing Salesforce Data
+
+Use the `react-native-force` module:
+
+```javascript
+import { oauth, net, smartstore, mobilesync } from 'react-native-force';
+
+// Execute SOQL query
+net.query('SELECT Id, Name FROM Account LIMIT 10')
+  .then(response => {
+    console.log('Records:', response.records);
+  });
+
+// Check authentication status
+oauth.getAuthCredentials()
+  .then(credentials => {
+    console.log('Access token:', credentials.accessToken);
+  });
+```
+
+### Using SmartStore (Offline Storage)
+
+SmartStore is available in all templates:
+
+```javascript
+import { smartstore } from 'react-native-force';
+
+// Register a soup (table)
+smartstore.registerSoup(
+  false, // isGlobalStore
+  'contacts', // soupName
+  [ // indexes
+    { path: 'Id', type: 'string' },
+    { path: 'Name', type: 'string' }
+  ]
+);
+
+// Query data
+smartstore.querySoup(
+  false,
+  'contacts',
+  { queryType: 'exact', path: 'Id', matchKey: '001xx000003DGb0' }
+);
+```
+
+### Using MobileSync (Offline Synchronization)
+
+MobileSync is demonstrated in MobileSyncExplorerReactNative:
+
+```javascript
+import { mobilesync } from 'react-native-force';
+
+// Sync down from Salesforce
+mobilesync.syncDown(
+  false, // isGlobalStore
+  { type: 'soql', query: 'SELECT Id, Name FROM Contact LIMIT 100' }, // target
+  'contacts', // soupName
+  { mergeMode: mobilesync.MERGE_MODE.OVERWRITE }, // options
+  'contactSync' // syncName
+);
+
+// Sync up to Salesforce
+mobilesync.syncUp(
+  false, // isGlobalStore
+  {}, // options
+  'contacts', // soupName
+  { mergeMode: mobilesync.MERGE_MODE.OVERWRITE, fieldlist: ['Name', 'Email'] } // options
+);
+```
+
+## Testing React Native Templates
+
+Use the `test_template.sh` script to validate templates:
+
+```bash
+# Test a specific template
+./test_template.sh --template ReactNativeTemplate --platform ios
+
+# Test with custom SDK branches
+./test_template.sh \
+  --template ReactNativeTemplate \
+  --msdk-ios-branch my-feature \
+  --msdk-android-branch my-feature \
+  --rn-force-branch my-feature
+```
+
+See [TESTING.md](../../TESTING.md) for comprehensive testing documentation.
+
+## Troubleshooting
+
+### iOS Pod Install Fails
+
+```bash
+cd ios
+rm -rf Pods Podfile.lock
+pod install --repo-update
+```
+
+### Android Build Fails
+
+```bash
+cd android
+./gradlew clean
+cd ..
+rm -rf android/.gradle
+npm run android
+```
+
+### Metro Bundler Issues
+
+```bash
+npm start -- --reset-cache
+```
+
+### SDK Dependency Issues
+
+```bash
+# Delete SDK dependencies and reinstall
+rm -rf mobile_sdk
+node installios.js    # or installandroid.js
+```
+
+## Next Steps
+
+- Read the individual template documentation for detailed information
+- See [TEMPLATE_ANATOMY.md](./TEMPLATE_ANATOMY.md) for deep dive into template structure
+- Review [ReactNativeTemplate.md](./ReactNativeTemplate.md), [ReactNativeTypeScriptTemplate.md](./ReactNativeTypeScriptTemplate.md), [ReactNativeDeferredTemplate.md](./ReactNativeDeferredTemplate.md), and [MobileSyncExplorerReactNative.md](./MobileSyncExplorerReactNative.md) for template-specific details
+- Check the [Salesforce Mobile SDK Documentation](https://developer.salesforce.com/docs/platform/mobile-sdk/guide)
+
+## Related Documentation
+
+- [Main Templates README](../../README.md)
+- [CLAUDE.md](../../CLAUDE.md) - AI development guidelines
+- [TESTING.md](../../TESTING.md) - Template testing guide
+- [SalesforceMobileSDK-ReactNative](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative) - React Native bridge repository

--- a/docs/react-native-templates/README.md
+++ b/docs/react-native-templates/README.md
@@ -2,6 +2,8 @@
 
 This guide covers all React Native templates in the Salesforce Mobile SDK Templates repository.
 
+> **API style note:** The `react-native-force` SDK uses **callback-based** APIs (`fn(args, successCallback, errorCallback)`). For Promise-based usage, wrap calls with `forceUtil.promiser(fn)`. Code examples in this guide use the actual callback style — examples elsewhere that show Promises should be treated as illustrative.
+
 ## Overview
 
 The Salesforce Mobile SDK provides four React Native templates that serve different use cases:
@@ -240,27 +242,33 @@ Edit the bootconfig files after generation:
 
 ### Accessing Salesforce Data
 
-Use the `react-native-force` module:
+Use the `react-native-force` module. **The SDK uses callback-based APIs** (`success`, `error`):
 
 ```javascript
 import { oauth, net, smartstore, mobilesync } from 'react-native-force';
 
 // Execute SOQL query
-net.query('SELECT Id, Name FROM Account LIMIT 10')
-  .then(response => {
-    console.log('Records:', response.records);
-  });
+net.query(
+  'SELECT Id, Name FROM Contact LIMIT 10',
+  (response) => { console.log('Records:', response.records); },
+  (error) => { console.error(error); }
+);
 
 // Check authentication status
-oauth.getAuthCredentials()
-  .then(credentials => {
-    console.log('Access token:', credentials.accessToken);
-  });
+oauth.getAuthCredentials(
+  (credentials) => { console.log('Access token:', credentials.accessToken); },
+  (error) => { console.error(error); }
+);
+```
+
+If you want to use Promises, wrap callback APIs with `forceUtil.promiser`:
+```javascript
+import { forceUtil } from 'react-native-force';
+const query = forceUtil.promiser(net.query);
+const records = (await query('SELECT Id FROM Contact')).records;
 ```
 
 ### Using SmartStore (Offline Storage)
-
-SmartStore is available in all templates:
 
 ```javascript
 import { smartstore } from 'react-native-force';
@@ -268,18 +276,22 @@ import { smartstore } from 'react-native-force';
 // Register a soup (table)
 smartstore.registerSoup(
   false, // isGlobalStore
-  'contacts', // soupName
-  [ // indexes
+  'contacts',
+  [
     { path: 'Id', type: 'string' },
     { path: 'Name', type: 'string' }
-  ]
+  ],
+  (soupName) => { /* success */ },
+  (error) => { /* error */ }
 );
 
 // Query data
 smartstore.querySoup(
   false,
   'contacts',
-  { queryType: 'exact', path: 'Id', matchKey: '001xx000003DGb0' }
+  { queryType: 'exact', indexPath: 'Id', matchKey: '001xx000003DGb0' },
+  (cursor) => { /* success */ },
+  (error) => { /* error */ }
 );
 ```
 
@@ -296,15 +308,20 @@ mobilesync.syncDown(
   { type: 'soql', query: 'SELECT Id, Name FROM Contact LIMIT 100' }, // target
   'contacts', // soupName
   { mergeMode: mobilesync.MERGE_MODE.OVERWRITE }, // options
-  'contactSync' // syncName
+  'contactSync', // syncName
+  (syncResult) => { /* success */ },
+  (error) => { /* error */ }
 );
 
 // Sync up to Salesforce
 mobilesync.syncUp(
   false, // isGlobalStore
-  {}, // options
-  'contacts', // soupName
-  { mergeMode: mobilesync.MERGE_MODE.OVERWRITE, fieldlist: ['Name', 'Email'] } // options
+  {}, // target (use empty {} for default)
+  'contacts',
+  { mergeMode: mobilesync.MERGE_MODE.OVERWRITE, fieldlist: ['Name', 'Email'] },
+  null, // syncName
+  (syncResult) => { /* success */ },
+  (error) => { /* error */ }
 );
 ```
 

--- a/docs/react-native-templates/ReactNativeDeferredTemplate.md
+++ b/docs/react-native-templates/ReactNativeDeferredTemplate.md
@@ -1,0 +1,801 @@
+# ReactNativeDeferredTemplate
+
+The deferred authentication React Native template for Salesforce Mobile SDK applications.
+
+## Overview
+
+`ReactNativeDeferredTemplate` demonstrates the **deferred authentication pattern**, where login is optional and happens on-demand rather than being required at app launch.
+
+Key features:
+
+- **JavaScript-based** React Native application
+- **Deferred authentication** - login only when needed
+- **Guest mode** - users can explore the app without logging in
+- **Explicit login/logout** - user-initiated authentication
+- **Cross-platform** support (iOS and Android)
+- **Login-on-demand** - authenticate when accessing protected features
+
+## When to Use This Template
+
+Choose `ReactNativeDeferredTemplate` if:
+
+- Your app should work without immediate authentication
+- You want to provide a "guest mode" or "try before you buy" experience
+- Authentication should only occur when accessing Salesforce data
+- Users need to be able to log out and continue using the app
+- Your app has both public and protected features
+
+## Use Cases
+
+### Example 1: News/Content App
+
+```
+App Launch → Show news articles (public)
+User taps "Save to Salesforce" → Prompt for login
+After login → Save article to Salesforce object
+User can logout → Continue reading articles
+```
+
+### Example 2: Product Catalog
+
+```
+App Launch → Show product catalog (public)
+User taps "Add to Cart" → Prompt for login
+After login → Sync cart with Salesforce
+User can logout → Continue browsing products
+```
+
+### Example 3: Learning App
+
+```
+App Launch → Show course list (public)
+User taps "Enroll" → Prompt for login
+After login → Track progress in Salesforce
+User can logout → Continue viewing courses
+```
+
+## Not the Right Fit?
+
+- **Need authentication on launch?** → Use [ReactNativeTemplate](./ReactNativeTemplate.md)
+- **Want TypeScript?** → No deferred TypeScript template yet (create one!)
+- **Learning the SDK?** → Use [MobileSyncExplorerReactNative](./MobileSyncExplorerReactNative.md)
+
+## Creating an App from This Template
+
+### Using the CLI
+
+```bash
+forcereact create \
+  --appname MyApp \
+  --packagename com.mycompany.myapp \
+  --organization "My Company" \
+  --templatename ReactNativeDeferredTemplate
+```
+
+### With OAuth Configuration
+
+```bash
+forcereact create \
+  --appname MyApp \
+  --packagename com.mycompany.myapp \
+  --organization "My Company" \
+  --templatename ReactNativeDeferredTemplate \
+  --consumerkey "3MVG9..." \
+  --callbackurl "myapp://oauth/callback"
+```
+
+## Authentication Pattern Comparison
+
+| Feature | Standard Templates | ReactNativeDeferredTemplate |
+|---------|-------------------|----------------------------|
+| **Launch behavior** | Require login immediately | No login required |
+| **Initial screen** | OAuth login screen | App content |
+| **Authentication trigger** | Automatic on launch | User taps "Login" button |
+| **Guest mode** | Not supported | Fully supported |
+| **Logout** | Rare (usually stays logged in) | Common (users switch between modes) |
+| **API calls before login** | Not possible | Fail gracefully, prompt login |
+
+## Deferred Authentication Flow
+
+```mermaid
+flowchart TD
+    A[App Launches] --> B{Platform}
+    
+    B -->|iOS| C[AppDelegate: AuthHelper.loginIfRequired]
+    B -->|Android| D[MainActivity: shouldAuthenticate = false]
+    
+    C --> E[Start React Native - NO login prompt]
+    D --> E
+    
+    E --> F[App renders without authentication]
+    
+    F --> G{User action}
+    
+    G -->|Browse public content| H[Show public data]
+    G -->|Tap Login button| I[oauth.authenticate]
+    
+    H --> G
+    
+    I --> J{Login successful?}
+    
+    J -->|Yes| K[Update UI: logged in]
+    J -->|No| L[Show error, stay in guest mode]
+    
+    K --> M{User taps Logout?}
+    
+    M -->|Yes| N[oauth.logout]
+    N --> O[Clear user data, return to guest mode]
+    O --> G
+    
+    M -->|No| P[Continue using authenticated features]
+    P --> M
+```
+
+## Key Differences from Standard Template
+
+### iOS: AppDelegate.swift
+
+**Standard Template:**
+```swift
+// User MUST log in before React Native starts
+AuthHelper.loginIfRequired() {
+  factory.startReactNative(
+    withModuleName: "MyApp",
+    in: self.window,
+    launchOptions: launchOptions
+  )
+}
+```
+
+**Deferred Template:**
+```swift
+// React Native starts immediately, login happens later if needed
+// (Same code, but behavior changes based on how React Native handles it)
+AuthHelper.loginIfRequired() {
+  factory.startReactNative(
+    withModuleName: "ReactNativeDeferredTemplate",
+    in: self.window,
+    launchOptions: launchOptions
+  )
+}
+```
+
+Note: iOS uses the same AppDelegate code. The deferred behavior is implemented in React Native JavaScript.
+
+### Android: MainActivity.kt
+
+**Standard Template:**
+```kotlin
+override fun shouldAuthenticate() = true  // Require login on launch
+```
+
+**Deferred Template:**
+```kotlin
+override fun shouldAuthenticate() = false  // NO login required on launch
+```
+
+This is the critical difference for Android - setting `shouldAuthenticate()` to `false` allows the app to start without authentication.
+
+### React Native: app.js
+
+**Standard Template:**
+```javascript
+componentDidMount() {
+  // Assumes user is already authenticated
+  oauth.getAuthCredentials()
+    .then(() => this.fetchData())
+    .catch(error => console.error(error));
+}
+```
+
+**Deferred Template:**
+```javascript
+componentDidMount() {
+  // Check auth status, but don't require it
+  this.checkAuthStatus();
+}
+
+checkAuthStatus = () => {
+  oauth.getAuthCredentials()
+    .then(credentials => {
+      this.setState({ authenticated: true, credentials });
+    })
+    .catch(() => {
+      // User not authenticated - that's OK!
+      this.setState({ authenticated: false });
+    });
+}
+
+login = () => {
+  oauth.authenticate()
+    .then(credentials => {
+      this.setState({ authenticated: true, credentials });
+    })
+    .catch(error => {
+      console.error('Login failed:', error);
+    });
+}
+
+logout = () => {
+  oauth.logout();
+  this.setState({ authenticated: false, credentials: null });
+}
+```
+
+## Project Structure
+
+Same as [ReactNativeTemplate](./ReactNativeTemplate.md) with these key file differences:
+
+```
+MyApp/
+├── app.js                       # Deferred auth logic
+├── ios/
+│   └── MyApp/
+│       └── AppDelegate.swift    # Same as standard template
+└── android/
+    └── app/src/main/java/
+        └── MainActivity.kt      # shouldAuthenticate() = false
+```
+
+## Implementation Guide
+
+### Complete app.js Example
+
+```javascript
+import React from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  FlatList,
+  Button,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
+
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { oauth, net } from 'react-native-force';
+
+const Stack = createStackNavigator();
+
+export default class App extends React.Component {
+  state = {
+    authenticated: false,
+    credentials: null,
+    records: [],
+    loading: false,
+    error: null,
+  };
+
+  componentDidMount() {
+    this.checkAuthStatus();
+  }
+
+  checkAuthStatus = () => {
+    oauth.getAuthCredentials()
+      .then(credentials => {
+        console.log('User is authenticated');
+        this.setState({ authenticated: true, credentials });
+      })
+      .catch(() => {
+        console.log('User is not authenticated - guest mode');
+        this.setState({ authenticated: false });
+      });
+  }
+
+  login = () => {
+    this.setState({ loading: true, error: null });
+    
+    oauth.authenticate()
+      .then(credentials => {
+        this.setState({ 
+          authenticated: true, 
+          credentials,
+          loading: false 
+        });
+      })
+      .catch(error => {
+        console.error('Login failed:', error);
+        this.setState({ 
+          error: 'Login failed. Please try again.',
+          loading: false 
+        });
+      });
+  }
+
+  logout = () => {
+    oauth.logout();
+    this.setState({ 
+      authenticated: false, 
+      credentials: null,
+      records: [],
+      error: null 
+    });
+  }
+
+  fetchData = () => {
+    if (!this.state.authenticated) {
+      this.setState({ error: 'Please login to view data' });
+      return;
+    }
+
+    this.setState({ loading: true, error: null });
+
+    net.query('SELECT Id, Name FROM Account LIMIT 10')
+      .then(response => {
+        this.setState({ 
+          records: response.records,
+          loading: false 
+        });
+      })
+      .catch(error => {
+        console.error('Query failed:', error);
+        this.setState({ 
+          error: 'Failed to fetch data',
+          loading: false 
+        });
+      });
+  }
+
+  render() {
+    return (
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Home">
+            {props => <HomeScreen {...props} {...this.state} {...this} />}
+          </Stack.Screen>
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+  }
+}
+
+function HomeScreen({ authenticated, credentials, records, loading, error, login, logout, fetchData }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Deferred Auth Demo</Text>
+
+      {loading && <ActivityIndicator size="large" />}
+      
+      {error && <Text style={styles.error}>{error}</Text>}
+
+      {authenticated ? (
+        <View>
+          <Text style={styles.status}>Logged in as: {credentials?.userId}</Text>
+          
+          <Button title="Fetch Salesforce Data" onPress={fetchData} />
+          <Button title="Logout" onPress={logout} color="red" />
+
+          {records.length > 0 && (
+            <FlatList
+              data={records}
+              keyExtractor={item => item.Id}
+              renderItem={({ item }) => (
+                <Text style={styles.record}>{item.Name}</Text>
+              )}
+            />
+          )}
+        </View>
+      ) : (
+        <View>
+          <Text style={styles.status}>Guest Mode</Text>
+          <Text style={styles.info}>
+            You can browse the app without logging in.
+            Tap Login to access Salesforce data.
+          </Text>
+          <Button title="Login to Salesforce" onPress={login} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20 },
+  header: { fontSize: 24, fontWeight: 'bold', marginBottom: 20 },
+  status: { fontSize: 18, marginBottom: 10 },
+  info: { fontSize: 14, color: '#666', marginBottom: 20 },
+  error: { color: 'red', marginBottom: 10 },
+  record: { padding: 10, borderBottomWidth: 1, borderColor: '#ccc' },
+});
+```
+
+### Protecting Features That Require Authentication
+
+```javascript
+function ProtectedFeature() {
+  const [authenticated, setAuthenticated] = useState(false);
+
+  useEffect(() => {
+    checkAuth();
+  }, []);
+
+  async function checkAuth() {
+    try {
+      await oauth.getAuthCredentials();
+      setAuthenticated(true);
+    } catch {
+      setAuthenticated(false);
+    }
+  }
+
+  async function tryFetchData() {
+    if (!authenticated) {
+      // Prompt for login
+      try {
+        await oauth.authenticate();
+        setAuthenticated(true);
+        // Now fetch data
+        const response = await net.query('SELECT Id, Name FROM Account');
+        return response.records;
+      } catch (error) {
+        Alert.alert('Login Required', 'Please login to access this feature');
+        return [];
+      }
+    } else {
+      // User already authenticated, fetch directly
+      const response = await net.query('SELECT Id, Name FROM Account');
+      return response.records;
+    }
+  }
+
+  return (
+    <View>
+      {authenticated ? (
+        <Text>You have access to protected features</Text>
+      ) : (
+        <Text>Login required for protected features</Text>
+      )}
+      <Button title="Load Data" onPress={tryFetchData} />
+    </View>
+  );
+}
+```
+
+### Graceful API Failure Handling
+
+```javascript
+async function fetchWithAuth(soql) {
+  try {
+    // Try to fetch data
+    const response = await net.query(soql);
+    return { success: true, data: response.records };
+  } catch (error) {
+    // Check if error is auth-related
+    if (error.message?.includes('authentication') || error.message?.includes('unauthorized')) {
+      // Prompt user to login
+      try {
+        await oauth.authenticate();
+        // Retry the query
+        const response = await net.query(soql);
+        return { success: true, data: response.records };
+      } catch (loginError) {
+        return { success: false, error: 'Login failed', needsAuth: true };
+      }
+    } else {
+      return { success: false, error: error.message };
+    }
+  }
+}
+
+// Usage
+const result = await fetchWithAuth('SELECT Id, Name FROM Account');
+if (result.success) {
+  console.log('Data:', result.data);
+} else if (result.needsAuth) {
+  Alert.alert('Login Required', 'Please login to access this data');
+} else {
+  Alert.alert('Error', result.error);
+}
+```
+
+## User Experience Best Practices
+
+### 1. Clear Status Indicators
+
+Show users whether they're logged in or in guest mode:
+
+```javascript
+function StatusBar({ authenticated, credentials }) {
+  return (
+    <View style={styles.statusBar}>
+      {authenticated ? (
+        <View style={styles.authenticatedStatus}>
+          <Icon name="check-circle" color="green" />
+          <Text>Logged in as {credentials.userId}</Text>
+        </View>
+      ) : (
+        <View style={styles.guestStatus}>
+          <Icon name="user" color="gray" />
+          <Text>Guest Mode</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+```
+
+### 2. Progressive Feature Access
+
+Show what features require authentication:
+
+```javascript
+function FeatureList({ authenticated }) {
+  const features = [
+    { name: 'Browse Products', requiresAuth: false },
+    { name: 'Save Favorites', requiresAuth: true },
+    { name: 'View Order History', requiresAuth: true },
+    { name: 'Contact Support', requiresAuth: false },
+  ];
+
+  return (
+    <FlatList
+      data={features}
+      renderItem={({ item }) => (
+        <View style={styles.feature}>
+          <Text>{item.name}</Text>
+          {item.requiresAuth && !authenticated && (
+            <Text style={styles.lockIcon}>🔒 Login required</Text>
+          )}
+        </View>
+      )}
+    />
+  );
+}
+```
+
+### 3. Contextual Login Prompts
+
+Prompt for login at the right moment:
+
+```javascript
+function SaveButton({ authenticated, onSave }) {
+  async function handlePress() {
+    if (!authenticated) {
+      Alert.alert(
+        'Login Required',
+        'You need to login to save this item.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Login', onPress: async () => {
+            try {
+              await oauth.authenticate();
+              await onSave();
+            } catch (error) {
+              Alert.alert('Login Failed', error.message);
+            }
+          }}
+        ]
+      );
+    } else {
+      await onSave();
+    }
+  }
+
+  return <Button title="Save" onPress={handlePress} />;
+}
+```
+
+### 4. Preserve User Context on Logout
+
+Don't lose the user's place in the app:
+
+```javascript
+function logout() {
+  Alert.alert(
+    'Logout',
+    'Are you sure you want to logout? You can continue using the app in guest mode.',
+    [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Logout', style: 'destructive', onPress: () => {
+        oauth.logout();
+        // Clear auth-related state but keep navigation state
+        setAuthenticated(false);
+        setCredentials(null);
+        // User stays on current screen
+      }}
+    ]
+  );
+}
+```
+
+## Testing
+
+### Test Scenarios
+
+1. **Launch without authentication**
+   - App should load normally
+   - Guest mode features should work
+   - Protected features should prompt for login
+
+2. **Login from guest mode**
+   - Tap login button
+   - Complete OAuth flow
+   - App should update to show authenticated state
+   - Protected features should now work
+
+3. **Logout from authenticated mode**
+   - Tap logout button
+   - App should return to guest mode
+   - Protected features should no longer work
+   - Guest mode features should still work
+
+4. **API calls before login**
+   - Attempt to fetch Salesforce data without logging in
+   - Should fail gracefully
+   - Should prompt for login
+   - After login, should retry and succeed
+
+5. **Session expiration**
+   - Login and use app
+   - Let session expire (or revoke token in Salesforce Setup)
+   - Attempt protected action
+   - Should detect expired session and prompt for re-login
+
+### Manual Testing Script
+
+```
+1. Launch app
+   ✓ App loads without login screen
+   ✓ Shows "Guest Mode" status
+
+2. Browse guest features
+   ✓ Can navigate between screens
+   ✓ Can view public content
+
+3. Try protected feature
+   ✓ Shows login prompt
+   ✓ Can cancel and stay in guest mode
+
+4. Login
+   ✓ OAuth screen appears
+   ✓ After login, returns to app
+   ✓ Shows "Logged in" status
+   ✓ Protected features now work
+
+5. Use protected features
+   ✓ Can fetch Salesforce data
+   ✓ Can create/update records
+   ✓ Can use SmartStore
+
+6. Logout
+   ✓ Returns to guest mode
+   ✓ Protected features no longer work
+   ✓ Guest features still work
+
+7. Login again
+   ✓ Can login again after logout
+   ✓ All features work as before
+```
+
+## Common Patterns
+
+### Remember Authentication State
+
+```javascript
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+async function rememberAuth(authenticated) {
+  await AsyncStorage.setItem('wasAuthenticated', authenticated.toString());
+}
+
+async function checkPreviousAuth() {
+  const wasAuth = await AsyncStorage.getItem('wasAuthenticated');
+  return wasAuth === 'true';
+}
+
+// On app launch
+async componentDidMount() {
+  const wasAuthenticated = await checkPreviousAuth();
+  if (wasAuthenticated) {
+    // Try to restore session
+    try {
+      const credentials = await oauth.getAuthCredentials();
+      this.setState({ authenticated: true, credentials });
+    } catch {
+      // Session expired, clear flag
+      await rememberAuth(false);
+    }
+  }
+}
+```
+
+### Conditional Navigation
+
+```javascript
+function MainNavigator({ authenticated }) {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="Browse" component={BrowseScreen} />
+      
+      {authenticated ? (
+        <>
+          <Stack.Screen name="Favorites" component={FavoritesScreen} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
+        </>
+      ) : (
+        <Stack.Screen name="Login" component={LoginScreen} />
+      )}
+    </Stack.Navigator>
+  );
+}
+```
+
+### Auth-Aware Components
+
+```javascript
+function withAuth(Component) {
+  return function AuthAwareComponent(props) {
+    const [authenticated, setAuthenticated] = useState(false);
+
+    useEffect(() => {
+      oauth.getAuthCredentials()
+        .then(() => setAuthenticated(true))
+        .catch(() => setAuthenticated(false));
+    }, []);
+
+    return <Component {...props} authenticated={authenticated} />;
+  };
+}
+
+// Usage
+const AuthAwareScreen = withAuth(MyScreen);
+```
+
+## Troubleshooting
+
+### App Still Requires Login on Launch (Android)
+
+**Problem:** Android app shows OAuth screen immediately despite using deferred template.
+
+**Solution:** Check `MainActivity.kt`:
+
+```kotlin
+override fun shouldAuthenticate() = false  // Must be false!
+```
+
+### iOS Shows Login Screen Immediately
+
+**Problem:** iOS app requires login on launch.
+
+**Cause:** The iOS SDK doesn't have a `shouldAuthenticate` setting. Authentication behavior is controlled by React Native code.
+
+**Solution:** Make sure `app.js` doesn't call `oauth.authenticate()` in `componentDidMount()`. It should only call `oauth.getAuthCredentials()` and handle the error gracefully.
+
+### API Calls Fail Silently
+
+**Problem:** Calls to `net.query()` fail without showing login prompt.
+
+**Solution:** Add proper error handling:
+
+```javascript
+try {
+  const response = await net.query('SELECT Id FROM Account');
+  return response.records;
+} catch (error) {
+  if (!authenticated) {
+    // Prompt for login
+    await oauth.authenticate();
+    // Retry
+    const response = await net.query('SELECT Id FROM Account');
+    return response.records;
+  } else {
+    throw error;
+  }
+}
+```
+
+## Next Steps
+
+- Read [TEMPLATE_ANATOMY.md](./TEMPLATE_ANATOMY.md) for template internals
+- Review [ReactNativeTemplate](./ReactNativeTemplate.md) for standard authentication
+- Explore [MobileSyncExplorerReactNative.md](./MobileSyncExplorerReactNative.md) for offline patterns
+- Check [Salesforce Mobile SDK Documentation](https://developer.salesforce.com/docs/platform/mobile-sdk/guide)
+
+## Related Resources
+
+- [OAuth 2.0 User-Agent Flow](https://help.salesforce.com/articleView?id=remoteaccess_oauth_user_agent_flow.htm)
+- [React Native Documentation](https://reactnative.dev/)
+- [SalesforceMobileSDK-ReactNative Repository](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative)

--- a/docs/react-native-templates/ReactNativeDeferredTemplate.md
+++ b/docs/react-native-templates/ReactNativeDeferredTemplate.md
@@ -2,6 +2,8 @@
 
 The deferred authentication React Native template for Salesforce Mobile SDK applications.
 
+> **API style note:** The `react-native-force` SDK uses callback-based APIs (`fn(args, successCallback, errorCallback)`). Promise-style code in this guide is illustrative; use `forceUtil.promiser(fn)` for actual promise wrappers.
+
 ## Overview
 
 `ReactNativeDeferredTemplate` demonstrates the **deferred authentication pattern**, where login is optional and happens on-demand rather than being required at app launch.

--- a/docs/react-native-templates/ReactNativeTemplate.md
+++ b/docs/react-native-templates/ReactNativeTemplate.md
@@ -2,6 +2,8 @@
 
 The basic JavaScript React Native template for Salesforce Mobile SDK applications.
 
+> **API style note:** The `react-native-force` SDK uses callback-based APIs (`fn(args, successCallback, errorCallback)`). Promise-style code in this guide is illustrative; use `forceUtil.promiser(fn)` for actual promise wrappers.
+
 ## Overview
 
 `ReactNativeTemplate` is the default starting point for creating React Native apps with the Salesforce Mobile SDK. It provides:
@@ -108,65 +110,69 @@ MyApp/
 
 The main application code. This is where you'll spend most of your time customizing.
 
-**Default implementation:**
+**Default implementation** (matches actual `app.js`):
+
+`app.js` exports `App` as a **named export**, not default:
+```javascript
+export const App = function() { /* ... */ };
+```
+
+`index.js` imports it as a named import:
+```javascript
+import {AppRegistry} from 'react-native';
+import {App} from './app.js';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);
+```
+
+The `App` component:
+- On mount, calls `oauth.getAuthCredentials(...)` (callback-based) to check auth
+- On auth failure, falls through to `oauth.authenticate(...)` to start OAuth login
+- After auth, calls `net.query('SELECT Id, Name FROM Contact ORDER BY Name LIMIT 100', ...)` to fetch contacts
+- Renders a `FlatList` of contacts
 
 ```javascript
 import React from 'react';
-import {
-    StyleSheet,
-    Text,
-    View,
-    FlatList,
-    ActivityIndicator,
-    TouchableOpacity,
-} from 'react-native';
-
-import { NavigationContainer } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
+import { StyleSheet, Text, View, FlatList, ActivityIndicator } from 'react-native';
 import { oauth, net } from 'react-native-force';
 
-const Stack = createStackNavigator();
-
-export default class App extends React.Component {
-  state = {
-    authenticated: false,
-    records: []
-  };
+class ContactListScreen extends React.Component {
+  state = { data: [], loading: true, error: null };
 
   componentDidMount() {
-    // Authenticate and fetch data
-    oauth.getAuthCredentials()
-      .then(credentials => {
-        this.setState({ authenticated: true });
-        return net.query('SELECT Id, Name FROM Account LIMIT 10');
-      })
-      .then(response => {
-        this.setState({ records: response.records });
-      })
-      .catch(error => {
-        console.error('Error:', error);
-      });
+    setTimeout(() => {
+      oauth.getAuthCredentials(
+        (credentials) => this.fetchData(),
+        (error) => oauth.authenticate(
+          () => this.fetchData(),
+          (authError) => this.setState({ loading: false, error: 'Auth failed' })
+        )
+      );
+    }, 1000);
   }
 
-  render() {
-    return (
-      <NavigationContainer>
-        <Stack.Navigator>
-          <Stack.Screen name="Home" component={HomeScreen} />
-          <Stack.Screen name="Details" component={DetailsScreen} />
-        </Stack.Navigator>
-      </NavigationContainer>
+  fetchData() {
+    const soql = 'SELECT Id, Name FROM Contact ORDER BY Name LIMIT 100';
+    net.query(
+      soql,
+      (response) => this.setState({ data: response.records || [], loading: false }),
+      (error) => this.setState({ loading: false, error: 'Query failed' })
     );
   }
+
+  render() { /* ... FlatList, etc. ... */ }
 }
+
+export const App = () => <ContactListScreen />;
 ```
 
 **Key points:**
 
-- `oauth.getAuthCredentials()` - Verify authentication
-- `net.query()` - Execute SOQL queries
-- React Navigation for multi-screen navigation
-- Component-based architecture
+- `App` is a **named export** (`export const App`), not default
+- Sample query is on `Contact`, not `Account`
+- All SDK calls are **callback-based**: `(args, success, error)`
+- For Promise-based usage, wrap with `forceUtil.promiser`
 
 ### iOS Configuration
 

--- a/docs/react-native-templates/ReactNativeTemplate.md
+++ b/docs/react-native-templates/ReactNativeTemplate.md
@@ -1,0 +1,697 @@
+# ReactNativeTemplate
+
+The basic JavaScript React Native template for Salesforce Mobile SDK applications.
+
+## Overview
+
+`ReactNativeTemplate` is the default starting point for creating React Native apps with the Salesforce Mobile SDK. It provides:
+
+- **JavaScript-based** React Native application
+- **Immediate authentication** on app launch
+- **Cross-platform** support (iOS and Android)
+- **Sample SOQL query** and data display
+- **React Navigation** for multi-screen apps
+- **Mobile SDK integration** with `react-native-force`
+
+## When to Use This Template
+
+Choose `ReactNativeTemplate` if:
+
+- You're starting a new React Native app from scratch
+- You prefer JavaScript over TypeScript
+- Your app requires users to authenticate before accessing any features
+- You want a minimal, clean starting point to build upon
+- You're familiar with React Native and want Mobile SDK integration
+
+## Not the Right Fit?
+
+- **Want TypeScript?** → Use [ReactNativeTypeScriptTemplate](./ReactNativeTypeScriptTemplate.md)
+- **Need guest mode?** → Use [ReactNativeDeferredTemplate](./ReactNativeDeferredTemplate.md)
+- **Learning the SDK?** → Use [MobileSyncExplorerReactNative](./MobileSyncExplorerReactNative.md)
+
+## Creating an App from This Template
+
+### Using the CLI
+
+```bash
+forcereact create \
+  --appname MyApp \
+  --packagename com.mycompany.myapp \
+  --organization "My Company"
+```
+
+### With OAuth Configuration
+
+```bash
+forcereact create \
+  --appname MyApp \
+  --packagename com.mycompany.myapp \
+  --organization "My Company" \
+  --consumerkey "3MVG9..." \
+  --callbackurl "myapp://oauth/callback"
+```
+
+### Specifying Platforms
+
+```bash
+# iOS only
+forcereact create --appname MyApp --packagename com.mycompany.myapp --platform ios
+
+# Android only
+forcereact create --appname MyApp --packagename com.mycompany.myapp --platform android
+
+# Both (default)
+forcereact create --appname MyApp --packagename com.mycompany.myapp --platform ios,android
+```
+
+## Project Structure
+
+```
+MyApp/
+├── package.json                 # Dependencies and SDK references
+├── app.js                       # Main application code (CUSTOMIZE THIS)
+├── index.js                     # React Native entry point
+├── metro.config.js              # Metro bundler configuration
+├── babel.config.js              # Babel configuration
+├── .eslintrc.js                 # ESLint rules
+├── .prettierrc.js               # Code formatting rules
+├── mobile_sdk/                  # Cloned SDK repositories (gitignored)
+│   ├── SalesforceMobileSDK-iOS/
+│   └── SalesforceMobileSDK-Android/
+├── ios/                         # iOS native project
+│   ├── Podfile                  # CocoaPods dependencies
+│   ├── MyApp.xcworkspace        # Open this in Xcode
+│   ├── MyApp.xcodeproj/         # Xcode project
+│   └── MyApp/
+│       ├── AppDelegate.swift    # iOS app lifecycle
+│       ├── bootconfig.plist     # OAuth configuration
+│       └── Info.plist           # App metadata
+└── android/                     # Android native project
+    ├── settings.gradle          # Composite build configuration
+    ├── app/
+    │   ├── build.gradle         # App dependencies
+    │   └── src/main/
+    │       ├── AndroidManifest.xml
+    │       ├── java/com/mycompany/myapp/
+    │       │   ├── MainActivity.kt
+    │       │   └── MainApplication.kt
+    │       └── res/
+    │           ├── values/
+    │           │   └── bootconfig.xml  # OAuth configuration
+    │           └── xml/
+    │               └── servers.xml     # Login servers
+```
+
+## Key Files
+
+### app.js
+
+The main application code. This is where you'll spend most of your time customizing.
+
+**Default implementation:**
+
+```javascript
+import React from 'react';
+import {
+    StyleSheet,
+    Text,
+    View,
+    FlatList,
+    ActivityIndicator,
+    TouchableOpacity,
+} from 'react-native';
+
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { oauth, net } from 'react-native-force';
+
+const Stack = createStackNavigator();
+
+export default class App extends React.Component {
+  state = {
+    authenticated: false,
+    records: []
+  };
+
+  componentDidMount() {
+    // Authenticate and fetch data
+    oauth.getAuthCredentials()
+      .then(credentials => {
+        this.setState({ authenticated: true });
+        return net.query('SELECT Id, Name FROM Account LIMIT 10');
+      })
+      .then(response => {
+        this.setState({ records: response.records });
+      })
+      .catch(error => {
+        console.error('Error:', error);
+      });
+  }
+
+  render() {
+    return (
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="Details" component={DetailsScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+  }
+}
+```
+
+**Key points:**
+
+- `oauth.getAuthCredentials()` - Verify authentication
+- `net.query()` - Execute SOQL queries
+- React Navigation for multi-screen navigation
+- Component-based architecture
+
+### iOS Configuration
+
+#### AppDelegate.swift
+
+Initializes the Mobile SDK and handles authentication.
+
+```swift
+import SalesforceReact
+import SalesforceSDKCore
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  override init() {
+    super.init()
+    SalesforceReactSDKManager.initializeSDK()
+  }
+  
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    // ... setup code ...
+    
+    // Authenticate before starting React Native
+    AuthHelper.loginIfRequired() {
+      factory.startReactNative(
+        withModuleName: "MyApp",
+        in: self.window,
+        launchOptions: launchOptions
+      )
+    }
+    
+    return true
+  }
+}
+```
+
+**Authentication flow:**
+
+```mermaid
+sequenceDiagram
+    participant iOS as iOS App
+    participant SDK as Mobile SDK
+    participant OAuth as OAuth Server
+    participant RN as React Native
+
+    iOS->>SDK: AuthHelper.loginIfRequired()
+    
+    alt User Not Authenticated
+        SDK->>OAuth: Present login screen
+        OAuth-->>SDK: User credentials
+        SDK->>OAuth: Exchange for tokens
+        OAuth-->>SDK: Access token + refresh token
+    else User Already Authenticated
+        SDK->>SDK: Validate existing tokens
+    end
+    
+    SDK->>RN: startReactNative()
+    RN-->>iOS: App ready
+```
+
+#### bootconfig.plist
+
+OAuth configuration for the app.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>remoteAccessConsumerKey</key>
+    <string>3MVG9...</string>
+    <key>oauthRedirectURI</key>
+    <string>myapp://oauth/callback</string>
+    <key>shouldAuthenticate</key>
+    <true/>
+</dict>
+</plist>
+```
+
+**To update after generation:**
+
+1. Open `ios/MyApp/bootconfig.plist` in Xcode or text editor
+2. Replace `remoteAccessConsumerKey` with your Connected App's consumer key
+3. Replace `oauthRedirectURI` with your callback URL
+
+#### Podfile
+
+Defines CocoaPods dependencies.
+
+```ruby
+require_relative '../mobile_sdk/SalesforceMobileSDK-iOS/mobilesdk_pods'
+
+platform :ios, '18.0'
+prepare_react_native_project!
+
+target 'MyApp' do
+  config = use_native_modules!
+  use_frameworks! :linkage => :static
+
+  # React Native core
+  use_react_native!(
+    :path => config[:reactNativePath],
+    :app_path => "#{Pod::Config.instance.installation_root}/.."
+  )
+
+  # Mobile SDK libraries
+  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  
+  # React Native bridge
+  pod 'SalesforceReact', :path => '../node_modules/react-native-force'
+
+  post_install do |installer|
+    react_native_post_install(installer, config[:reactNativePath])
+    mobile_sdk_post_install(installer)
+  end
+end
+```
+
+### Android Configuration
+
+#### MainActivity.kt
+
+Main activity for the React Native app.
+
+```kotlin
+package com.mycompany.myapp
+
+import android.os.Bundle
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+import com.salesforce.androidsdk.reactnative.ui.SalesforceReactActivity
+
+class MainActivity : SalesforceReactActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(null) // react-native-screens requires null
+    }
+
+    override fun getMainComponentName() = "MyApp"
+
+    override fun createReactActivityDelegate() = 
+        DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+
+    // Require authentication on app launch
+    override fun shouldAuthenticate() = true
+}
+```
+
+**Key method:**
+
+- `shouldAuthenticate() = true` - Requires authentication before showing React Native content
+- Change to `false` for deferred authentication (see ReactNativeDeferredTemplate)
+
+#### bootconfig.xml
+
+OAuth configuration for Android.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="remoteAccessConsumerKey">3MVG9...</string>
+    <string name="oauthRedirectURI">myapp://oauth/callback</string>
+</resources>
+```
+
+**Location:** `android/app/src/main/res/values/bootconfig.xml`
+
+#### settings.gradle
+
+Configures Gradle composite build to use the cloned Android SDK.
+
+```gradle
+includeBuild('../mobile_sdk/SalesforceMobileSDK-Android') {
+    dependencySubstitution {
+        substitute(module('com.salesforce.mobilesdk:SalesforceSDK'))
+            .using project(':libs:SalesforceSDK')
+        substitute(module('com.salesforce.mobilesdk:SalesforceReact'))
+            .using project(':libs:SalesforceReact')
+    }
+}
+```
+
+## Running the App
+
+### iOS
+
+```bash
+# Install dependencies
+npm install
+cd ios && pod install && cd ..
+
+# Start Metro bundler
+npm start
+
+# In another terminal, run on iOS
+npm run ios
+
+# Or open in Xcode
+open ios/MyApp.xcworkspace
+# Then click Run button
+```
+
+### Android
+
+```bash
+# Install dependencies
+npm install
+
+# Start Metro bundler
+npm start
+
+# In another terminal, run on Android
+npm run android
+
+# Or open in Android Studio
+# File > Open > select android/ directory
+# Then click Run button
+```
+
+## Customization Guide
+
+### Changing the SOQL Query
+
+Edit `app.js` and modify the query in `componentDidMount()`:
+
+```javascript
+componentDidMount() {
+  oauth.getAuthCredentials()
+    .then(() => {
+      // Change this query to fetch your data
+      return net.query('SELECT Id, Name, Industry FROM Account ORDER BY Name LIMIT 50');
+    })
+    .then(response => {
+      this.setState({ records: response.records });
+    });
+}
+```
+
+### Adding New Screens
+
+1. Create a new component:
+
+```javascript
+// ContactScreen.js
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ContactScreen({ route }) {
+  const { contactId } = route.params;
+  
+  return (
+    <View style={styles.container}>
+      <Text>Contact ID: {contactId}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20 }
+});
+```
+
+2. Add to navigation in `app.js`:
+
+```javascript
+<Stack.Navigator>
+  <Stack.Screen name="Home" component={HomeScreen} />
+  <Stack.Screen name="Contact" component={ContactScreen} />
+</Stack.Navigator>
+```
+
+3. Navigate to the screen:
+
+```javascript
+navigation.navigate('Contact', { contactId: '003...' });
+```
+
+### Using SmartStore for Offline Storage
+
+```javascript
+import { smartstore } from 'react-native-force';
+
+// Register a soup (table)
+smartstore.registerSoup(
+  false, // isGlobalStore
+  'accounts', // soupName
+  [ // indexes
+    { path: 'Id', type: 'string' },
+    { path: 'Name', type: 'full_text' }
+  ]
+).then(() => {
+  // Store records
+  return smartstore.upsertSoupEntries(
+    false,
+    'accounts',
+    [
+      { Id: '001...', Name: 'Acme Corp', _soupEntryId: 1 },
+      { Id: '001...', Name: 'Global Inc', _soupEntryId: 2 }
+    ]
+  );
+});
+
+// Query data
+smartstore.querySoup(
+  false,
+  'accounts',
+  { queryType: 'match', path: 'Name', matchKey: 'Acme', order: 'ascending' }
+).then(result => {
+  console.log('Records:', result.currentPageOrderedEntries);
+});
+```
+
+### Handling Logout
+
+```javascript
+import { oauth } from 'react-native-force';
+
+function logout() {
+  oauth.logout();
+  // App will restart and show login screen
+}
+```
+
+### Fetching User Info
+
+```javascript
+import { oauth } from 'react-native-force';
+
+oauth.getAuthCredentials().then(credentials => {
+  console.log('User ID:', credentials.userId);
+  console.log('Org ID:', credentials.orgId);
+  console.log('Instance URL:', credentials.instanceUrl);
+  console.log('Access Token:', credentials.accessToken);
+});
+```
+
+## Application Flow
+
+```mermaid
+flowchart TD
+    A[App Launches] --> B{Platform}
+    
+    B -->|iOS| C[AppDelegate.init]
+    B -->|Android| D[MainActivity.onCreate]
+    
+    C --> E[SalesforceReactSDKManager.initializeSDK]
+    D --> F[Check shouldAuthenticate]
+    
+    E --> G{User Authenticated?}
+    F --> G
+    
+    G -->|No| H[Show OAuth Login]
+    G -->|Yes| I[Validate Tokens]
+    
+    H --> J[User Enters Credentials]
+    J --> K[Exchange for Access Token]
+    K --> I
+    
+    I --> L[Start React Native]
+    L --> M[index.js registers app]
+    M --> N[app.js componentDidMount]
+    N --> O[oauth.getAuthCredentials]
+    O --> P[net.query - Fetch Data]
+    P --> Q[Render UI with Data]
+```
+
+## Data Flow
+
+```mermaid
+flowchart LR
+    A[React Native Component] --> B[react-native-force]
+    B --> C{Platform}
+    
+    C -->|iOS| D[SalesforceReact.framework]
+    C -->|Android| E[SalesforceReact.aar]
+    
+    D --> F[SalesforceSDKCore]
+    E --> G[SalesforceSDK]
+    
+    F --> H[REST API]
+    G --> H
+    
+    H --> I[Salesforce Org]
+    I --> H
+    
+    H --> F
+    H --> G
+    
+    F --> B
+    G --> B
+    
+    B --> A
+```
+
+## Common Issues
+
+### iOS: Pod Install Fails
+
+**Error:** `Unable to find a specification for...`
+
+**Solution:**
+```bash
+cd ios
+rm -rf Pods Podfile.lock
+pod install --repo-update
+```
+
+### Android: Gradle Build Fails
+
+**Error:** `Could not resolve com.salesforce.mobilesdk:SalesforceReact`
+
+**Solution:**
+```bash
+# Ensure mobile_sdk directory exists
+ls mobile_sdk/SalesforceMobileSDK-Android
+
+# If missing, run:
+node installandroid.js
+```
+
+### Metro Bundler: Module Not Found
+
+**Error:** `Unable to resolve module react-native-force`
+
+**Solution:**
+```bash
+# Clear cache and reinstall
+rm -rf node_modules package-lock.json
+npm install
+npm start -- --reset-cache
+```
+
+### Authentication Loop
+
+**Symptom:** App keeps showing login screen repeatedly
+
+**Causes & Solutions:**
+
+1. **Invalid OAuth configuration**
+   - Check `bootconfig.plist` (iOS) or `bootconfig.xml` (Android)
+   - Ensure consumer key and callback URL match your Connected App
+
+2. **Callback URL not registered**
+   - Add callback URL to URL Schemes in Xcode (iOS)
+   - Add callback URL to AndroidManifest.xml intent filter (Android)
+
+3. **Connected App not configured**
+   - Verify OAuth settings in Salesforce Setup
+   - Enable "Refresh Token" policy
+
+## Testing
+
+### Manual Testing
+
+1. **Launch and authenticate**
+   - App should show OAuth login screen
+   - After login, should show data from SOQL query
+
+2. **Test offline behavior**
+   - Login and let data load
+   - Enable airplane mode
+   - Force-quit and restart app
+   - Should re-authenticate using refresh token
+
+3. **Test logout**
+   - Add logout button (see Customization Guide)
+   - Logout should clear tokens and return to login screen
+
+### Automated Testing
+
+Run Jest tests:
+
+```bash
+npm test
+```
+
+### Template Testing
+
+Test the template itself with `test_template.sh`:
+
+```bash
+cd /path/to/SalesforceMobileSDK-Templates
+
+# Test iOS
+./test_template.sh --template ReactNativeTemplate --platform ios
+
+# Test Android
+./test_template.sh --template ReactNativeTemplate --platform android
+
+# Test with custom SDK branch
+./test_template.sh \
+  --template ReactNativeTemplate \
+  --msdk-ios-branch my-feature \
+  --platform ios
+```
+
+## Next Steps
+
+### Learn More
+
+- Read [TEMPLATE_ANATOMY.md](./TEMPLATE_ANATOMY.md) for deep dive into template structure
+- Review [MobileSyncExplorerReactNative.md](./MobileSyncExplorerReactNative.md) for offline sync patterns
+- Check [Salesforce Mobile SDK Documentation](https://developer.salesforce.com/docs/platform/mobile-sdk/guide)
+
+### Add Features
+
+- Implement CRUD operations (Create, Read, Update, Delete)
+- Add offline storage with SmartStore
+- Implement offline sync with MobileSync
+- Add push notifications
+- Implement biometric authentication
+- Add custom login screen
+
+### Related Templates
+
+- [ReactNativeTypeScriptTemplate](./ReactNativeTypeScriptTemplate.md) - TypeScript version
+- [ReactNativeDeferredTemplate](./ReactNativeDeferredTemplate.md) - Guest mode / login on demand
+- [MobileSyncExplorerReactNative](./MobileSyncExplorerReactNative.md) - Full sample with offline sync
+
+## Additional Resources
+
+- [React Native Documentation](https://reactnative.dev/)
+- [React Navigation Documentation](https://reactnavigation.org/)
+- [Salesforce REST API](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/)
+- [SalesforceMobileSDK-ReactNative Repository](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative)

--- a/docs/react-native-templates/ReactNativeTypeScriptTemplate.md
+++ b/docs/react-native-templates/ReactNativeTypeScriptTemplate.md
@@ -1,0 +1,946 @@
+# ReactNativeTypeScriptTemplate
+
+The TypeScript React Native template for Salesforce Mobile SDK applications.
+
+## Overview
+
+`ReactNativeTypeScriptTemplate` is the TypeScript version of the basic React Native template. It provides:
+
+- **TypeScript** with full type safety and IDE support
+- **Immediate authentication** on app launch
+- **Cross-platform** support (iOS and Android)
+- **Sample SOQL query** with typed responses
+- **React Navigation** with TypeScript navigation types
+- **Mobile SDK integration** with `react-native-force`
+
+## When to Use This Template
+
+Choose `ReactNativeTypeScriptTemplate` if:
+
+- You want TypeScript's type safety and developer experience
+- You're building a large-scale application
+- Your team prefers strongly-typed code
+- You need better IDE autocomplete and refactoring
+- You want to catch errors at compile-time rather than runtime
+- Your app requires users to authenticate before accessing any features
+
+## Not the Right Fit?
+
+- **Prefer JavaScript?** → Use [ReactNativeTemplate](./ReactNativeTemplate.md)
+- **Need guest mode?** → Use [ReactNativeDeferredTemplate](./ReactNativeDeferredTemplate.md) (JavaScript only)
+- **Learning the SDK?** → Use [MobileSyncExplorerReactNative](./MobileSyncExplorerReactNative.md) (JavaScript only)
+
+## Creating an App from This Template
+
+### Using the CLI
+
+```bash
+forcereact create \
+  --appname MyApp \
+  --packagename com.mycompany.myapp \
+  --organization "My Company" \
+  --templatename ReactNativeTypeScriptTemplate
+```
+
+### With OAuth Configuration
+
+```bash
+forcereact create \
+  --appname MyApp \
+  --packagename com.mycompany.myapp \
+  --organization "My Company" \
+  --templatename ReactNativeTypeScriptTemplate \
+  --consumerkey "3MVG9..." \
+  --callbackurl "myapp://oauth/callback"
+```
+
+## Differences from JavaScript Template
+
+| Feature | ReactNativeTemplate | ReactNativeTypeScriptTemplate |
+|---------|---------------------|-------------------------------|
+| Language | JavaScript (`.js`) | TypeScript (`.tsx`) |
+| Type Checking | Runtime only | Compile-time + Runtime |
+| IDE Support | Basic | Advanced (autocomplete, refactoring) |
+| Error Detection | Runtime errors | Compile-time errors |
+| Interfaces/Types | None | Fully typed |
+| Build Step | Babel only | TypeScript compiler + Babel |
+| Learning Curve | Lower | Higher |
+| Maintenance | Good | Better (type safety prevents bugs) |
+
+## Project Structure
+
+```
+MyApp/
+├── package.json                 # Dependencies and SDK references
+├── app.tsx                      # Main application code (TypeScript)
+├── index.js                     # React Native entry point
+├── tsconfig.json                # TypeScript compiler configuration
+├── metro.config.js              # Metro bundler configuration
+├── babel.config.js              # Babel configuration
+├── .eslintrc.js                 # ESLint rules (with TS support)
+├── mobile_sdk/                  # Cloned SDK repositories (gitignored)
+│   ├── SalesforceMobileSDK-iOS/
+│   └── SalesforceMobileSDK-Android/
+├── ios/                         # iOS native project (same as JS template)
+└── android/                     # Android native project (same as JS template)
+```
+
+## Key Files
+
+### app.tsx
+
+The main application code with TypeScript types.
+
+**Default implementation:**
+
+```typescript
+import React from 'react';
+import {
+    StyleSheet,
+    Text,
+    View,
+    FlatList,
+    ActivityIndicator,
+    TouchableOpacity,
+} from 'react-native';
+
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { oauth, net } from 'react-native-force';
+
+// Define navigation types
+type RootStackParamList = {
+  Home: undefined;
+  Details: { recordId: string };
+};
+
+const Stack = createStackNavigator<RootStackParamList>();
+
+// Define data types
+interface SalesforceRecord {
+  Id: string;
+  Name: string;
+  attributes: {
+    type: string;
+    url: string;
+  };
+}
+
+interface AppState {
+  authenticated: boolean;
+  records: SalesforceRecord[];
+  loading: boolean;
+}
+
+export default class App extends React.Component<{}, AppState> {
+  state: AppState = {
+    authenticated: false,
+    records: [],
+    loading: true
+  };
+
+  componentDidMount(): void {
+    this.authenticate();
+  }
+
+  authenticate = async (): Promise<void> => {
+    try {
+      const credentials = await oauth.getAuthCredentials();
+      this.setState({ authenticated: true });
+      await this.fetchData();
+    } catch (error) {
+      console.error('Authentication error:', error);
+      this.setState({ loading: false });
+    }
+  }
+
+  fetchData = async (): Promise<void> => {
+    try {
+      const response = await net.query('SELECT Id, Name FROM Account LIMIT 10');
+      this.setState({ 
+        records: response.records as SalesforceRecord[],
+        loading: false 
+      });
+    } catch (error) {
+      console.error('Query error:', error);
+      this.setState({ loading: false });
+    }
+  }
+
+  render() {
+    return (
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="Details" component={DetailsScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+  }
+}
+```
+
+**Key TypeScript features:**
+
+- `type RootStackParamList` - Type-safe navigation
+- `interface SalesforceRecord` - Typed Salesforce data
+- `interface AppState` - Typed component state
+- `async/await` with return type annotations
+- Type assertion for API responses
+
+### tsconfig.json
+
+TypeScript compiler configuration.
+
+```json
+{
+  "extends": "@react-native/typescript-config/tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react-native",
+    "lib": ["es2017"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "target": "esnext"
+  },
+  "exclude": [
+    "node_modules",
+    "babel.config.js",
+    "metro.config.js",
+    "jest.config.js"
+  ]
+}
+```
+
+**Key options:**
+
+- `strict: true` - Enable all strict type-checking options
+- `noEmit: true` - Don't emit JS files (Babel handles transpilation)
+- `skipLibCheck: true` - Skip type checking of declaration files
+- `resolveJsonModule: true` - Import JSON files with types
+
+## TypeScript Features
+
+### Type-Safe Navigation
+
+Define navigation types for type-safe screen navigation:
+
+```typescript
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+type RootStackParamList = {
+  Home: undefined;
+  Details: { recordId: string; name: string };
+  Edit: { recordId: string };
+};
+
+// Use in screen components
+type DetailsScreenProps = NativeStackScreenProps<RootStackParamList, 'Details'>;
+
+function DetailsScreen({ route, navigation }: DetailsScreenProps) {
+  const { recordId, name } = route.params; // Fully typed!
+  
+  return (
+    <View>
+      <Text>Record: {name}</Text>
+      <Button
+        title="Edit"
+        onPress={() => navigation.navigate('Edit', { recordId })}
+      />
+    </View>
+  );
+}
+```
+
+**Benefits:**
+
+- Autocomplete for screen names
+- Type-checked route parameters
+- Compile-time errors for invalid navigation
+
+### Typed Salesforce Responses
+
+Define interfaces for Salesforce data:
+
+```typescript
+interface Account {
+  Id: string;
+  Name: string;
+  Industry?: string;
+  AnnualRevenue?: number;
+  attributes: {
+    type: 'Account';
+    url: string;
+  };
+}
+
+interface Contact {
+  Id: string;
+  FirstName?: string;
+  LastName: string;
+  Email?: string;
+  AccountId?: string;
+  attributes: {
+    type: 'Contact';
+    url: string;
+  };
+}
+
+// Use with SOQL queries
+async function fetchAccounts(): Promise<Account[]> {
+  const response = await net.query<{ records: Account[] }>(
+    'SELECT Id, Name, Industry, AnnualRevenue FROM Account LIMIT 10'
+  );
+  return response.records;
+}
+
+async function fetchContacts(): Promise<Contact[]> {
+  const response = await net.query<{ records: Contact[] }>(
+    'SELECT Id, FirstName, LastName, Email FROM Contact LIMIT 10'
+  );
+  return response.records;
+}
+```
+
+**Benefits:**
+
+- Autocomplete for record fields
+- Type errors for misspelled fields
+- Null safety for optional fields
+
+### Typed SmartStore Operations
+
+Type-safe offline storage:
+
+```typescript
+import { smartstore } from 'react-native-force';
+
+interface ContactSoupEntry {
+  _soupEntryId: number;
+  Id: string;
+  FirstName: string;
+  LastName: string;
+  Email?: string;
+  __local__: boolean;
+  __locally_created__: boolean;
+  __locally_updated__: boolean;
+  __locally_deleted__: boolean;
+}
+
+async function saveContacts(contacts: Contact[]): Promise<void> {
+  const soupEntries: ContactSoupEntry[] = contacts.map((contact, index) => ({
+    _soupEntryId: index + 1,
+    ...contact,
+    __local__: false,
+    __locally_created__: false,
+    __locally_updated__: false,
+    __locally_deleted__: false,
+  }));
+
+  await smartstore.upsertSoupEntries(
+    false,
+    'contacts',
+    soupEntries
+  );
+}
+
+async function queryContacts(): Promise<ContactSoupEntry[]> {
+  const result = await smartstore.querySoup(
+    false,
+    'contacts',
+    { queryType: 'range', indexPath: 'LastName', order: 'ascending' }
+  );
+  return result.currentPageOrderedEntries as ContactSoupEntry[];
+}
+```
+
+### Typed React Hooks
+
+Use TypeScript with React Hooks:
+
+```typescript
+import React, { useState, useEffect } from 'react';
+
+function ContactList() {
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    fetchContacts()
+      .then(setContacts)
+      .catch(setError)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <ActivityIndicator />;
+  if (error) return <Text>Error: {error.message}</Text>;
+
+  return (
+    <FlatList
+      data={contacts}
+      keyExtractor={item => item.Id}
+      renderItem={({ item }) => (
+        <Text>{item.FirstName} {item.LastName}</Text>
+      )}
+    />
+  );
+}
+```
+
+### Typed Props and State
+
+Type-safe component props and state:
+
+```typescript
+interface ContactCardProps {
+  contact: Contact;
+  onPress: (contactId: string) => void;
+  showEmail?: boolean;
+}
+
+interface ContactCardState {
+  expanded: boolean;
+}
+
+class ContactCard extends React.Component<ContactCardProps, ContactCardState> {
+  state: ContactCardState = {
+    expanded: false
+  };
+
+  static defaultProps = {
+    showEmail: true
+  };
+
+  handlePress = () => {
+    this.props.onPress(this.props.contact.Id);
+  }
+
+  toggleExpanded = () => {
+    this.setState(prevState => ({ expanded: !prevState.expanded }));
+  }
+
+  render() {
+    const { contact, showEmail } = this.props;
+    const { expanded } = this.state;
+
+    return (
+      <TouchableOpacity onPress={this.handlePress}>
+        <Text>{contact.FirstName} {contact.LastName}</Text>
+        {showEmail && <Text>{contact.Email}</Text>}
+      </TouchableOpacity>
+    );
+  }
+}
+```
+
+## Type Definitions for react-native-force
+
+The `react-native-force` module includes TypeScript definitions. Here's the type structure:
+
+```typescript
+declare module 'react-native-force' {
+  export namespace oauth {
+    interface Credentials {
+      accessToken: string;
+      refreshToken?: string;
+      instanceUrl: string;
+      userId: string;
+      orgId: string;
+      loginUrl: string;
+      identityUrl: string;
+      clientId: string;
+      userAgent: string;
+      communityId?: string;
+      communityUrl?: string;
+    }
+
+    function getAuthCredentials(): Promise<Credentials>;
+    function authenticate(): Promise<Credentials>;
+    function logout(): void;
+  }
+
+  export namespace net {
+    interface QueryResponse<T = any> {
+      records: T[];
+      totalSize: number;
+      done: boolean;
+      nextRecordsUrl?: string;
+    }
+
+    function query<T = QueryResponse>(soql: string): Promise<T>;
+    function create(sobject: string, fields: object): Promise<any>;
+    function update(sobject: string, id: string, fields: object): Promise<void>;
+    function del(sobject: string, id: string): Promise<void>;
+    function retrieve(sobject: string, id: string, fieldlist: string[]): Promise<any>;
+  }
+
+  export namespace smartstore {
+    interface IndexSpec {
+      path: string;
+      type: 'string' | 'integer' | 'floating' | 'full_text' | 'json1';
+    }
+
+    interface QuerySpec {
+      queryType: 'exact' | 'range' | 'like' | 'match' | 'smart';
+      indexPath?: string;
+      path?: string;
+      matchKey?: string;
+      beginKey?: any;
+      endKey?: any;
+      likeKey?: string;
+      smartSql?: string;
+      order?: 'ascending' | 'descending';
+      pageSize?: number;
+    }
+
+    function registerSoup(
+      isGlobalStore: boolean,
+      soupName: string,
+      indexes: IndexSpec[]
+    ): Promise<void>;
+
+    function upsertSoupEntries(
+      isGlobalStore: boolean,
+      soupName: string,
+      entries: any[]
+    ): Promise<any[]>;
+
+    function querySoup(
+      isGlobalStore: boolean,
+      soupName: string,
+      querySpec: QuerySpec
+    ): Promise<any>;
+  }
+
+  export namespace mobilesync {
+    enum MERGE_MODE {
+      OVERWRITE,
+      LEAVE_IF_CHANGED
+    }
+
+    function syncDown(
+      isGlobalStore: boolean,
+      target: any,
+      soupName: string,
+      options: any,
+      syncName: string
+    ): Promise<any>;
+
+    function syncUp(
+      isGlobalStore: boolean,
+      options: any,
+      soupName: string,
+      syncOptions: any
+    ): Promise<any>;
+
+    function reSync(
+      isGlobalStore: boolean,
+      syncName: string
+    ): Promise<any>;
+  }
+}
+```
+
+## Running the App
+
+### Development
+
+```bash
+# Install dependencies
+npm install
+cd ios && pod install && cd ..
+
+# Type-check (run this often during development)
+npx tsc --noEmit
+
+# Start Metro bundler
+npm start
+
+# Run on iOS
+npm run ios
+
+# Run on Android
+npm run android
+```
+
+### Type Checking
+
+```bash
+# Check for type errors
+npx tsc --noEmit
+
+# Watch mode (continuous type checking)
+npx tsc --noEmit --watch
+```
+
+### Linting
+
+```bash
+# Run ESLint with TypeScript support
+npm run lint
+
+# Auto-fix issues
+npm run lint -- --fix
+```
+
+## Customization Guide
+
+### Adding a Typed Screen Component
+
+```typescript
+import React, { useState, useEffect } from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { net } from 'react-native-force';
+
+// Define navigation types
+type RootStackParamList = {
+  Home: undefined;
+  AccountList: undefined;
+  AccountDetails: { accountId: string };
+};
+
+type Props = NativeStackScreenProps<RootStackParamList, 'AccountList'>;
+
+// Define data types
+interface Account {
+  Id: string;
+  Name: string;
+  Industry?: string;
+  attributes: { type: 'Account'; url: string };
+}
+
+export default function AccountListScreen({ navigation }: Props) {
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    loadAccounts();
+  }, []);
+
+  async function loadAccounts(): Promise<void> {
+    try {
+      const response = await net.query<{ records: Account[] }>(
+        'SELECT Id, Name, Industry FROM Account ORDER BY Name LIMIT 50'
+      );
+      setAccounts(response.records);
+    } catch (error) {
+      console.error('Error loading accounts:', error);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      {loading ? (
+        <Text>Loading...</Text>
+      ) : (
+        <FlatList
+          data={accounts}
+          keyExtractor={item => item.Id}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              onPress={() => navigation.navigate('AccountDetails', { accountId: item.Id })}
+            >
+              <Text style={styles.name}>{item.Name}</Text>
+              {item.Industry && <Text style={styles.industry}>{item.Industry}</Text>}
+            </TouchableOpacity>
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  name: { fontSize: 18, fontWeight: 'bold' },
+  industry: { fontSize: 14, color: '#666' }
+});
+```
+
+### Creating Type-Safe API Helpers
+
+```typescript
+// api.ts
+import { net } from 'react-native-force';
+
+export interface Account {
+  Id: string;
+  Name: string;
+  Industry?: string;
+  AnnualRevenue?: number;
+}
+
+export interface Contact {
+  Id: string;
+  FirstName?: string;
+  LastName: string;
+  Email?: string;
+  AccountId?: string;
+}
+
+export class SalesforceAPI {
+  static async getAccounts(limit: number = 10): Promise<Account[]> {
+    const response = await net.query<{ records: Account[] }>(
+      `SELECT Id, Name, Industry, AnnualRevenue FROM Account LIMIT ${limit}`
+    );
+    return response.records;
+  }
+
+  static async getAccount(id: string): Promise<Account> {
+    return await net.retrieve('Account', id, ['Id', 'Name', 'Industry', 'AnnualRevenue']);
+  }
+
+  static async createAccount(fields: Partial<Account>): Promise<string> {
+    const result = await net.create('Account', fields);
+    return result.id;
+  }
+
+  static async updateAccount(id: string, fields: Partial<Account>): Promise<void> {
+    await net.update('Account', id, fields);
+  }
+
+  static async deleteAccount(id: string): Promise<void> {
+    await net.del('Account', id);
+  }
+
+  static async getContactsForAccount(accountId: string): Promise<Contact[]> {
+    const response = await net.query<{ records: Contact[] }>(
+      `SELECT Id, FirstName, LastName, Email FROM Contact WHERE AccountId = '${accountId}'`
+    );
+    return response.records;
+  }
+}
+
+// Usage in components
+import { SalesforceAPI, Account } from './api';
+
+async function loadData() {
+  const accounts: Account[] = await SalesforceAPI.getAccounts(20);
+  const account: Account = await SalesforceAPI.getAccount('001...');
+  const newId: string = await SalesforceAPI.createAccount({ Name: 'Acme Corp' });
+}
+```
+
+### Type-Safe Context API
+
+```typescript
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { oauth } from 'react-native-force';
+
+interface AuthContextValue {
+  authenticated: boolean;
+  credentials: oauth.Credentials | null;
+  login: () => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [authenticated, setAuthenticated] = useState(false);
+  const [credentials, setCredentials] = useState<oauth.Credentials | null>(null);
+
+  async function login() {
+    try {
+      const creds = await oauth.authenticate();
+      setCredentials(creds);
+      setAuthenticated(true);
+    } catch (error) {
+      console.error('Login failed:', error);
+    }
+  }
+
+  function logout() {
+    oauth.logout();
+    setAuthenticated(false);
+    setCredentials(null);
+  }
+
+  return (
+    <AuthContext.Provider value={{ authenticated, credentials, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+}
+
+// Usage in components
+function MyComponent() {
+  const { authenticated, credentials, logout } = useAuth();
+
+  return (
+    <View>
+      <Text>User: {credentials?.userId}</Text>
+      <Button title="Logout" onPress={logout} />
+    </View>
+  );
+}
+```
+
+## Common TypeScript Patterns
+
+### Discriminated Unions for Loading States
+
+```typescript
+type LoadingState<T> =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: T }
+  | { status: 'error'; error: Error };
+
+function DataComponent() {
+  const [state, setState] = useState<LoadingState<Account[]>>({ status: 'idle' });
+
+  useEffect(() => {
+    setState({ status: 'loading' });
+    SalesforceAPI.getAccounts()
+      .then(data => setState({ status: 'success', data }))
+      .catch(error => setState({ status: 'error', error }));
+  }, []);
+
+  switch (state.status) {
+    case 'idle':
+      return <Text>Ready to load</Text>;
+    case 'loading':
+      return <ActivityIndicator />;
+    case 'success':
+      return <FlatList data={state.data} />;
+    case 'error':
+      return <Text>Error: {state.error.message}</Text>;
+  }
+}
+```
+
+### Generic Components
+
+```typescript
+interface ListProps<T> {
+  items: T[];
+  keyExtractor: (item: T) => string;
+  renderItem: (item: T) => React.ReactElement;
+}
+
+function GenericList<T>({ items, keyExtractor, renderItem }: ListProps<T>) {
+  return (
+    <FlatList
+      data={items}
+      keyExtractor={keyExtractor}
+      renderItem={({ item }) => renderItem(item)}
+    />
+  );
+}
+
+// Usage
+<GenericList<Account>
+  items={accounts}
+  keyExtractor={account => account.Id}
+  renderItem={account => <Text>{account.Name}</Text>}
+/>
+```
+
+## TypeScript Best Practices
+
+1. **Enable strict mode** in `tsconfig.json`
+2. **Avoid `any`** - Use `unknown` or specific types
+3. **Use interfaces for objects** - More readable than inline types
+4. **Export types** - Share types across files
+5. **Type API responses** - Don't trust external data
+6. **Use readonly** for immutable data
+7. **Leverage type guards** for runtime checks
+
+```typescript
+// Type guard example
+function isContact(record: any): record is Contact {
+  return record && typeof record.LastName === 'string';
+}
+
+// Usage
+if (isContact(data)) {
+  console.log(data.LastName); // TypeScript knows this is a Contact
+}
+```
+
+## Testing
+
+### Type-Safe Tests
+
+```typescript
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import AccountListScreen from './AccountListScreen';
+
+describe('AccountListScreen', () => {
+  it('loads and displays accounts', async () => {
+    const { getByText } = render(<AccountListScreen />);
+    
+    await waitFor(() => {
+      expect(getByText('Acme Corp')).toBeTruthy();
+    });
+  });
+});
+```
+
+## Troubleshooting
+
+### Type Errors in react-native-force
+
+If you see type errors from `react-native-force`, you may need to augment the type definitions:
+
+```typescript
+// types/react-native-force.d.ts
+declare module 'react-native-force' {
+  export namespace oauth {
+    interface Credentials {
+      // Add any missing properties here
+      customField?: string;
+    }
+  }
+}
+```
+
+### Module Resolution Errors
+
+Add path aliases to `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["./src/components/*"],
+      "@api/*": ["./src/api/*"]
+    }
+  }
+}
+```
+
+## Next Steps
+
+- Read [TEMPLATE_ANATOMY.md](./TEMPLATE_ANATOMY.md) for template internals
+- Review [ReactNativeTemplate.md](./ReactNativeTemplate.md) for non-TypeScript version
+- Check [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/)
+- Explore [React TypeScript Cheatsheet](https://react-typescript-cheatsheet.netlify.app/)
+
+## Related Resources
+
+- [TypeScript Documentation](https://www.typescriptlang.org/)
+- [React Native TypeScript](https://reactnative.dev/docs/typescript)
+- [React Navigation TypeScript](https://reactnavigation.org/docs/typescript/)
+- [Salesforce Mobile SDK Documentation](https://developer.salesforce.com/docs/platform/mobile-sdk/guide)

--- a/docs/react-native-templates/ReactNativeTypeScriptTemplate.md
+++ b/docs/react-native-templates/ReactNativeTypeScriptTemplate.md
@@ -2,6 +2,8 @@
 
 The TypeScript React Native template for Salesforce Mobile SDK applications.
 
+> **API style note:** The `react-native-force` SDK uses callback-based APIs (`fn(args, successCallback, errorCallback)`). Promise-style code in this guide is illustrative; use `forceUtil.promiser(fn)` for actual promise wrappers.
+
 ## Overview
 
 `ReactNativeTypeScriptTemplate` is the TypeScript version of the basic React Native template. It provides:
@@ -439,111 +441,42 @@ class ContactCard extends React.Component<ContactCardProps, ContactCardState> {
 
 ## Type Definitions for react-native-force
 
-The `react-native-force` module includes TypeScript definitions. Here's the type structure:
+The `react-native-force` package ships its own TypeScript definitions (`dist/index.d.ts` generated from `src/`). Important types to know:
+
+- **`UserAccount`** (from `react-native-force/dist/typings/oauth`):
+  ```typescript
+  type UserAccount = {
+    accessToken: string;
+    clientId: string;
+    instanceUrl: string;
+    loginUrl: string;
+    orgId: string;
+    refreshToken: string;
+    userAgent: string;
+    userId: string;
+  };
+  ```
+- **`SyncDownTarget`, `SyncUpTarget`, `SyncOptions`, `SyncStatus`, `SyncEvent`** from `react-native-force/dist/typings/mobilesync`
+- **`HttpMethod`, `LogLevel`, `QuerySpecType`, `StoreOrder`** from `react-native-force/dist/typings`
+- **`ExecSuccessCallback<T>`, `ExecErrorCallback`** for callback typing
+
+**The SDK uses callback-based APIs**, not Promises:
 
 ```typescript
-declare module 'react-native-force' {
-  export namespace oauth {
-    interface Credentials {
-      accessToken: string;
-      refreshToken?: string;
-      instanceUrl: string;
-      userId: string;
-      orgId: string;
-      loginUrl: string;
-      identityUrl: string;
-      clientId: string;
-      userAgent: string;
-      communityId?: string;
-      communityUrl?: string;
-    }
+import { oauth, net, forceUtil } from 'react-native-force';
+import type { UserAccount } from 'react-native-force/dist/typings/oauth';
 
-    function getAuthCredentials(): Promise<Credentials>;
-    function authenticate(): Promise<Credentials>;
-    function logout(): void;
-  }
+oauth.getAuthCredentials(
+  (creds: UserAccount) => { /* ... */ },
+  (err: Error) => { /* ... */ }
+);
 
-  export namespace net {
-    interface QueryResponse<T = any> {
-      records: T[];
-      totalSize: number;
-      done: boolean;
-      nextRecordsUrl?: string;
-    }
-
-    function query<T = QueryResponse>(soql: string): Promise<T>;
-    function create(sobject: string, fields: object): Promise<any>;
-    function update(sobject: string, id: string, fields: object): Promise<void>;
-    function del(sobject: string, id: string): Promise<void>;
-    function retrieve(sobject: string, id: string, fieldlist: string[]): Promise<any>;
-  }
-
-  export namespace smartstore {
-    interface IndexSpec {
-      path: string;
-      type: 'string' | 'integer' | 'floating' | 'full_text' | 'json1';
-    }
-
-    interface QuerySpec {
-      queryType: 'exact' | 'range' | 'like' | 'match' | 'smart';
-      indexPath?: string;
-      path?: string;
-      matchKey?: string;
-      beginKey?: any;
-      endKey?: any;
-      likeKey?: string;
-      smartSql?: string;
-      order?: 'ascending' | 'descending';
-      pageSize?: number;
-    }
-
-    function registerSoup(
-      isGlobalStore: boolean,
-      soupName: string,
-      indexes: IndexSpec[]
-    ): Promise<void>;
-
-    function upsertSoupEntries(
-      isGlobalStore: boolean,
-      soupName: string,
-      entries: any[]
-    ): Promise<any[]>;
-
-    function querySoup(
-      isGlobalStore: boolean,
-      soupName: string,
-      querySpec: QuerySpec
-    ): Promise<any>;
-  }
-
-  export namespace mobilesync {
-    enum MERGE_MODE {
-      OVERWRITE,
-      LEAVE_IF_CHANGED
-    }
-
-    function syncDown(
-      isGlobalStore: boolean,
-      target: any,
-      soupName: string,
-      options: any,
-      syncName: string
-    ): Promise<any>;
-
-    function syncUp(
-      isGlobalStore: boolean,
-      options: any,
-      soupName: string,
-      syncOptions: any
-    ): Promise<any>;
-
-    function reSync(
-      isGlobalStore: boolean,
-      syncName: string
-    ): Promise<any>;
-  }
-}
+// Promise-style: wrap with forceUtil.promiser
+const getAuth = forceUtil.promiser(oauth.getAuthCredentials);
+const creds: UserAccount = await getAuth();
 ```
+
+If you prefer additional types not exported by the package, you can add a `types/` folder to your project and write your own `.d.ts` declarations. **Do not redeclare the package's types** — that would mask the bundled definitions.
 
 ## Running the App
 

--- a/docs/react-native-templates/TEMPLATE_ANATOMY.md
+++ b/docs/react-native-templates/TEMPLATE_ANATOMY.md
@@ -1,0 +1,913 @@
+# React Native Template Anatomy
+
+This document provides a deep dive into the structure and mechanics of React Native templates in the Salesforce Mobile SDK.
+
+## Overview
+
+React Native templates are **cross-platform** templates that generate both iOS and Android native projects with a shared React Native JavaScript/TypeScript codebase. Understanding the template anatomy is essential for:
+
+- Creating new React Native templates
+- Customizing existing templates
+- Debugging template generation issues
+- Testing templates with custom SDK branches
+
+## Template Directory Structure
+
+```
+ReactNativeTemplate/
+├── package.json                 # SDK dependencies and npm packages
+├── template.js                  # Template customization script (MOST IMPORTANT)
+├── installios.js                # iOS SDK installation script
+├── installandroid.js            # Android SDK installation script
+├── app.js                       # Main React Native application code
+├── index.js                     # React Native entry point
+├── metro.config.js              # Metro bundler configuration
+├── babel.config.js              # Babel transpiler configuration
+├── jest.config.js               # Jest test configuration
+├── tsconfig.json                # TypeScript configuration (TypeScript templates only)
+├── .eslintrc.js                 # ESLint configuration
+├── .prettierrc.js               # Prettier configuration
+├── .watchmanconfig              # Watchman configuration
+├── Gemfile                      # Ruby dependencies (CocoaPods)
+├── ios/                         # iOS native project (see below)
+└── android/                     # Android native project (see below)
+```
+
+## Core Template Files
+
+### package.json
+
+Defines SDK dependencies and npm packages.
+
+**Key sections:**
+
+```json
+{
+  "name": "ReactNativeTemplate",
+  "version": "0.0.1",
+  "private": true,
+  
+  "scripts": {
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "start": "react-native start"
+  },
+  
+  "sdkDependencies": {
+    "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev",
+    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev"
+  },
+  
+  "dependencies": {
+    "react": "19.1.0",
+    "react-native": "0.81.5",
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
+    "@react-navigation/native": "7.1.10",
+    "@react-navigation/stack": "7.3.3",
+    "react-native-safe-area-context": "5.5.2",
+    "react-native-gesture-handler": "2.29.1",
+    "react-native-screens": "4.20.0"
+  }
+}
+```
+
+**sdkDependencies:**
+- Format: `"<repo-name>": "<repo-url>#<branch>"`
+- Used by `installios.js` and `installandroid.js` to clone SDK repositories
+- Cloned to `mobile_sdk/<repo-name>/` directory
+- Supports custom branches for testing (via `test_template.sh`)
+
+**dependencies:**
+- Standard npm packages
+- `react-native-force` is the React Native bridge to the native SDKs
+- Includes React Navigation for multi-screen apps
+
+### template.js
+
+The most important file in any template. This script customizes the template for the user's app.
+
+**Contract:**
+
+```javascript
+module.exports = {
+    appType: 'react_native',  // Template type
+    prepare: prepare          // Customization function
+};
+
+function prepare(config, replaceInFiles, moveFile, removeFile) {
+    // Customization logic
+    return result; // Array of workspace info
+}
+```
+
+**Input (`config` object):**
+
+```javascript
+{
+    appname: 'MyApp',                           // App name (display name)
+    packagename: 'com.mycompany.myapp',         // Bundle ID / package name
+    organization: 'My Company',                 // Organization name (iOS only)
+    platform: 'ios,android',                    // Target platforms (comma-separated)
+    consumerkey: '<oauth-consumer-key>',        // OAuth consumer key (optional)
+    callbackurl: '<oauth-callback-url>',        // OAuth callback URL (optional)
+    loginserver: 'https://login.salesforce.com' // Login server URL (optional)
+}
+```
+
+**Helper functions:**
+
+- `replaceInFiles(oldString, newString, fileArray)` - Replace text in multiple files
+- `moveFile(oldPath, newPath)` - Rename or move a file/directory
+- `removeFile(path)` - Delete a file or directory
+
+**Return value:**
+
+```javascript
+[
+    {
+        workspacePath: 'ios/MyApp.xcworkspace',     // Path to open in Xcode
+        bootconfigFile: 'ios/MyApp/bootconfig.plist', // OAuth config file
+        platform: 'ios'
+    },
+    {
+        workspacePath: 'android',                   // Path to open in Android Studio
+        bootconfigFile: 'android/app/src/main/res/values/bootconfig.xml',
+        platform: 'android'
+    }
+]
+```
+
+**Workflow:**
+
+```mermaid
+flowchart TD
+    A[template.js prepare called] --> B{Platform includes iOS?}
+    B -->|Yes| C[Replace iOS placeholders]
+    C --> D[Rename iOS files]
+    D --> E[require installios.js]
+    E --> F[Add iOS result]
+    
+    B -->|No| G[Remove ios/ directory]
+    G --> H[Remove installios.js]
+    
+    F --> I{Platform includes Android?}
+    H --> I
+    
+    I -->|Yes| J[Replace Android placeholders]
+    J --> K[Move Kotlin files to package structure]
+    K --> L[require installandroid.js]
+    L --> M[Add Android result]
+    
+    I -->|No| N[Remove android/ directory]
+    N --> O[Remove installandroid.js]
+    
+    M --> P[Return results array]
+    O --> P
+```
+
+**Example (simplified):**
+
+```javascript
+function prepare(config, replaceInFiles, moveFile, removeFile) {
+    var path = require('path');
+    var platforms = config.platform.split(',');
+    var result = [];
+
+    if (platforms.indexOf('ios') >= 0) {
+        // Template values to replace
+        var templateAppName = 'ReactNativeTemplate';
+        var templatePackageName = 'com.salesforce.reactnativetemplate';
+
+        // Replace app name in key files
+        replaceInFiles(templateAppName, config.appname, [
+            'package.json',
+            'index.js',
+            'ios/Podfile',
+            'ios/ReactNativeTemplate.xcodeproj/project.pbxproj',
+            'ios/ReactNativeTemplate/AppDelegate.swift'
+        ]);
+
+        // Replace package name (bundle ID)
+        replaceInFiles(templatePackageName, config.packagename, [
+            'ios/ReactNativeTemplate.xcodeproj/project.pbxproj',
+            'ios/ReactNativeTemplate/ReactNativeTemplate.entitlements'
+        ]);
+
+        // Replace OAuth placeholders
+        if (config.consumerkey) {
+            replaceInFiles('__INSERT_CONSUMER_KEY_HERE__', config.consumerkey, [
+                'ios/ReactNativeTemplate/bootconfig.plist'
+            ]);
+        }
+
+        // Rename directories and files
+        moveFile(
+            'ios/ReactNativeTemplate.xcodeproj',
+            path.join('ios', config.appname + '.xcodeproj')
+        );
+        moveFile(
+            'ios/ReactNativeTemplate',
+            path.join('ios', config.appname)
+        );
+
+        // Install iOS SDK dependencies
+        require('./installios');
+
+        // Return iOS workspace info
+        result.push({
+            workspacePath: path.join('ios', config.appname + '.xcworkspace'),
+            bootconfigFile: path.join('ios', config.appname, 'bootconfig.plist'),
+            platform: 'ios'
+        });
+    } else {
+        removeFile('ios');
+        removeFile('installios.js');
+    }
+
+    // Android customization (similar pattern)
+    // ...
+
+    return result;
+}
+```
+
+### installios.js
+
+Downloads iOS SDK dependencies and runs CocoaPods.
+
+**Workflow:**
+
+```mermaid
+flowchart LR
+    A[installios.js executed] --> B[yarn install]
+    B --> C[Read package.json sdkDependencies]
+    C --> D{mobile_sdk/SalesforceMobileSDK-iOS exists?}
+    D -->|No| E[git clone SalesforceMobileSDK-iOS]
+    D -->|Yes| F[Skip clone]
+    E --> G[Create .xcode.env]
+    F --> G
+    G --> H[pod update in ios/]
+    H --> I[Done]
+```
+
+**Code:**
+
+```javascript
+#!/usr/bin/env node
+
+var packageJson = require('./package.json');
+var execSync = require('child_process').execSync;
+var path = require('path');
+var fs = require('fs');
+
+console.log('Installing npm dependencies');
+execSync('yarn install', {stdio:[0,1,2]});
+
+console.log('Installing sdk dependencies');
+var sdkDependency = 'SalesforceMobileSDK-iOS';
+var repoUrlWithBranch = packageJson.sdkDependencies[sdkDependency];
+var parts = repoUrlWithBranch.split('#');
+var repoUrl = parts[0];
+var branch = parts.length > 1 ? parts[1] : 'master';
+var targetDir = path.join('mobile_sdk', sdkDependency);
+
+if (fs.existsSync(targetDir)) {
+    console.log(targetDir + ' already exists - if you want to refresh it, please remove it and re-run install.js');
+} else {
+    execSync('git clone --branch ' + branch + ' --single-branch --depth 1 ' + repoUrl + ' ' + targetDir, {stdio:[0,1,2]});
+}
+
+console.log('Adding .xcode.env');
+const nodePath = execSync('command -v node', { encoding: 'utf-8' }).trim();
+execSync(`echo export NODE_BINARY=${nodePath} > .xcode.env`, {stdio:[0,1,2], cwd:'ios'});
+
+console.log('Installing pod dependencies');
+execSync('pod update', {stdio:[0,1,2], cwd:'ios'});
+```
+
+**Key points:**
+
+- Runs `yarn install` to get npm packages (including `react-native-force`)
+- Clones `SalesforceMobileSDK-iOS` to `mobile_sdk/` directory
+- Uses shallow clone (`--depth 1`) for speed
+- Creates `.xcode.env` with node path (required by React Native 0.69+)
+- Runs `pod update` in `ios/` directory to install CocoaPods dependencies
+
+### installandroid.js
+
+Downloads Android SDK dependencies and prepares for Gradle composite build.
+
+**Workflow:**
+
+```mermaid
+flowchart LR
+    A[installandroid.js executed] --> B[yarn install]
+    B --> C[Read package.json sdkDependencies]
+    C --> D{mobile_sdk/SalesforceMobileSDK-Android exists?}
+    D -->|No| E[git clone SalesforceMobileSDK-Android]
+    D -->|Yes| F[Skip clone]
+    E --> G[Clean up unnecessary files]
+    F --> G
+    G --> H[Done - Gradle will use composite build]
+```
+
+**Code:**
+
+```javascript
+#!/usr/bin/env node
+
+var packageJson = require('./package.json');
+var execSync = require('child_process').execSync;
+var path = require('path');
+var fs = require('fs');
+var rimraf = require('rimraf');
+
+console.log('Installing npm dependencies');
+execSync('yarn install', {stdio:[0,1,2]});
+
+console.log('Installing sdk dependencies');
+var sdkDependency = 'SalesforceMobileSDK-Android';
+var repoUrlWithBranch = packageJson.sdkDependencies[sdkDependency];
+var parts = repoUrlWithBranch.split('#');
+var repoUrl = parts[0];
+var branch = parts.length > 1 ? parts[1] : 'master';
+var targetDir = path.join('mobile_sdk', sdkDependency);
+
+if (fs.existsSync(targetDir)) {
+    console.log(targetDir + ' already exists - if you want to refresh it, please remove it and re-run install.js');
+} else {
+    execSync('git clone --branch ' + branch + ' --single-branch --depth 1 ' + repoUrl + ' ' + targetDir, {stdio:[0,1,2]});
+    
+    // Clean up files that cause issues
+    rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'hybrid'));
+    rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'test'));
+    rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'SalesforceReact', 'package.json'));
+}
+```
+
+**Key differences from iOS:**
+
+- No CocoaPods equivalent to run (Gradle handles dependencies)
+- Cleans up `hybrid/`, `libs/test/`, and `SalesforceReact/package.json` (confuses Metro bundler)
+- Gradle uses **composite build** to reference the cloned SDK (see `android/settings.gradle`)
+
+**Composite build in settings.gradle:**
+
+```gradle
+includeBuild('../mobile_sdk/SalesforceMobileSDK-Android') {
+    dependencySubstitution {
+        substitute(module('com.salesforce.mobilesdk:SalesforceSDK')).
+            using project(':libs:SalesforceSDK')
+        substitute(module('com.salesforce.mobilesdk:SalesforceReact')).
+            using project(':libs:SalesforceReact')
+    }
+}
+```
+
+## iOS Project Structure
+
+```
+ios/
+├── Podfile                      # CocoaPods dependencies
+├── <AppName>.xcodeproj/         # Xcode project
+│   ├── project.pbxproj          # Project configuration (XML)
+│   └── xcshareddata/
+│       └── xcschemes/
+│           └── <AppName>.xcscheme # Build scheme
+└── <AppName>/                   # App directory
+    ├── AppDelegate.swift        # App lifecycle and SDK initialization
+    ├── bootconfig.plist         # OAuth configuration
+    ├── Info.plist               # App metadata and permissions
+    ├── <AppName>.entitlements   # App entitlements (keychain, etc.)
+    └── PrivacyInfo.xcprivacy    # Privacy manifest (required by Apple)
+```
+
+### iOS Key Files
+
+#### Podfile
+
+Defines CocoaPods dependencies for iOS.
+
+```ruby
+require Pod::Executable.execute_command('node', ['-p',
+  'require.resolve(
+    "react-native/scripts/react_native_pods.rb",
+    {paths: [process.argv[1]]},
+  )', __dir__]).strip
+require_relative '../mobile_sdk/SalesforceMobileSDK-iOS/mobilesdk_pods'
+
+platform :ios, '18.0'
+prepare_react_native_project!
+
+target 'ReactNativeTemplate' do
+  config = use_native_modules!
+
+  use_frameworks! :linkage => :static
+
+  # React Native core
+  use_react_native!(
+    :path => config[:reactNativePath],
+    :app_path => "#{Pod::Config.instance.installation_root}/.."
+  )
+
+  # Mobile SDK
+  use_mobile_sdk!(:path => '../mobile_sdk/SalesforceMobileSDK-iOS')
+  
+  # React Native bridge
+  pod 'SalesforceReact', :path => '../node_modules/react-native-force'
+
+  pre_install do |installer|
+    mobile_sdk_pre_install(installer)
+  end
+
+  post_install do |installer|
+    react_native_post_install(
+      installer,
+      config[:reactNativePath],
+      :mac_catalyst_enabled => false
+    )
+    mobile_sdk_post_install(installer)
+  end
+end
+```
+
+**Key dependencies:**
+
+- `use_mobile_sdk!` - Loads all Mobile SDK libraries from cloned repo
+- `pod 'SalesforceReact'` - React Native bridge
+- `use_react_native!` - React Native core libraries
+- `use_native_modules!` - Auto-links React Native community modules
+
+#### AppDelegate.swift
+
+App lifecycle and SDK initialization.
+
+```swift
+import UIKit
+import React
+import React_RCTAppDelegate
+import ReactAppDependencyProvider
+import SalesforceReact
+import SalesforceSDKCore
+import UserNotifications
+import UserNotificationsUI
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+  var reactNativeDelegate: ReactNativeDelegate?
+  var reactNativeFactory: RCTReactNativeFactory?
+  
+  override init() {
+    super.init()
+    // Initialize Mobile SDK for React Native
+    SalesforceReactSDKManager.initializeSDK()
+  }
+  
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = RCTReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+    
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+    window = UIWindow(frame: UIScreen.main.bounds)
+    
+    // Authenticate and start React Native
+    AuthHelper.loginIfRequired() {
+      factory.startReactNative(
+        withModuleName: "ReactNativeTemplate",
+        in: self.window,
+        launchOptions: launchOptions
+      )
+    }
+    
+    return true
+  }
+}
+
+class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
+  override func bundleURL() -> URL? {
+    #if DEBUG
+      RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+    #else
+      Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+    #endif
+  }
+}
+```
+
+**Key points:**
+
+- `SalesforceReactSDKManager.initializeSDK()` must be called in `init()`
+- `AuthHelper.loginIfRequired()` handles authentication flow
+- `startReactNative(withModuleName:)` launches the React Native app
+- Module name must match the one registered in `index.js`
+
+#### bootconfig.plist
+
+OAuth configuration for iOS.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>remoteAccessConsumerKey</key>
+    <string>__INSERT_CONSUMER_KEY_HERE__</string>
+    <key>oauthRedirectURI</key>
+    <string>__INSERT_CALLBACK_URL_HERE__</string>
+    <key>shouldAuthenticate</key>
+    <true/>
+</dict>
+</plist>
+```
+
+**Placeholders:**
+
+- `__INSERT_CONSUMER_KEY_HERE__` - Replaced by `config.consumerkey` in `template.js`
+- `__INSERT_CALLBACK_URL_HERE__` - Replaced by `config.callbackurl` in `template.js`
+
+#### Info.plist
+
+App metadata and permissions.
+
+**Key entries:**
+
+```xml
+<key>CFBundleDisplayName</key>
+<string>$(PRODUCT_NAME)</string>
+
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+
+<key>SFDCDefaultLoginHost</key>
+<string>__INSERT_DEFAULT_LOGIN_SERVER__</string>
+
+<key>CFBundleURLTypes</key>
+<array>
+    <dict>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+        </array>
+    </dict>
+</array>
+
+<key>NSCameraUsageDescription</key>
+<string>This app requires camera access</string>
+
+<key>NSPhotoLibraryUsageDescription</key>
+<string>This app requires photo library access</string>
+```
+
+## Android Project Structure
+
+```
+android/
+├── build.gradle                 # Root Gradle configuration
+├── settings.gradle              # Project structure and composite build
+├── gradle.properties            # Gradle properties
+└── app/                         # App module
+    ├── build.gradle             # App-level Gradle configuration
+    └── src/main/
+        ├── AndroidManifest.xml  # App manifest
+        ├── java/                # Kotlin source files
+        │   └── <package>/
+        │       ├── MainActivity.kt      # Main activity
+        │       └── MainApplication.kt   # Application class
+        └── res/                 # Android resources
+            ├── values/
+            │   ├── bootconfig.xml      # OAuth configuration
+            │   └── strings.xml         # String resources
+            └── xml/
+                └── servers.xml          # Login servers
+```
+
+### Android Key Files
+
+#### settings.gradle
+
+Defines project structure and composite build.
+
+```gradle
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+includeBuild('../mobile_sdk/SalesforceMobileSDK-Android') {
+    dependencySubstitution {
+        substitute(module('com.salesforce.mobilesdk:SalesforceSDK')).
+            using project(':libs:SalesforceSDK')
+        substitute(module('com.salesforce.mobilesdk:SalesforceReact')).
+            using project(':libs:SalesforceReact')
+    }
+}
+
+include ':app'
+```
+
+**Composite build:**
+
+- References the cloned `SalesforceMobileSDK-Android` repository
+- Gradle treats it as a local Maven repository
+- Allows using unreleased SDK versions for development
+
+#### app/build.gradle
+
+App-level Gradle configuration.
+
+```gradle
+apply plugin: "com.android.application"
+apply plugin: "org.jetbrains.kotlin.android"
+apply plugin: "com.facebook.react"
+
+react {
+    autolinkLibrariesWithApp()
+}
+
+android {
+    compileSdk 35
+    
+    namespace "com.salesforce.reactnativetemplate"
+    defaultConfig {
+        applicationId "com.salesforce.reactnativetemplate"
+        minSdkVersion 26
+        targetSdkVersion 35
+        versionCode 1
+        versionName "1.0"
+    }
+}
+
+dependencies {
+    implementation("com.facebook.react:react-android")
+    implementation("com.salesforce.mobilesdk:SalesforceReact")
+    
+    if (hermesEnabled.toBoolean()) {
+        implementation("com.facebook.react:hermes-android")
+    }
+}
+```
+
+#### MainActivity.kt
+
+Main activity for the React Native app.
+
+```kotlin
+package com.salesforce.reactnativetemplate
+
+import android.os.Bundle
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+import com.salesforce.androidsdk.reactnative.ui.SalesforceReactActivity
+
+class MainActivity : SalesforceReactActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(null) // react-native-screens requires null
+    }
+
+    override fun getMainComponentName() = "ReactNativeTemplate"
+
+    override fun createReactActivityDelegate() = 
+        DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+
+    override fun shouldAuthenticate() = true // Require login on launch
+}
+```
+
+**Key points:**
+
+- Extends `SalesforceReactActivity` (not standard `ReactActivity`)
+- `getMainComponentName()` must match the name in `index.js`
+- `shouldAuthenticate()` controls authentication behavior:
+  - `true` - Require login on launch (default)
+  - `false` - Deferred authentication
+
+#### bootconfig.xml
+
+OAuth configuration for Android.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="remoteAccessConsumerKey">__INSERT_CONSUMER_KEY_HERE__</string>
+    <string name="oauthRedirectURI">__INSERT_CALLBACK_URL_HERE__</string>
+</resources>
+```
+
+#### servers.xml
+
+Login server configuration.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<servers>
+    <server name="Production" url="__INSERT_DEFAULT_LOGIN_SERVER__" />
+</servers>
+```
+
+**Placeholder:**
+
+- `__INSERT_DEFAULT_LOGIN_SERVER__` - Replaced by `config.loginserver` in `template.js`
+
+## React Native Code Structure
+
+### index.js
+
+React Native entry point.
+
+```javascript
+import { AppRegistry } from 'react-native';
+import App from './app'; // or './app.tsx' for TypeScript
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);
+```
+
+### app.js (or app.tsx)
+
+Main application code.
+
+**Structure:**
+
+```javascript
+import React from 'react';
+import { StyleSheet, Text, View, FlatList } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { oauth, net } from 'react-native-force';
+
+const Stack = createStackNavigator();
+
+// Main App component
+export default class App extends React.Component {
+  componentDidMount() {
+    // Authenticate if needed
+    oauth.getAuthCredentials()
+      .then(credentials => {
+        // Fetch data from Salesforce
+        return net.query('SELECT Id, Name FROM Account LIMIT 10');
+      })
+      .then(response => {
+        this.setState({ records: response.records });
+      });
+  }
+
+  render() {
+    return (
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={HomeScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+  }
+}
+```
+
+## Template Placeholders
+
+All placeholders are replaced by `template.js` during app generation.
+
+| Placeholder | Replaced With | Files |
+|-------------|---------------|-------|
+| `ReactNativeTemplate` | `config.appname` | project.pbxproj, Podfile, MainActivity.kt, AppDelegate.swift, package.json, index.js |
+| `com.salesforce.reactnativetemplate` | `config.packagename` | project.pbxproj, entitlements, build.gradle, MainActivity.kt |
+| `ReactNativeTemplateOrganizationName` | `config.organization` | project.pbxproj |
+| `__INSERT_CONSUMER_KEY_HERE__` | `config.consumerkey` | bootconfig.plist, bootconfig.xml |
+| `__INSERT_CALLBACK_URL_HERE__` | `config.callbackurl` | bootconfig.plist, bootconfig.xml |
+| `__INSERT_DEFAULT_LOGIN_SERVER__` | `config.loginserver` | Info.plist, servers.xml |
+
+## Template Testing
+
+Templates can be tested using `test_template.sh` with SDK overrides:
+
+```bash
+./test_template.sh \
+  --template ReactNativeTemplate \
+  --platform ios \
+  --msdk-ios-org wmathurin \
+  --msdk-ios-branch my-feature
+```
+
+**What happens:**
+
+1. Script modifies `package.json` `sdkDependencies` to use custom branch
+2. Script runs `template.js` to generate the app
+3. Script runs `installios.js` (or `installandroid.js`)
+4. Script attempts to build the generated app with Xcode/Gradle
+
+## Advanced Topics
+
+### Creating a New React Native Template
+
+1. Copy an existing template (e.g., `ReactNativeTemplate`)
+2. Rename all occurrences of the template name
+3. Update `template.js`:
+   - Change `templateAppName` variable
+   - Change `templatePackageName` variable
+   - Add/remove customization logic as needed
+4. Update `app.js` (or `app.tsx`) with your custom logic
+5. Add entry to `templates.json`:
+   ```json
+   {
+     "path": "MyCustomTemplate",
+     "description": "My custom React Native template",
+     "appType": "react_native",
+     "platforms": ["ios", "android"]
+   }
+   ```
+6. Test with `test_template.sh`
+
+### Deferred Authentication Pattern
+
+Implemented in `ReactNativeDeferredTemplate`.
+
+**iOS changes:**
+
+- No changes to `AppDelegate.swift` (still calls `AuthHelper.loginIfRequired()`)
+- App handles unauthenticated state in React Native code
+- Uses `oauth.authenticate()` when user taps "Login" button
+
+**Android changes:**
+
+```kotlin
+override fun shouldAuthenticate() = false
+```
+
+**React Native code:**
+
+```javascript
+// Check if authenticated
+oauth.getAuthCredentials()
+  .then(credentials => {
+    // User is authenticated
+  })
+  .catch(error => {
+    // User is NOT authenticated - show login button
+  });
+
+// Trigger login
+oauth.authenticate()
+  .then(credentials => {
+    // User logged in successfully
+  });
+```
+
+### MobileSync Pattern
+
+Implemented in `MobileSyncExplorerReactNative`.
+
+**Key files:**
+
+- `js/StoreMgr.js` - Manages SmartStore and MobileSync operations
+- `js/ContactScreen.js` - CRUD operations for contacts
+- `js/SearchScreen.js` - Search and list contacts
+
+**Sync workflow:**
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant SmartStore
+    participant MobileSync
+    participant Salesforce
+
+    App->>SmartStore: registerSoup('contacts')
+    App->>MobileSync: syncDown(soql query)
+    MobileSync->>Salesforce: Query contacts
+    Salesforce-->>MobileSync: Return records
+    MobileSync->>SmartStore: Store records locally
+    MobileSync-->>App: Sync complete
+    
+    App->>SmartStore: querySoup('contacts')
+    SmartStore-->>App: Return cached records
+    
+    App->>SmartStore: upsertSoupEntries (modify record)
+    
+    App->>MobileSync: syncUp()
+    MobileSync->>SmartStore: Get dirty records
+    MobileSync->>Salesforce: Update records
+    Salesforce-->>MobileSync: Success
+    MobileSync->>SmartStore: Mark records as clean
+    MobileSync-->>App: Sync complete
+```
+
+## Related Documentation
+
+- [README.md](./README.md) - Overview of all React Native templates
+- [ReactNativeTemplate.md](./ReactNativeTemplate.md) - Basic JavaScript template
+- [ReactNativeTypeScriptTemplate.md](./ReactNativeTypeScriptTemplate.md) - TypeScript template
+- [ReactNativeDeferredTemplate.md](./ReactNativeDeferredTemplate.md) - Deferred authentication
+- [MobileSyncExplorerReactNative.md](./MobileSyncExplorerReactNative.md) - Full sample app
+- [../../CLAUDE.md](../../CLAUDE.md) - AI development guidelines
+- [../../TESTING.md](../../TESTING.md) - Template testing guide


### PR DESCRIPTION
## Summary

Adds comprehensive in-repo documentation for all 4 React Native templates: an overview, a deep-dive on template anatomy, and a per-template guide.

## What's new under `docs/react-native-templates/`

- **README.md** — Overview of all 4 RN templates, comparison table, choice guidance, common tasks (with actual callback-based API examples)
- **TEMPLATE_ANATOMY.md** — Deep dive on `template.js`, `installios.js`, `installandroid.js`, the placeholder system, generation flow, with Mermaid diagrams
- **ReactNativeTemplate.md** — Basic JavaScript template guide
- **ReactNativeTypeScriptTemplate.md** — TypeScript template guide (no fabricated module declarations; references actual `src/typings/` types)
- **ReactNativeDeferredTemplate.md** — Deferred-login template guide
- **MobileSyncExplorerReactNative.md** — Sample app guide (notes `react-native-elements` and `react-native-vector-icons` as unique deps)

## Accuracy review

All docs were reviewed against the templates on this branch:
- `App` documented as a **named export** (`export const App`), not default
- Sample SOQL query uses **`Contact`** (matches actual `app.js`), not `Account`
- API examples use the SDK's actual **callback-based** style (`fn(args, success, error)`); a top-of-doc note explains how to wrap with `forceUtil.promiser` for promise style
- TypeScript guide points at the package's bundled `dist/typings/` instead of redeclaring fabricated types

## Test plan

- [ ] Render docs on GitHub and verify Mermaid diagrams display correctly
- [ ] Spot-check examples against actual `*/app.js` and `*/index.js`
- [ ] Verify cross-links between docs work