### PR TITLE
React Native New Architecture: Fix Android template build

### DIFF
--- a/MobileSyncExplorerReactNative/android/app/build.gradle
+++ b/MobileSyncExplorerReactNative/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 /**

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.3.20"
     }
     repositories {
         google()

--- a/MobileSyncExplorerReactNative/package.json
+++ b/MobileSyncExplorerReactNative/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "sdkDependencies": {
-    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev",
+    "SalesforceMobileSDK-Android": "https://github.com/wmathurin/SalesforceMobileSDK-Android.git#rn-migration",
     "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
   },
   "dependencies": {
@@ -20,7 +20,7 @@
     "react-native": "0.81.5",
     "@react-native/new-app-screen": "0.81.5",
     "react-native-safe-area-context": "5.5.2",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
+    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-migration",
     "react-native-gesture-handler": "2.31.2",
     "react-native-screens": "4.25.2",
     "react-native-elements": "3.4.3",

--- a/ReactNativeDeferredTemplate/android/app/build.gradle
+++ b/ReactNativeDeferredTemplate/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 /**

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.3.20"
     }
     repositories {
         google()

--- a/ReactNativeDeferredTemplate/package.json
+++ b/ReactNativeDeferredTemplate/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "sdkDependencies": {
-    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev",
+    "SalesforceMobileSDK-Android": "https://github.com/wmathurin/SalesforceMobileSDK-Android.git#rn-migration",
     "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
   },
   "dependencies": {
@@ -20,7 +20,7 @@
     "react-native": "0.81.5",
     "@react-native/new-app-screen": "0.81.5",
     "react-native-safe-area-context": "5.5.2",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
+    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-migration",
     "react-native-gesture-handler": "2.31.2",
     "react-native-screens": "4.25.2"
   },

--- a/ReactNativeTemplate/android/app/build.gradle
+++ b/ReactNativeTemplate/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 /**

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.3.20"
     }
     repositories {
         google()

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "sdkDependencies": {
-    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev",
+    "SalesforceMobileSDK-Android": "https://github.com/wmathurin/SalesforceMobileSDK-Android.git#rn-migration",
     "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
   },
   "dependencies": {
@@ -20,7 +20,7 @@
     "react-native": "0.81.5",
     "@react-native/new-app-screen": "0.81.5",
     "react-native-safe-area-context": "5.5.2",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
+    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-migration",
     "react-native-gesture-handler": "2.31.2",
     "react-native-screens": "4.25.2"
   },

--- a/ReactNativeTypeScriptTemplate/android/app/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 /**

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.3.20"
     }
     repositories {
         google()

--- a/ReactNativeTypeScriptTemplate/package.json
+++ b/ReactNativeTypeScriptTemplate/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "sdkDependencies": {
-    "SalesforceMobileSDK-Android": "https://github.com/forcedotcom/SalesforceMobileSDK-Android.git#dev",
+    "SalesforceMobileSDK-Android": "https://github.com/wmathurin/SalesforceMobileSDK-Android.git#rn-migration",
     "SalesforceMobileSDK-iOS": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git#dev"
   },
   "dependencies": {
@@ -20,7 +20,7 @@
     "react-native": "0.81.5",
     "@react-native/new-app-screen": "0.81.5",
     "react-native-safe-area-context": "5.5.2",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
+    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-migration",
     "react-native-gesture-handler": "2.31.2",
     "react-native-screens": "4.25.2"
   },


### PR DESCRIPTION
## Summary

- Restore `apply plugin: "org.jetbrains.kotlin.android"` that was removed by PR #516
- Bump Kotlin version from 2.0.21 to 2.3.20 to match Android SDK libraries
- Point package.json sdkDependencies at `wmathurin#rn-migration` for CI

## Problem

PR #516 removed the Kotlin Android plugin from template `app/build.gradle` files because AGP 9.1.1 has built-in Kotlin support. However, after downgrading to AGP 8.12.0, the explicit plugin is needed again. Without it, `.kt` files (MainApplication.kt, MainActivity.kt) are silently not compiled, causing a `ClassNotFoundException` at runtime.

Additionally, the Android SDK libraries are compiled with Kotlin 2.3.20, so the template Kotlin plugin version must match (was 2.0.21 → now 2.3.20) to avoid metadata compatibility errors.

## Templates Updated

- ReactNativeTemplate
- ReactNativeTypeScriptTemplate
- ReactNativeDeferredTemplate
- MobileSyncExplorerReactNative

## Testing

- All 4 templates build successfully on Android
- All 4 templates build successfully on iOS
- App launches without crash on emulator (verified MainApplication.dex present)

## Related PRs

- SalesforceMobileSDK-ReactNative: https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/pull/449
- SalesforceMobileSDK-Android: https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2902

## Before merging

- [ ] Revert `package.json` sdkDependencies in all 4 RN templates to `forcedotcom#dev`
- [ ] Revert `react-native-force` dependency to `forcedotcom#dev`