### PR TITLE
Update nightly schedule to Mon/Wed/Fri at 2 AM PT and fix security issues

### DIFF
--- a/.github/workflows/android-reusable-workflow.yaml
+++ b/.github/workflows/android-reusable-workflow.yaml
@@ -10,6 +10,9 @@ on:
         required: false
         description: 'JSON array of template names to test (optional if platform-based filtering is used)'
 
+permissions:
+  contents: read
+
 jobs:
   generate-template-list:
     runs-on: ubuntu-latest
@@ -17,25 +20,30 @@ jobs:
       templates: ${{ steps.set-templates.outputs.templates }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
         if: ${{ !inputs.is_pr }}
 
       - name: Generate template list
         id: set-templates
+        env:
+          TEMPLATES: ${{ inputs.templates }}
         run: |
-          if [ -n "${{ inputs.templates }}" ]; then
+          if [ -n "${TEMPLATES}" ]; then
             # Use provided template list
-            echo 'templates=${{ inputs.templates }}' >> $GITHUB_OUTPUT
+            printf 'templates=%s\n' "${TEMPLATES}" >> "$GITHUB_OUTPUT"
           else
             # Generate list from templates.json filtered by Android platform
-            TEMPLATES=$(jq -c '[.[] | select(.platforms[] == "android") | .path]' templates.json)
-            echo "templates=$TEMPLATES" >> $GITHUB_OUTPUT
+            TEMPLATES_LIST=$(jq -c '[.[] | select(.platforms[] == "android") | .path]' templates.json)
+            printf 'templates=%s\n' "${TEMPLATES_LIST}" >> "$GITHUB_OUTPUT"
           fi
 
   test-android:
@@ -47,31 +55,34 @@ jobs:
         template: ${{ fromJson(needs.generate-template-list.outputs.templates) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
         if: ${{ !inputs.is_pr }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.7"
           add-job-summary: on-failure
@@ -82,14 +93,30 @@ jobs:
 
       - name: Check template platform support
         id: check-platform
+        env:
+          TEMPLATE: ${{ matrix.template }}
         run: |
-          PLATFORMS=$(jq -r '.[] | select(.path == "${{ matrix.template }}") | .platforms[]' templates.json)
+          PLATFORMS=$(jq -r --arg t "$TEMPLATE" '.[] | select(.path == $t) | .platforms[]' templates.json)
           if echo "$PLATFORMS" | grep -q "^android$"; then
-            echo "supported=true" >> $GITHUB_OUTPUT
+            printf 'supported=true\n' >> "$GITHUB_OUTPUT"
           else
-            echo "supported=false" >> $GITHUB_OUTPUT
+            printf 'supported=false\n' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Test Android template
+        id: test-template
         if: steps.check-platform.outputs.supported == 'true'
-        run: ./test_template.sh --template "${{ matrix.template }}" --platform android
+        env:
+          TEMPLATE: ${{ matrix.template }}
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test_template.sh --template "${TEMPLATE}" --platform android 2>&1 | tee "build_logs/${TEMPLATE}-android.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.test-template.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: template-build-logs-${{ matrix.template }}-android
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/ios-reusable-workflow.yaml
+++ b/.github/workflows/ios-reusable-workflow.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         description: 'macOS runner version'
 
+permissions:
+  contents: read
+
 jobs:
   generate-template-list:
     runs-on: ubuntu-latest
@@ -22,25 +25,30 @@ jobs:
       templates: ${{ steps.set-templates.outputs.templates }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
         if: ${{ !inputs.is_pr }}
 
       - name: Generate template list
         id: set-templates
+        env:
+          TEMPLATES: ${{ inputs.templates }}
         run: |
-          if [ -n "${{ inputs.templates }}" ]; then
+          if [ -n "${TEMPLATES}" ]; then
             # Use provided template list
-            echo 'templates=${{ inputs.templates }}' >> $GITHUB_OUTPUT
+            printf 'templates=%s\n' "${TEMPLATES}" >> "$GITHUB_OUTPUT"
           else
             # Generate list from templates.json filtered by iOS platform
-            TEMPLATES=$(jq -c '[.[] | select(.platforms[] == "ios") | .path]' templates.json)
-            echo "templates=$TEMPLATES" >> $GITHUB_OUTPUT
+            TEMPLATES_LIST=$(jq -c '[.[] | select(.platforms[] == "ios") | .path]' templates.json)
+            printf 'templates=%s\n' "${TEMPLATES_LIST}" >> "$GITHUB_OUTPUT"
           fi
 
   test-ios:
@@ -52,13 +60,16 @@ jobs:
         template: ${{ fromJson(needs.generate-template-list.outputs.templates) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
         if: ${{ !inputs.is_pr }}
 
       - name: Install jq
@@ -66,14 +77,30 @@ jobs:
 
       - name: Check template platform support
         id: check-platform
+        env:
+          TEMPLATE: ${{ matrix.template }}
         run: |
-          PLATFORMS=$(jq -r '.[] | select(.path == "${{ matrix.template }}") | .platforms[]' templates.json)
+          PLATFORMS=$(jq -r --arg t "$TEMPLATE" '.[] | select(.path == $t) | .platforms[]' templates.json)
           if echo "$PLATFORMS" | grep -q "^ios$"; then
-            echo "supported=true" >> $GITHUB_OUTPUT
+            printf 'supported=true\n' >> "$GITHUB_OUTPUT"
           else
-            echo "supported=false" >> $GITHUB_OUTPUT
+            printf 'supported=false\n' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Test iOS template
+        id: test-template
         if: steps.check-platform.outputs.supported == 'true'
-        run: ./test_template.sh --template "${{ matrix.template }}" --platform ios
+        env:
+          TEMPLATE: ${{ matrix.template }}
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test_template.sh --template "${TEMPLATE}" --platform ios 2>&1 | tee "build_logs/${TEMPLATE}-ios.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.test-template.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: template-build-logs-${{ matrix.template }}-ios
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,11 +10,15 @@ permissions:
 
 jobs:
   ios-nightly:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ios-reusable-workflow.yaml
 
   android-nightly:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
     uses: ./.github/workflows/android-reusable-workflow.yaml

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,9 +2,11 @@ name: Nightly Tests
 
 on:
   schedule:
-    # Run at 2 AM PST (10 AM UTC) every day
-    - cron: '0 10 * * *'
+    - cron: '0 10 * * 1,3,5'  # cron is UTC; 2 AM PT Mon/Wed/Fri.
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   ios-nightly:
@@ -23,18 +25,21 @@ jobs:
     if: always()
     steps:
       - name: Generate summary
+        env:
+          IOS_RESULT: ${{ needs.ios-nightly.result }}
+          ANDROID_RESULT: ${{ needs.android-nightly.result }}
         run: |
-          echo "## Nightly Template Test Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Date:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Results" >> $GITHUB_STEP_SUMMARY
-          echo "- iOS Tests: ${{ needs.ios-nightly.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Android Tests: ${{ needs.android-nightly.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Nightly Template Test Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Date:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "- iOS Tests: ${IOS_RESULT}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Android Tests: ${ANDROID_RESULT}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ needs.ios-nightly.result }}" == "success" ] && [ "${{ needs.android-nightly.result }}" == "success" ]; then
-            echo "✅ All template tests passed!" >> $GITHUB_STEP_SUMMARY
+          if [ "${IOS_RESULT}" == "success" ] && [ "${ANDROID_RESULT}" == "success" ]; then
+            echo "✅ All template tests passed!" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "❌ Some tests failed - please review the workflow logs" >> $GITHUB_STEP_SUMMARY
+            echo "❌ Some tests failed - please review the workflow logs" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,7 +1,9 @@
 name: Pull Request
 
 on:
-  pull_request_target:
+  # pull_request_target is required for fork PRs to access secrets and the merged tree.
+  # Mitigated by permission-check job (Validate Write Permission step).
+  pull_request_target:  # zizmor: ignore[dangerous-triggers]
     branches: [dev, master]
     paths:
       - '*/install.js'
@@ -25,12 +27,15 @@ on:
       - 'templates.json'
       - 'test_template.sh'
 
+permissions:
+  contents: read
+
 jobs:
   permission-check:
     runs-on: ubuntu-latest
     steps:
       - name: Check Write Permission
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
         id: check_permissions
         with:
           route: GET /repos/${{ github.repository }}/collaborators/${{ github.triggering_actor }}/permission
@@ -55,14 +60,15 @@ jobs:
       test-all: ${{ steps.set-templates.outputs.test-all }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c  # v44.5.7
         with:
           files: |
             **/install.js
@@ -90,14 +96,16 @@ jobs:
 
       - name: Determine changed templates
         id: set-templates
+        env:
+          CHANGED_FILES_JSON: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           # Store the JSON output and remove escaped quotes
-          CHANGED_FILES=$(echo '${{ steps.changed-files.outputs.all_changed_files }}' | sed 's/\\//g')
-          echo "Changed files: $CHANGED_FILES"
+          CHANGED_FILES=$(printf '%s' "${CHANGED_FILES_JSON}" | sed 's/\\//g')
+          echo "Changed files: ${CHANGED_FILES}"
 
           # Check if test script or templates.json changed (test all templates)
           TEST_ALL=false
-          for file in $(jq -r '.[]' <<< "$CHANGED_FILES"); do
+          for file in $(jq -r '.[]' <<< "${CHANGED_FILES}"); do
             if [[ "$file" == "test_template.sh" ]] || [[ "$file" == "templates.json" ]]; then
               TEST_ALL=true
               echo "Core test file changed: $file"
@@ -109,16 +117,16 @@ jobs:
           TEMPLATES=$(jq -r '.[].path' templates.json)
 
           if [ "$TEST_ALL" = true ]; then
-            echo "test-all=true" >> $GITHUB_OUTPUT
-            echo "has-changes=true" >> $GITHUB_OUTPUT
+            printf 'test-all=true\n' >> "$GITHUB_OUTPUT"
+            printf 'has-changes=true\n' >> "$GITHUB_OUTPUT"
             # Convert all templates to JSON array (compact format for GitHub Actions)
             TEMPLATES_JSON=$(echo "$TEMPLATES" | jq -R . | jq -sc .)
-            echo "templates=$TEMPLATES_JSON" >> $GITHUB_OUTPUT
+            printf 'templates=%s\n' "${TEMPLATES_JSON}" >> "$GITHUB_OUTPUT"
             echo "Testing all templates due to core file changes"
           else
             # Extract template directories from changed files
             CHANGED_TEMPLATES=()
-            for file in $(jq -r '.[]' <<< "$CHANGED_FILES"); do
+            for file in $(jq -r '.[]' <<< "${CHANGED_FILES}"); do
               # Get the first directory component
               TEMPLATE_DIR=$(echo "$file" | cut -d'/' -f1)
 
@@ -131,17 +139,17 @@ jobs:
               fi
             done
 
-            echo "test-all=false" >> $GITHUB_OUTPUT
+            printf 'test-all=false\n' >> "$GITHUB_OUTPUT"
 
             # Convert to JSON array (compact format for GitHub Actions)
             if [ ${#CHANGED_TEMPLATES[@]} -gt 0 ]; then
               TEMPLATES_JSON=$(printf '%s\n' "${CHANGED_TEMPLATES[@]}" | jq -R . | jq -sc .)
-              echo "templates=$TEMPLATES_JSON" >> $GITHUB_OUTPUT
-              echo "has-changes=true" >> $GITHUB_OUTPUT
+              printf 'templates=%s\n' "${TEMPLATES_JSON}" >> "$GITHUB_OUTPUT"
+              printf 'has-changes=true\n' >> "$GITHUB_OUTPUT"
               echo "Templates to test: ${CHANGED_TEMPLATES[@]}"
             else
-              echo "templates=[]" >> $GITHUB_OUTPUT
-              echo "has-changes=false" >> $GITHUB_OUTPUT
+              printf 'templates=[]\n' >> "$GITHUB_OUTPUT"
+              printf 'has-changes=false\n' >> "$GITHUB_OUTPUT"
               echo "No template changes detected"
             fi
           fi
@@ -168,31 +176,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Summary
+        env:
+          HAS_CHANGES: ${{ needs.detect-changed-templates.outputs.has-changes }}
+          TEST_ALL: ${{ needs.detect-changed-templates.outputs.test-all }}
+          TEMPLATES_JSON: ${{ needs.detect-changed-templates.outputs.templates }}
+          IOS_RESULT: ${{ needs.ios-pr.result }}
+          ANDROID_RESULT: ${{ needs.android-pr.result }}
         run: |
-          echo "## Template Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Template Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ needs.detect-changed-templates.outputs.has-changes }}" != "true" ]; then
-            echo "✓ No template changes detected - tests skipped" >> $GITHUB_STEP_SUMMARY
+          if [ "${HAS_CHANGES}" != "true" ]; then
+            echo "✓ No template changes detected - tests skipped" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          if [ "${{ needs.detect-changed-templates.outputs.test-all }}" == "true" ]; then
-            echo "ℹ️ Core files changed - testing all templates" >> $GITHUB_STEP_SUMMARY
+          if [ "${TEST_ALL}" == "true" ]; then
+            echo "ℹ️ Core files changed - testing all templates" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "ℹ️ Testing changed templates only" >> $GITHUB_STEP_SUMMARY
+            echo "ℹ️ Testing changed templates only" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Templates Tested" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo '${{ needs.detect-changed-templates.outputs.templates }}' | jq -r '.[]' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Templates Tested" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          printf '%s' "${TEMPLATES_JSON}" | jq -r '.[]' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ needs.ios-pr.result }}" == "failure" ] || [ "${{ needs.android-pr.result }}" == "failure" ]; then
-            echo "❌ Some tests failed" >> $GITHUB_STEP_SUMMARY
+          if [ "${IOS_RESULT}" == "failure" ] || [ "${ANDROID_RESULT}" == "failure" ]; then
+            echo "❌ Some tests failed" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           else
-            echo "✅ All tests passed" >> $GITHUB_STEP_SUMMARY
+            echo "✅ All tests passed" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -155,6 +155,8 @@ jobs:
           fi
 
   ios-pr:
+    permissions:
+      contents: read
     needs: detect-changed-templates
     if: needs.detect-changed-templates.outputs.has-changes == 'true'
     uses: ./.github/workflows/ios-reusable-workflow.yaml
@@ -163,6 +165,8 @@ jobs:
       templates: ${{ needs.detect-changed-templates.outputs.templates }}
 
   android-pr:
+    permissions:
+      contents: read
     needs: detect-changed-templates
     if: needs.detect-changed-templates.outputs.has-changes == 'true'
     uses: ./.github/workflows/android-reusable-workflow.yaml


### PR DESCRIPTION
## Summary

Implements [W-22712082 — Cleanup CI for all Repos](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002b3viMYAQ/view).

**Schedule change**: Nightly tests now run **Mon/Wed/Fri at 2 AM PT** (`0 10 * * 1,3,5` UTC), down from daily. The SDK repos this workflow tests (iOS/Android) only run on weekdays, so weekend Templates runs were validating the same SDK code as Friday's run — pure waste. Alternates with the Package nightly's Tue/Thu 2 AM slot.

**Security hardening**: All workflows updated to follow the [GitHub Actions injection-prevention best practices](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/):

- **All third-party actions SHA-pinned** with the resolved tag in a comment.
- **Top-level `permissions: contents: read`** added to every workflow.
- **All `${{ ... }}` shell interpolation** in `run:` blocks refactored to `env:` variables with quoted shell expansions. Notable refactors: `Generate template list` step (writes user-controlled `inputs.templates` to GITHUB_OUTPUT — now piped through env), `Check template platform support` (uses `jq --arg` instead of inline template expansion), `pr-summary` and `nightly-summary` jobs (`needs.*.outputs/result` piped through env).
- **`pull_request_target`** retained with `# zizmor: ignore[dangerous-triggers]` and inline comment documenting the permission-check mitigation.
- **`actions/checkout` steps** set `with: persist-credentials: false`.
- **Build logs archived on failure** for diagnostic purposes.
- **Job-level `permissions:` on reusable-workflow callers** in `nightly.yaml` and `pr.yaml`.

After this change, `zizmor --offline` reports 0 High-confidence findings across all four CI workflows.

## Test plan

- [x] Verified locally with `python3 yaml.safe_load`, `actionlint -shellcheck=`, `zizmor --offline`. All clean.
- [x] CI verification: opened test PR on personal fork (`brandonpage/SalesforceMobileSDK-Templates#1`) targeting the same `cleanup-ci-w22712082` branch as this PR. The test PR triggers the new workflows against a real source change in `iOSNativeSwiftTemplate`. **No regressions observed** — see linked PR for run details.
- [ ] Reviewer to confirm the `permissions:` blocks match the team's expected privilege levels for each workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
