### PR TITLE
[auto-generated] Fix CI: Use generic simulator destination in test_template.sh

### DIFF
--- a/test_template.sh
+++ b/test_template.sh
@@ -136,7 +136,7 @@ build_ios() {
         return 1
     fi
     
-    if xcodebuild $BUILD_TARGET -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' build CODE_SIGNING_ALLOWED=NO; then
+    if xcodebuild $BUILD_TARGET -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO; then
         print_status "SUCCESS" "$template_name (iOS): Build successful"
         for ((i=0; i<cd_back_count; i++)); do
             cd - > /dev/null


### PR DESCRIPTION
## Summary
- Replace hardcoded `name=iPhone 17` simulator destination with portable `generic/platform=iOS Simulator`
- This makes the build step work across all Xcode versions without requiring specific device names

## Root Cause
`test_template.sh` line 139 hardcoded `platform=iOS Simulator,name=iPhone 17` but CI runners (macos-15) use Xcode 16.4 which only ships iPhone 16 simulators. "iPhone 17" requires Xcode 17+.

## Test plan
- [ ] Verify iOSNativeSwiftTemplate builds successfully in CI
- [ ] Verify other iOS templates also build (if they use the same function)
- [ ] Confirm no regression on template generation