### PR TITLE
Bump Android minSdk to 31

### DIFF
--- a/AndroidIDPTemplate/app/build.gradle.kts
+++ b/AndroidIDPTemplate/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
     }
 
     buildTypes {

--- a/AndroidNativeKotlinTemplate/app/build.gradle.kts
+++ b/AndroidNativeKotlinTemplate/app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
     defaultConfig {
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
     }
 
     packaging {

--- a/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/PushNotificationsAdapter.kt
+++ b/AndroidNativeKotlinTemplate/app/src/main/java/com/salesforce/androidnativekotlintemplate/PushNotificationsAdapter.kt
@@ -31,9 +31,7 @@ import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.getBroadcast
 import android.content.Intent
 import android.content.pm.PackageManager.PERMISSION_GRANTED
-import android.os.Build.VERSION_CODES.Q
 import android.os.Bundle
-import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.BigTextStyle
 import androidx.core.app.NotificationCompat.PRIORITY_DEFAULT
@@ -56,7 +54,6 @@ import java.util.UUID.randomUUID
 /* Actionable Notifications Template: When not using [PushNotificationsAdapter] and Actionable Notifications, this could be removed. */
 internal class PushNotificationsAdapter : PushNotificationInterface {
 
-    @RequiresApi(Q)
     override fun onPushMessageReceived(
         data: Map<String?, String?>?,
     ) {

--- a/AndroidNativeLoginTemplate/app/build.gradle.kts
+++ b/AndroidNativeLoginTemplate/app/build.gradle.kts
@@ -31,7 +31,7 @@ android {
 
     defaultConfig {
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
     }
 
     packaging {

--- a/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/NativeLogin.kt
+++ b/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/NativeLogin.kt
@@ -32,7 +32,6 @@ import android.os.Build.VERSION.SDK_INT
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
-import android.os.Build.VERSION_CODES.S
 import android.os.Build.VERSION_CODES.TIRAMISU
 import android.os.Bundle
 import android.widget.Toast
@@ -75,10 +74,8 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -1192,22 +1189,10 @@ class NativeLogin : FragmentActivity() {
 
     @Composable
     fun LoginTheme(composable: @Composable () -> Unit) {
-        val dynamicColors = SDK_INT >= S
-        val isDarkTheme = isSystemInDarkTheme()
-        val colorScheme = when {
-            dynamicColors && isDarkTheme -> {
-                dynamicDarkColorScheme(LocalContext.current)
-            }
-
-            dynamicColors && !isDarkTheme -> {
-                dynamicLightColorScheme(LocalContext.current)
-            }
-
-            !dynamicColors && isDarkTheme -> {
-                darkColorScheme()
-            }
-
-            else -> lightColorScheme()
+        val colorScheme = if (isSystemInDarkTheme()) {
+            dynamicDarkColorScheme(LocalContext.current)
+        } else {
+            dynamicLightColorScheme(LocalContext.current)
         }
 
         MaterialTheme(colorScheme = colorScheme, content = composable)

--- a/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
+++ b/MobileSyncExplorerKotlinTemplate/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
     defaultConfig {
         applicationId = "com.salesforce.mobilesyncexplorerkotlintemplate"
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
         versionCode = 1
         versionName = "1.0"
 

--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         buildToolsVersion = "35.0.0"
-        minSdkVersion = 28
+        minSdkVersion = 31
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         buildToolsVersion = "35.0.0"
-        minSdkVersion = 28
+        minSdkVersion = 31
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         buildToolsVersion = "35.0.0"
-        minSdkVersion = 28
+        minSdkVersion = 31
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         buildToolsVersion = "35.0.0"
-        minSdkVersion = 28
+        minSdkVersion = 31
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"


### PR DESCRIPTION
## Summary
- Bumps `minSdk` from 28 to 31 across all 4 native Kotlin templates (`AndroidNativeKotlinTemplate`, `AndroidNativeLoginTemplate`, `AndroidIDPTemplate`, `MobileSyncExplorerKotlinTemplate`) and all 4 React Native templates.
- Drops dead `@RequiresApi(Q)` annotation in `PushNotificationsAdapter.kt`.
- Collapses now-constant `SDK_INT >= S` dynamic-color branch in `AndroidNativeLoginTemplate/NativeLogin.kt` (`LoginTheme`).

## Test plan
- [x] `test_template.sh` builds each Android template successfully
- [x] `test_template.sh` builds each RN template successfully
- [x] Manual: verify generated app from each template runs on an API 31 device

🤖 Generated with [Claude Code](https://claude.com/claude-code)