### PR TITLE
Revert react-native-force URL to forcedotcom#dev

### DIFF
--- a/MobileSyncExplorerReactNative/package.json
+++ b/MobileSyncExplorerReactNative/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.84.1",
     "@react-native/new-app-screen": "0.84.1",
     "react-native-safe-area-context": "5.8.0",
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.84",
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "2.31.2",
     "react-native-screens": "4.25.2",
     "react-native-elements": "3.4.3",

--- a/ReactNativeDeferredTemplate/package.json
+++ b/ReactNativeDeferredTemplate/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.84.1",
     "@react-native/new-app-screen": "0.84.1",
     "react-native-safe-area-context": "5.8.0",
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.84",
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "2.31.2",
     "react-native-screens": "4.25.2"
   },

--- a/ReactNativeTemplate/package.json
+++ b/ReactNativeTemplate/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.84.1",
     "@react-native/new-app-screen": "0.84.1",
     "react-native-safe-area-context": "5.8.0",
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.84",
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "2.31.2",
     "react-native-screens": "4.25.2"
   },

--- a/ReactNativeTypeScriptTemplate/package.json
+++ b/ReactNativeTypeScriptTemplate/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.84.1",
     "@react-native/new-app-screen": "0.84.1",
     "react-native-safe-area-context": "5.8.0",
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.84",
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
     "react-native-gesture-handler": "2.31.2",
     "react-native-screens": "4.25.2"
   },


### PR DESCRIPTION
## Summary

- Reverts `react-native-force` in all 4 RN template `package.json` files from the temporary `wmathurin#rn-upgrade-0.84` fork reference back to `forcedotcom#dev`

## Context

The `wmathurin#rn-upgrade-0.84` URL was used during RN 0.84.1 upgrade development so that templates could pull from the in-progress fork branch. Now that PR #530 has been merged, this reverts to the canonical reference.