### PR TITLE
Fix Kotlin version mismatch in React Native templates

### DIFF
--- a/AndroidNativeKotlinTemplate/template.js
+++ b/AndroidNativeKotlinTemplate/template.js
@@ -49,6 +49,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     var templateMainActivityFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'MainActivity.kt');
     var templateMainApplicationFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'MainApplication.kt');
     var templateQrCodeEnabledLoginActivityFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'QrCodeEnabledLoginActivity.kt');
+    var templatePushNotificationsAdapterFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'PushNotificationsAdapter.kt');
 
     //
     // Replace in files
@@ -58,7 +59,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     replaceInFiles(templateAppName, config.appname, [templatePackageJsonFile, templateSettingsGradle, templateStringsXmlFile]);
 
     // package name
-    replaceInFiles(templatePackageName, config.packagename, [templateBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile, templateQrCodeEnabledLoginActivityFile]);
+    replaceInFiles(templatePackageName, config.packagename, [templateBuildGradleFile, templateStringsXmlFile, templateMainActivityFile, templateMainApplicationFile, templateQrCodeEnabledLoginActivityFile, templatePushNotificationsAdapterFile]);
 
     // consumer key
     if (config.consumerkey && config.consumerkey !== '') {
@@ -80,13 +81,16 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     var tmpPathActivityFile = path.join('app', 'src', 'MainActivity.kt');
     var tmpPathApplicationFile = path.join('app', 'src', 'MainApplication.kt');
     var tmpPathQrCodeEnabledLoginActivityFile = path.join('app', 'src', 'QrCodeEnabledLoginActivity.kt');
+    var tmpPathPushNotificationsAdapterFile = path.join('app', 'src', 'PushNotificationsAdapter.kt');
     moveFile(templateMainActivityFile, tmpPathActivityFile);
     moveFile(templateMainApplicationFile, tmpPathApplicationFile);
     moveFile(templateQrCodeEnabledLoginActivityFile, tmpPathQrCodeEnabledLoginActivityFile);
+    moveFile(templatePushNotificationsAdapterFile, tmpPathPushNotificationsAdapterFile);
     removeFile(path.join('app', 'src', 'main', 'java', 'com'));
     moveFile(tmpPathActivityFile, path.join.apply(null, ['app', 'src', 'main', 'java'].concat(config.packagename.split('.')).concat(['MainActivity.kt'])));
     moveFile(tmpPathApplicationFile, path.join.apply(null, ['app', 'src', 'main', 'java'].concat(config.packagename.split('.')).concat(['MainApplication.kt'])));
     moveFile(tmpPathQrCodeEnabledLoginActivityFile, path.join.apply(null, ['app', 'src', 'main', 'java'].concat(config.packagename.split('.')).concat(['QrCodeEnabledLoginActivity.kt'])));
+    moveFile(tmpPathPushNotificationsAdapterFile, path.join.apply(null, ['app', 'src', 'main', 'java'].concat(config.packagename.split('.')).concat(['PushNotificationsAdapter.kt'])));
 
     //
     // Run install.js

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.3.20"
     }
     repositories {
         google()

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.3.20"
     }
     repositories {
         google()

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.3.20"
     }
     repositories {
         google()

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.3.20"
     }
     repositories {
         google()


### PR DESCRIPTION
## Summary
- Updates `kotlinVersion` from `2.0.21` to `2.3.20` in all React Native template `android/build.gradle` files
- Aligns with `SalesforceMobileSDK-Android` which uses Kotlin 2.3.20 (`org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20`)
- Fixes "Incompatible classes were found in dependencies" compilation errors when building template apps against the SDK

## Affected Templates
- `ReactNativeTemplate/android/build.gradle`
- `ReactNativeTypeScriptTemplate/android/build.gradle`
- `ReactNativeDeferredTemplate/android/build.gradle`
- `MobileSyncExplorerReactNative/android/build.gradle`

## Root Cause
The SDK is compiled with Kotlin 2.3.20 (producing metadata version 2.2.0), but templates specified Kotlin 2.0.21 which cannot read metadata > 2.1.0. This causes the `forcereact-android` and `forcereact-android-sfdx` nightly CI jobs to fail in the Package repo.

## Test plan
- [ ] Verify `forcereact create` generates a project that compiles successfully against the latest SDK
- [ ] Confirm nightly CI `forcereact-android` job passes with this fix