### PR TITLE
Temporary fix: React Native Android templates AGP compatibility

### DIFF
--- a/MobileSyncExplorerReactNative/android/app/build.gradle
+++ b/MobileSyncExplorerReactNative/android/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: "com.android.application"
-apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 /**
@@ -87,11 +86,12 @@ android {
     }
     buildFeatures {
         buildConfig = true
+        resValues = true
     }
     buildTypes {
         release {
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -12,9 +12,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:9.1.1")
+        classpath("com.android.tools.build:gradle:8.12.0")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
 

--- a/MobileSyncExplorerReactNative/android/gradle.properties
+++ b/MobileSyncExplorerReactNative/android/gradle.properties
@@ -42,7 +42,3 @@ hermesEnabled=true
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
 edgeToEdgeEnabled=false
-
-android.defaults.buildfeatures.buildconfig=true
-android.builtInKotlin=false
-android.newDsl=false

--- a/MobileSyncExplorerReactNative/android/gradle/wrapper/gradle-wrapper.properties
+++ b/MobileSyncExplorerReactNative/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/MobileSyncExplorerReactNative/installandroid.js
+++ b/MobileSyncExplorerReactNative/installandroid.js
@@ -22,5 +22,35 @@ if (fs.existsSync(targetDir)) {
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'hybrid'));
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'test'));
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'SalesforceReact', 'package.json')); // confuses metro bundler
+
+    // Patch settings.gradle.kts to exclude sample apps
+    var settingsFile = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'settings.gradle.kts');
+    if (fs.existsSync(settingsFile)) {
+        var settings = fs.readFileSync(settingsFile, 'utf8');
+        // Comment out sample app includes
+        settings = settings.replace(/^include\("(hybrid|native):/gm, '// include("$1:');
+        fs.writeFileSync(settingsFile, settings, 'utf8');
+        console.log('Patched settings.gradle.kts to exclude sample apps');
+    }
+
+    // Patch buildSrc build.gradle.kts to use AGP 8.12.0 for React Native compatibility
+    var buildSrcGradle = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'buildSrc', 'build.gradle.kts');
+    if (fs.existsSync(buildSrcGradle)) {
+        var buildSrcContent = fs.readFileSync(buildSrcGradle, 'utf8');
+        // Replace AGP version with 8.12.0
+        buildSrcContent = buildSrcContent.replace(/"com\.android\.tools\.build:gradle:[^"]+"/g, '"com.android.tools.build:gradle:8.12.0"');
+        fs.writeFileSync(buildSrcGradle, buildSrcContent, 'utf8');
+        console.log('Patched buildSrc/build.gradle.kts to use AGP 8.12.0');
+    }
+
+    // Patch build.gradle.kts to use AGP 8.12.0
+    var buildGradle = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'build.gradle.kts');
+    if (fs.existsSync(buildGradle)) {
+        var buildContent = fs.readFileSync(buildGradle, 'utf8');
+        // Replace AGP version with 8.12.0
+        buildContent = buildContent.replace(/"com\.android\.tools\.build:gradle:[^"]+"/g, '"com.android.tools.build:gradle:8.12.0"');
+        fs.writeFileSync(buildGradle, buildContent, 'utf8');
+        console.log('Patched build.gradle.kts to use AGP 8.12.0');
+    }
 }
 

--- a/MobileSyncExplorerReactNative/package.json
+++ b/MobileSyncExplorerReactNative/package.json
@@ -21,8 +21,8 @@
     "@react-native/new-app-screen": "0.81.5",
     "react-native-safe-area-context": "5.5.2",
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
-    "react-native-gesture-handler": "2.29.1",
-    "react-native-screens": "4.20.0",
+    "react-native-gesture-handler": "2.31.2",
+    "react-native-screens": "4.25.2",
     "react-native-elements": "3.4.3",
     "react-native-vector-icons": "10.0.2"
   },

--- a/ReactNativeDeferredTemplate/android/app/build.gradle
+++ b/ReactNativeDeferredTemplate/android/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: "com.android.application"
-apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 /**
@@ -87,11 +86,12 @@ android {
     }
     buildFeatures {
         buildConfig = true
+        resValues = true
     }
     buildTypes {
         release {
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -12,9 +12,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:9.1.1")
+        classpath("com.android.tools.build:gradle:8.12.0")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
 

--- a/ReactNativeDeferredTemplate/android/gradle.properties
+++ b/ReactNativeDeferredTemplate/android/gradle.properties
@@ -42,7 +42,3 @@ hermesEnabled=true
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
 edgeToEdgeEnabled=false
-
-android.defaults.buildfeatures.buildconfig=true
-android.builtInKotlin=false
-android.newDsl=false

--- a/ReactNativeDeferredTemplate/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ReactNativeDeferredTemplate/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ReactNativeDeferredTemplate/installandroid.js
+++ b/ReactNativeDeferredTemplate/installandroid.js
@@ -22,5 +22,35 @@ if (fs.existsSync(targetDir)) {
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'hybrid'));
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'test'));
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'SalesforceReact', 'package.json')); // confuses metro bundler
+
+    // Patch settings.gradle.kts to exclude sample apps
+    var settingsFile = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'settings.gradle.kts');
+    if (fs.existsSync(settingsFile)) {
+        var settings = fs.readFileSync(settingsFile, 'utf8');
+        // Comment out sample app includes
+        settings = settings.replace(/^include\("(hybrid|native):/gm, '// include("$1:');
+        fs.writeFileSync(settingsFile, settings, 'utf8');
+        console.log('Patched settings.gradle.kts to exclude sample apps');
+    }
+
+    // Patch buildSrc build.gradle.kts to use AGP 8.12.0 for React Native compatibility
+    var buildSrcGradle = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'buildSrc', 'build.gradle.kts');
+    if (fs.existsSync(buildSrcGradle)) {
+        var buildSrcContent = fs.readFileSync(buildSrcGradle, 'utf8');
+        // Replace AGP version with 8.12.0
+        buildSrcContent = buildSrcContent.replace(/"com\.android\.tools\.build:gradle:[^"]+"/g, '"com.android.tools.build:gradle:8.12.0"');
+        fs.writeFileSync(buildSrcGradle, buildSrcContent, 'utf8');
+        console.log('Patched buildSrc/build.gradle.kts to use AGP 8.12.0');
+    }
+
+    // Patch build.gradle.kts to use AGP 8.12.0
+    var buildGradle = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'build.gradle.kts');
+    if (fs.existsSync(buildGradle)) {
+        var buildContent = fs.readFileSync(buildGradle, 'utf8');
+        // Replace AGP version with 8.12.0
+        buildContent = buildContent.replace(/"com\.android\.tools\.build:gradle:[^"]+"/g, '"com.android.tools.build:gradle:8.12.0"');
+        fs.writeFileSync(buildGradle, buildContent, 'utf8');
+        console.log('Patched build.gradle.kts to use AGP 8.12.0');
+    }
 }
 

--- a/ReactNativeDeferredTemplate/package.json
+++ b/ReactNativeDeferredTemplate/package.json
@@ -21,8 +21,8 @@
     "@react-native/new-app-screen": "0.81.5",
     "react-native-safe-area-context": "5.5.2",
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
-    "react-native-gesture-handler": "2.29.1",
-    "react-native-screens": "4.20.0"
+    "react-native-gesture-handler": "2.31.2",
+    "react-native-screens": "4.25.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/ReactNativeTemplate/android/app/build.gradle
+++ b/ReactNativeTemplate/android/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: "com.android.application"
-apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 /**
@@ -87,11 +86,12 @@ android {
     }
     buildFeatures {
         buildConfig = true
+        resValues = true
     }
     buildTypes {
         release {
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -12,9 +12,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:9.1.1")
+        classpath("com.android.tools.build:gradle:8.12.0")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
 

--- a/ReactNativeTemplate/android/gradle.properties
+++ b/ReactNativeTemplate/android/gradle.properties
@@ -42,7 +42,3 @@ hermesEnabled=true
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
 edgeToEdgeEnabled=false
-
-android.defaults.buildfeatures.buildconfig=true
-android.builtInKotlin=false
-android.newDsl=false

--- a/ReactNativeTemplate/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ReactNativeTemplate/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ReactNativeTemplate/android/settings.gradle
+++ b/ReactNativeTemplate/android/settings.gradle
@@ -11,5 +11,11 @@ includeBuild('../node_modules/@react-native/gradle-plugin')
 
 def salesforceMobileSdkRoot = new File('../mobile_sdk/SalesforceMobileSDK-Android')
 if (salesforceMobileSdkRoot.exists()) {
-    includeBuild(salesforceMobileSdkRoot)
+    includeBuild(salesforceMobileSdkRoot) {
+        dependencySubstitution {
+            substitute(module('com.salesforce.mobilesdk:SalesforceSDK')).using(project(':libs:SalesforceSDK'))
+            substitute(module('com.salesforce.mobilesdk:SalesforceAnalytics')).using(project(':libs:SalesforceAnalytics'))
+            substitute(module('com.salesforce.mobilesdk:SalesforceReact')).using(project(':libs:SalesforceReact'))
+        }
+    }
 }

--- a/ReactNativeTemplate/installandroid.js
+++ b/ReactNativeTemplate/installandroid.js
@@ -22,5 +22,35 @@ if (fs.existsSync(targetDir)) {
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'hybrid'));
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'test'));
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'SalesforceReact', 'package.json')); // confuses metro bundler
+
+    // Patch settings.gradle.kts to exclude sample apps
+    var settingsFile = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'settings.gradle.kts');
+    if (fs.existsSync(settingsFile)) {
+        var settings = fs.readFileSync(settingsFile, 'utf8');
+        // Comment out sample app includes
+        settings = settings.replace(/^include\("(hybrid|native):/gm, '// include("$1:');
+        fs.writeFileSync(settingsFile, settings, 'utf8');
+        console.log('Patched settings.gradle.kts to exclude sample apps');
+    }
+
+    // Patch buildSrc build.gradle.kts to use AGP 8.12.0 for React Native compatibility
+    var buildSrcGradle = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'buildSrc', 'build.gradle.kts');
+    if (fs.existsSync(buildSrcGradle)) {
+        var buildSrcContent = fs.readFileSync(buildSrcGradle, 'utf8');
+        // Replace AGP version with 8.12.0
+        buildSrcContent = buildSrcContent.replace(/"com\.android\.tools\.build:gradle:[^"]+"/g, '"com.android.tools.build:gradle:8.12.0"');
+        fs.writeFileSync(buildSrcGradle, buildSrcContent, 'utf8');
+        console.log('Patched buildSrc/build.gradle.kts to use AGP 8.12.0');
+    }
+
+    // Patch build.gradle.kts to use AGP 8.12.0
+    var buildGradle = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'build.gradle.kts');
+    if (fs.existsSync(buildGradle)) {
+        var buildContent = fs.readFileSync(buildGradle, 'utf8');
+        // Replace AGP version with 8.12.0
+        buildContent = buildContent.replace(/"com\.android\.tools\.build:gradle:[^"]+"/g, '"com.android.tools.build:gradle:8.12.0"');
+        fs.writeFileSync(buildGradle, buildContent, 'utf8');
+        console.log('Patched build.gradle.kts to use AGP 8.12.0');
+    }
 }
 

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -21,8 +21,8 @@
     "@react-native/new-app-screen": "0.81.5",
     "react-native-safe-area-context": "5.5.2",
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
-    "react-native-gesture-handler": "2.29.1",
-    "react-native-screens": "4.20.0"
+    "react-native-gesture-handler": "2.31.2",
+    "react-native-screens": "4.25.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/ReactNativeTypeScriptTemplate/android/app/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: "com.android.application"
-apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 /**
@@ -87,11 +86,12 @@ android {
     }
     buildFeatures {
         buildConfig = true
+        resValues = true
     }
     buildTypes {
         release {
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -12,9 +12,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:9.1.1")
+        classpath("com.android.tools.build:gradle:8.12.0")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
 

--- a/ReactNativeTypeScriptTemplate/android/gradle.properties
+++ b/ReactNativeTypeScriptTemplate/android/gradle.properties
@@ -42,7 +42,3 @@ hermesEnabled=true
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
 edgeToEdgeEnabled=false
-
-android.defaults.buildfeatures.buildconfig=true
-android.builtInKotlin=false
-android.newDsl=false

--- a/ReactNativeTypeScriptTemplate/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ReactNativeTypeScriptTemplate/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ReactNativeTypeScriptTemplate/installandroid.js
+++ b/ReactNativeTypeScriptTemplate/installandroid.js
@@ -22,5 +22,35 @@ if (fs.existsSync(targetDir)) {
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'hybrid'));
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'test'));
     rimraf.sync(path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'libs', 'SalesforceReact', 'package.json')); // confuses metro bundler
+
+    // Patch settings.gradle.kts to exclude sample apps
+    var settingsFile = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'settings.gradle.kts');
+    if (fs.existsSync(settingsFile)) {
+        var settings = fs.readFileSync(settingsFile, 'utf8');
+        // Comment out sample app includes
+        settings = settings.replace(/^include\("(hybrid|native):/gm, '// include("$1:');
+        fs.writeFileSync(settingsFile, settings, 'utf8');
+        console.log('Patched settings.gradle.kts to exclude sample apps');
+    }
+
+    // Patch buildSrc build.gradle.kts to use AGP 8.12.0 for React Native compatibility
+    var buildSrcGradle = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'buildSrc', 'build.gradle.kts');
+    if (fs.existsSync(buildSrcGradle)) {
+        var buildSrcContent = fs.readFileSync(buildSrcGradle, 'utf8');
+        // Replace AGP version with 8.12.0
+        buildSrcContent = buildSrcContent.replace(/"com\.android\.tools\.build:gradle:[^"]+"/g, '"com.android.tools.build:gradle:8.12.0"');
+        fs.writeFileSync(buildSrcGradle, buildSrcContent, 'utf8');
+        console.log('Patched buildSrc/build.gradle.kts to use AGP 8.12.0');
+    }
+
+    // Patch build.gradle.kts to use AGP 8.12.0
+    var buildGradle = path.join('mobile_sdk', 'SalesforceMobileSDK-Android', 'build.gradle.kts');
+    if (fs.existsSync(buildGradle)) {
+        var buildContent = fs.readFileSync(buildGradle, 'utf8');
+        // Replace AGP version with 8.12.0
+        buildContent = buildContent.replace(/"com\.android\.tools\.build:gradle:[^"]+"/g, '"com.android.tools.build:gradle:8.12.0"');
+        fs.writeFileSync(buildGradle, buildContent, 'utf8');
+        console.log('Patched build.gradle.kts to use AGP 8.12.0');
+    }
 }
 

--- a/ReactNativeTypeScriptTemplate/package.json
+++ b/ReactNativeTypeScriptTemplate/package.json
@@ -21,8 +21,8 @@
     "@react-native/new-app-screen": "0.81.5",
     "react-native-safe-area-context": "5.5.2",
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
-    "react-native-gesture-handler": "2.29.1",
-    "react-native-screens": "4.20.0"
+    "react-native-gesture-handler": "2.31.2",
+    "react-native-screens": "4.25.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary

This PR fixes the React Native Android template build issues caused by the recent Android SDK upgrade to AGP 9.1.1, Gradle 9.4.1, and Kotlin 2.3.20 ([PR #2871](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2871)).

**This is a temporary solution for development builds.** We plan to upgrade React Native before shipping Mobile SDK 14.0 to a version that natively supports AGP 9+ and Gradle 9+.

## Problem

React Native 0.81.5 and its ecosystem libraries were designed for AGP 8.x. AGP 9.1.1 includes built-in Kotlin support, which conflicts with these libraries that explicitly apply the `kotlin-android` plugin.

## Solution

### For Template Apps (Development & Production)
- Downgrade to **AGP 8.12.0** and **Gradle 8.14.3** (compatible with RN 0.81.5)
- Use Kotlin Gradle Plugin **2.0.21** (via variable)
- Update **react-native-gesture-handler** to **2.31.2** (adds Kotlin 2.3 support)
- Update **react-native-screens** to **4.25.2** (latest stable)
- Remove deprecated Gradle properties
- Update ProGuard configuration

### For Development Builds Only
- Patch cloned Android SDK in `mobile_sdk/` to use AGP 8.12.0
- This allows composite builds to work during development

### For Production Builds
- No patching needed
- Uses published Maven Central artifacts (already compiled)
- AAR files work with any consumer AGP version

## Templates Updated

- ✅ ReactNativeTemplate
- ✅ ReactNativeDeferredTemplate
- ✅ ReactNativeTypeScriptTemplate
- ✅ MobileSyncExplorerReactNative

## Testing

All React Native templates build successfully for Android:

```
Total Tests: 8
Passed: 8
Failed: 0
```

## Future Work

Before Mobile SDK 14.0 release, we need to:
- Upgrade React Native to a version that supports AGP 9+
- This will eliminate the need for AGP downgrade and patching
- Remove the temporary compatibility workarounds

## Checklist

- [x] All 4 React Native templates build successfully on Android
- [x] Tested with `test_template.sh --platform android`
- [x] Changes only affect React Native templates
- [x] Production builds (Maven Central) unaffected
- [x] Documented as temporary solution