### PR TITLE
Enable automatic biometric presentation in iOSNativeLoginTemplate

### DIFF
--- a/iOSNativeLoginTemplate/iOSNativeLoginTemplate/SceneDelegate.swift
+++ b/iOSNativeLoginTemplate/iOSNativeLoginTemplate/SceneDelegate.swift
@@ -62,6 +62,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                                                 communityUrl: loginUrl,
                                                 nativeLoginViewController: nativeLoginViewController,
                                                 scene:scene)
+
+        // Enable automatic biometric presentation:
+        // - Shows opt-in dialog after login (if user hasn't opted in yet)
+        // - Auto-triggers biometric unlock when the app is locked (if user has opted in)
+        SalesforceManager.shared.biometricAuthenticationManager().automaticPresentation = true
         
         //
         // To setup Password-less login:


### PR DESCRIPTION
 ## Summary
  - Sets `biometricAuthenticationManager().automaticPresentation = true` in `SceneDelegate` of `iOSNativeLoginTemplate`
  so the SDK drives the biometric flow automatically.
  - Demonstrates usage of `automaticPresentation`.

  ## Test plan
  - [x] Generate an app from `iOSNativeLoginTemplate` and confirm it builds (`./test_template.sh --template
  iOSNativeLoginTemplate --platform ios`).
  - [x] Run the generated app, log in, and verify the biometric opt-in dialog is presented automatically.
  - [x] Opt in, background/lock the app, and verify the biometric unlock prompt is auto-triggered on resume.
