### PR TITLE
Fix missing PushNotificationsAdapter.kt in AndroidNativeKotlinTemplate

### DIFF
--- a/AndroidNativeKotlinTemplate/template.js
+++ b/AndroidNativeKotlinTemplate/template.js
@@ -49,6 +49,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     var templateMainActivityFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'MainActivity.kt');
     var templateMainApplicationFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'MainApplication.kt');
     var templateQrCodeEnabledLoginActivityFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'QrCodeEnabledLoginActivity.kt');
+    var templatePushNotificationsAdapterFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'PushNotificationsAdapter.kt');
 
     //
     // Replace in files
@@ -58,7 +59,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateSettingsGradle, templateStringsXmlFile]);
 
     // package name
-    replaceInFiles(templatePackageName, config.packagename, [templateBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile, templateQrCodeEnabledLoginActivityFile]);
+    replaceInFiles(templatePackageName, config.packagename, [templateBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile, templateQrCodeEnabledLoginActivityFile, templatePushNotificationsAdapterFile]);
 
     // consumer key
     if (config.consumerkey && config.consumerkey !== '') {
@@ -80,13 +81,16 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     var tmpPathActivityFile = path.join('app', 'src', 'MainActivity.kt');
     var tmpPathApplicationFile = path.join('app', 'src', 'MainApplication.kt');
     var tmpPathQrCodeEnabledLoginActivityFile = path.join('app', 'src', 'QrCodeEnabledLoginActivity.kt');
+    var tmpPathPushNotificationsAdapterFile = path.join('app', 'src', 'PushNotificationsAdapter.kt');
     moveFile(templateMainActivityFile, tmpPathActivityFile);
     moveFile(templateMainApplicationFile, tmpPathApplicationFile);
     moveFile(templateQrCodeEnabledLoginActivityFile, tmpPathQrCodeEnabledLoginActivityFile);
+    moveFile(templatePushNotificationsAdapterFile, tmpPathPushNotificationsAdapterFile);
     removeFile(path.join('app', 'src', 'main', 'java', 'com'));
     moveFile(tmpPathActivityFile, path.join.apply(null, ['app', 'src', 'main', 'java'].concat(config.packagename.split('.')).concat(['MainActivity.kt'])));
     moveFile(tmpPathApplicationFile, path.join.apply(null, ['app', 'src', 'main', 'java'].concat(config.packagename.split('.')).concat(['MainApplication.kt'])));
     moveFile(tmpPathQrCodeEnabledLoginActivityFile, path.join.apply(null, ['app', 'src', 'main', 'java'].concat(config.packagename.split('.')).concat(['QrCodeEnabledLoginActivity.kt'])));
+    moveFile(tmpPathPushNotificationsAdapterFile, path.join.apply(null, ['app', 'src', 'main', 'java'].concat(config.packagename.split('.')).concat(['PushNotificationsAdapter.kt'])));
 
     //
     // Run install.js


### PR DESCRIPTION
## Summary
- `template.js` moves source files to a temp location, removes the old package directory, then moves files to the new package path
- `PushNotificationsAdapter.kt` was not included in this process, so it was deleted when the `com/` directory was removed
- This caused `Unresolved reference 'PushNotificationsAdapter'` when building apps from the template
- Fixes the `forcedroid` and `forcedroid-sfdx` nightly CI failures in the Package repo

## Test plan
- [ ] Run `./test_template.sh --template AndroidNativeKotlinTemplate --platform android`
- [ ] Verify `PushNotificationsAdapter.kt` exists in generated app with correct package name
- [ ] Verify SalesforceMobileSDK-Package `forcedroid` nightly jobs pass