### PR TITLE
Sync consumer skills from Skills-internal (2026-06-03)

### DIFF
--- a/skills/android-mobile-sdk/SKILL.md
+++ b/skills/android-mobile-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: android-mobile-sdk
-description: Comprehensive guide for integrating Salesforce Mobile SDK into Android Kotlin applications. Covers creating new apps, adding SDK authentication, SmartStore (encrypted database), MobileSync (cloud sync), and biometric authentication.
+description: Add Salesforce Mobile SDK capabilities to Android Kotlin applications. Covers creating new apps with the SDK pre-integrated, or adding base SDK, SmartStore (encrypted database), MobileSync (cloud sync), and biometric authentication to existing applications.
 ---
 
 # Android Salesforce Mobile SDK Integration
@@ -159,7 +159,9 @@ Now proceed to the [Add Mobile SDK](#add-mobile-sdk) section below to create the
 <a name="add-mobile-sdk"></a>
 ## Add Mobile SDK
 
-This section integrates the Salesforce Mobile SDK into an existing Android Kotlin application, wiring up authentication so users are prompted to log in to Salesforce when the app launches.
+This section integrates the Salesforce Mobile SDK into an **existing** Android Kotlin application, wiring up authentication so users are prompted to log in to Salesforce when the app launches.
+
+> **Important — do not recreate Gradle scaffolding.** The app already has a working Gradle wrapper, `gradle.properties`, `settings.gradle.kts`, and root `build.gradle.kts`. Do **not** overwrite those files. The instructions below only modify `app/build.gradle.kts`, `AndroidManifest.xml`, and `MainActivity.kt`, and create `MainApplication.kt`, `bootconfig.xml`, `servers.xml`, and `strings.xml`. If you find yourself about to write a `gradle-wrapper.properties` or root `build.gradle.kts`, stop — you're confusing this scenario with **Create New App**.
 
 ### Prerequisites
 
@@ -172,11 +174,16 @@ Before starting, gather:
 
 ### Step 1: Add the SDK Dependency
 
-In `app/build.gradle.kts`, add `MobileSyncSDKManager`. Using `MobileSync` as the single dependency pulls in `SmartStore` and `SalesforceSDKCore` transitively.
+This scenario adds **Salesforce Mobile SDK Core only** — OAuth login and REST. Adding SmartStore (encrypted local database) or MobileSync (cloud data sync) is covered by the dedicated scenarios later in this skill; do not pre-emptively pull them in here.
+
+In `app/build.gradle.kts`, **add** the `SalesforceSDK` artifact (Mobile SDK Core) via Maven Central. Don't remove existing dependencies the app already declares:
 
 ```kotlin
 dependencies {
-    implementation("com.salesforce.mobilesdk:MobileSync:13.2.0")
+    implementation("com.salesforce.mobilesdk:SalesforceSDK:13.2.0")
+    // Required: SalesforceActivity (used in Step 7) extends AppCompatActivity.
+    // Keep the existing appcompat dependency if your app already has it, or add:
+    implementation("androidx.appcompat:appcompat:1.7.0")
 }
 ```
 
@@ -224,17 +231,19 @@ Create `MainApplication.kt` in the app's main package (same directory as `MainAc
 package <AppPackage>
 
 import android.app.Application
-import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager
+import com.salesforce.androidsdk.app.SalesforceSDKManager
 
 class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        MobileSyncSDKManager.initNative(applicationContext, MainActivity::class.java)
+        SalesforceSDKManager.initNative(applicationContext, MainActivity::class.java)
     }
 }
 ```
 
-Replace `<AppPackage>` with your package name. `MobileSyncSDKManager.initNative()` must be called before any SDK class is used.
+Replace `<AppPackage>` with your package name. `SalesforceSDKManager.initNative()` must be called before any SDK class is used.
+
+> **Adding SmartStore or MobileSync later?** Those are separate scenarios in this same skill (see _Add SmartStore_ and _Add MobileSync_ below). They swap the dependency artifact and the SDK manager class. Don't pre-emptively pull them in here — start with `SalesforceSDK` and stay on it for the base authentication scenario.
 
 ### Step 3: Update AndroidManifest.xml
 
@@ -584,6 +593,18 @@ Create `app/src/main/res/raw/usersyncs.json` (next to `userstore.json`):
       "options": {
         "mergeMode": "LEAVE_IF_CHANGED"
       }
+    },
+    {
+      "syncName": "syncUp<SoupName>",
+      "syncType": "syncUp",
+      "soupName": "<SoupName>",
+      "target": {
+        "createFieldlist": ["Name"],
+        "updateFieldlist": ["Name"]
+      },
+      "options": {
+        "mergeMode": "LEAVE_IF_CHANGED"
+      }
     }
   ]
 }
@@ -592,14 +613,75 @@ Create `app/src/main/res/raw/usersyncs.json` (next to `userstore.json`):
 Replace:
 - `<SoupName>` with the soup name used in `userstore.json` — this is the **local** SmartStore table name
 - `<SalesforceObject>` in the SOQL `FROM` clause with the **Salesforce sObject API name** to sync from (e.g. `Account`, `Contact`)
+- Tailor `createFieldlist` and `updateFieldlist` to the fields you want to push. Omitting `target.type` is intentional — the SDK defaults to `CollectionSyncUpTarget`, the standard sync-up target.
 
 > The soup name and the sObject name are often the same but they don't have to be. The soup is a local storage concept; the SOQL target is a server-side Salesforce object.
 
-The SDK reads `usersyncs.json` automatically from `res/raw/` — no code registration is needed beyond calling `setupUserSyncsFromDefaultConfig()`.
+The SDK reads `usersyncs.json` automatically from `res/raw/` when you call `setupUserSyncsFromDefaultConfig()`. That call **registers** each named sync as a `SyncState` record in SmartStore — it does **not** run any of them. To actually pull data from Salesforce, you must invoke a sync explicitly (Step 5).
 
-### Step 5: Build and Verify
+### Step 5: Trigger the Sync to Pull Data
 
-Build and run. After login, you should see **"SmartStore + MobileSync ready"** and data should begin syncing from Salesforce.
+After `setupUserSyncsFromDefaultConfig()` has registered the syncs, call `reSync` to run one.
+
+> **`onUpdate` fires asynchronously** as the sync transitions through `RUNNING` → `DONE` / `FAILED`. Re-query the soup and update your UI **inside** the `onUpdate` block when status reaches `DONE` — your view will stay empty if you query before that.
+
+> **Always pass the current user account** to `SyncManager.getInstance(userAccount)`. The no-arg overload uses the default org and will fail for sandbox or multi-org setups.
+
+```kotlin
+import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.mobilesync.manager.SyncManager
+import com.salesforce.androidsdk.mobilesync.util.SyncState
+
+override fun onResume(client: RestClient?) {
+    if (client == null) return
+    MobileSyncSDKManager.getInstance().setupUserStoreFromDefaultConfig()
+    MobileSyncSDKManager.getInstance().setupUserSyncsFromDefaultConfig()
+
+    val user: UserAccount = MobileSyncSDKManager.getInstance().userAccountManager.currentUser
+    SyncManager.getInstance(user).reSync("syncDown<SoupName>", object : SyncManager.SyncUpdateCallback {
+        override fun onUpdate(sync: SyncState) {
+            if (sync.status == SyncState.Status.DONE) {
+                // Re-query the soup and update your UI here.
+            } else if (sync.status == SyncState.Status.FAILED) {
+                Log.e(TAG, "Sync failed: ${sync.error}")
+            }
+        }
+    })
+}
+```
+
+> **`SyncUpdateCallback` is a regular `interface` (not `fun interface`).** SAM-conversion lambdas don't compile — use the `object :` expression shown above.
+
+### Step 6: Creating Local Records for Sync-Up
+
+When the user creates a record before it has been pushed to Salesforce, flag it as locally created so sync-up will push it. The server `Id` is filled in on the next sync-up.
+
+```kotlin
+import org.json.JSONObject
+
+fun createLocalRecord(name: String) {
+    val user = MobileSyncSDKManager.getInstance().userAccountManager.currentUser
+    val store = MobileSyncSDKManager.getInstance().getSmartStore(user)
+
+    val entry = JSONObject().apply {
+        put("attributes", JSONObject().put("type", "<SalesforceObject>"))  // e.g. "Account"
+        put("Name", name)
+        put("__local__", true)           // boolean true, not integer 1
+        put("__locally_created__", true)
+        put("__locally_updated__", false)
+        put("__locally_deleted__", false)
+    }
+    store.upsert("<SoupName>", entry)    // do NOT pre-set _soupEntryId
+}
+```
+
+> **`__local__` must be a JSON boolean `true`, not `1`.** The SDK's dirty-record query hardcodes `WHERE {soup:__local__} = 'true'` (string comparison). SmartStore serialises a JSON boolean as the string `"true"` when the index type is `"string"` (set in `userstore.json`). An integer `1` never matches.
+
+> **Do not pre-set `_soupEntryId`** before calling `upsert`. SmartStore treats a record that already carries `_soupEntryId` as an update request; if that ID doesn't exist the call is a silent no-op.
+
+### Step 7: Build and Verify
+
+Build and run. After login, you should see **"SmartStore + MobileSync ready"**, and `reSync` will fetch records from Salesforce into the local `<SoupName>` soup. Verify by querying the soup with `SmartStoreInspectorActivity` or your own SmartSQL `SELECT {<SoupName>:_soup} FROM {<SoupName>}` query.
 
 ---
 
@@ -613,6 +695,14 @@ This section adds fingerprint / face / iris biometric authentication to an exist
 **The app must already have the Mobile SDK integrated.** Check `MainApplication.kt` for `MobileSyncSDKManager.initNative()` (or `SmartStoreSDKManager`) and that `bootconfig.xml` exists. If not, complete the [Add Mobile SDK](#add-mobile-sdk) section first.
 
 The SDK handles all locking, unlocking, and the native biometric prompt automatically once the user opts in.
+
+**Connected App configuration (required, in your Salesforce org):**
+
+- **Setup → App Manager → your Connected App → drop-down → View → Custom Attributes → New**
+  - Key: `ENABLE_BIOMETRIC_AUTHENTICATION`
+  - Value: `"true"` (with the literal quotes — Custom Attribute values are JSON literals; `true` without quotes will not enable the policy)
+- **Setup → App Manager → your Connected App → Edit Policies → OAuth Policies**: **uncheck "Require Secret for Refresh Token Flow"**. Mobile SDK uses PKCE without a client secret. If this is checked, biometric success → token refresh → `invalid_client` 400 → SDK silently logs the user out and shows fresh OAuth (see Troubleshooting below).
+- The user must log in *fresh* after these changes — Custom Attributes and OAuth policies are read from the userinfo response at login time, so a re-login picks up the new values immediately.
 
 ### Step 1: Add the androidx.biometric Dependency
 
@@ -629,7 +719,7 @@ Sync Gradle after editing.
 
 ### Step 2: Update MainActivity.kt
 
-Add `onPostResume()` to check device biometric capability and present the SDK opt-in dialog if needed.
+Trigger the opt-in check from `onResume(client: RestClient?)` — the SDK callback that fires *after* the user account is bound. Triggering it from `onPostResume()` will silently skip the dialog on first login because the user isn't bound yet, and `enabled` reads `false`.
 
 **Add these imports** (at the top of `MainActivity.kt`):
 
@@ -640,27 +730,45 @@ import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager
 ```
 
-**Add `onPostResume()`** (after `onResume(client: RestClient?)`):
+**Drop a no-arg-state guard into `onCreate`** so activity recreate doesn't restore the SDK's opt-in dialog (it lacks a no-arg constructor — see Troubleshooting). Replace `super.onCreate(savedInstanceState)` with:
 
 ```kotlin
-override fun onPostResume() {
-    super.onPostResume()
+override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null)   // Discard prior FragmentManager state — SDK's
+                           // BiometricAuthOptInPrompt has no no-arg ctor.
+    // ... rest of your onCreate ...
+}
+```
 
+**Extend your existing `onResume(client: RestClient?)`** to present the opt-in dialog at the right moment:
+
+```kotlin
+override fun onResume(client: RestClient?) {
+    if (client == null) return
+    // ... existing post-login logic (e.g. setupUserStoreFromDefaultConfig) ...
+    maybePresentBiometricOptIn()
+}
+
+private fun maybePresentBiometricOptIn() {
+    val mgr = MobileSyncSDKManager.getInstance().biometricAuthenticationManager ?: return
     val deviceHasBiometrics = BiometricManager.from(this).canAuthenticate(
         BIOMETRIC_STRONG or BIOMETRIC_WEAK
     ) == BiometricManager.BIOMETRIC_SUCCESS
-
-    MobileSyncSDKManager.getInstance().biometricAuthenticationManager?.run {
-        if (enabled && deviceHasBiometrics && !hasBiometricOptedIn()) {
-            presentOptInDialog(supportFragmentManager)
+    if (mgr.enabled && deviceHasBiometrics && !mgr.hasBiometricOptedIn()) {
+        // Defer to next main-thread tick: on fresh login, onResume(client) is
+        // invoked from a USERSWITCHED broadcast receiver while the
+        // FragmentManager is in saved state, which would otherwise crash with
+        // "Can not perform this action after onSaveInstanceState".
+        window.decorView.post {
+            if (!supportFragmentManager.isStateSaved && !mgr.hasBiometricOptedIn()) {
+                mgr.presentOptInDialog(supportFragmentManager)
+            }
         }
     }
 }
 ```
 
-> **`onPostResume()`** fires after `onResume()` and after the activity window is fully visible — the correct lifecycle point to present a dialog.
-
-> **`biometricAuthenticationManager`** is a nullable property on `SalesforceSDKManager`. The `?.run { }` block safely no-ops when no user is logged in.
+> **`biometricAuthenticationManager`** is a nullable property on `SalesforceSDKManager`. It's null until a user is authenticated.
 
 ### Step 3: Build and Verify
 
@@ -713,19 +821,42 @@ The `soupName` in `usersyncs.json` must exactly match the `soupName` in `usersto
 **`setupUserSyncsFromDefaultConfig()` silently does nothing**
 `usersyncs.json` must be in `app/src/main/res/raw/`.
 
+**No data appears in the soup after login**
+`setupUserSyncsFromDefaultConfig()` only **registers** the named syncs from `usersyncs.json`; it does not run them. Trigger one explicitly with `SyncManager.getInstance().reSync(syncName, callback)` (see "Add MobileSync" Step 5). Symptoms: `SyncManager.getInstance().getSyncStatus("<syncName>")` returns a `SyncState` with status `NEW` and `progress == 0`.
+
+**`Unresolved reference: SyncManager`**
+Add `import com.salesforce.androidsdk.mobilesync.manager.SyncManager`. The `MobileSyncSDKManager` does **not** expose `SyncManager` as a property — always access it via the `SyncManager.getInstance()` companion function.
+
 ### Biometric Issues
 
 **Opt-in dialog never appears**
-`enabled` is `false` — the connected app in your org does not have `ENABLE_BIOMETRIC_AUTHENTICATION` set. The dialog correctly does not appear.
+Three real causes:
+1. The Connected App doesn't have `ENABLE_BIOMETRIC_AUTHENTICATION` Custom Attribute set to `"true"` (with quotes).
+2. Your code triggers `presentOptInDialog` from `onPostResume()` rather than `onResume(client: RestClient?)` — on a fresh login the user account isn't bound during `onPostResume`, so `mgr.enabled` reads `false` and the `if` is skipped. Trigger from `onResume(client)` instead.
+3. The user wasn't logged in fresh after the Custom Attribute was added. Log out and back in.
 
-**`IllegalStateException`: Can not perform this action after onSaveInstanceState**
-The dialog is being presented too early in the lifecycle. Ensure you are calling `presentOptInDialog` from `onPostResume()`, not `onResume()`.
+**`IllegalStateException`: Can not perform this action after onSaveInstanceState (right after fresh login)**
+The SDK's `onResume(client)` is invoked from a `USERSWITCHED` broadcast receiver after a fresh login, when the FragmentManager has already saved state. Defer the dialog presentation to the next main-thread tick and guard against state loss:
+
+```kotlin
+window.decorView.post {
+    if (!supportFragmentManager.isStateSaved && !mgr.hasBiometricOptedIn()) {
+        mgr.presentOptInDialog(supportFragmentManager)
+    }
+}
+```
+
+**`Fragment$InstantiationException: could not find Fragment constructor` for `BiometricAuthOptInPrompt`**
+On activity recreate (rotation, theme change, process restore), FragmentManager tries to restore the SDK's opt-in dialog using a no-arg constructor that doesn't exist. Workaround: pass `null` to `super.onCreate(savedInstanceState)` in your `MainActivity.onCreate` to discard fragment state. The SDK fragments re-present themselves on next resume, so nothing is lost.
+
+**Biometric prompt succeeds, then app immediately shows fresh login screen**
+After successful biometric, the SDK refreshes the access token. If the Connected App has **"Require Secret for Refresh Token Flow"** *checked*, the refresh fails with `invalid_client` (visible in `adb logcat | grep ClientManager`: `Invalid Refresh Token: (Error: invalid_client, Status Code: 400)`), and the SDK silently logs the user out. Uncheck this setting on the Connected App (see Prerequisites above).
 
 **`Unresolved reference: BiometricManager`**
 The `androidx.biometric:biometric` dependency is missing or Gradle sync didn't complete.
 
 **`biometricAuthenticationManager` is null**
-No user is currently authenticated. This is expected before login. The `?.run { }` safe-call handles this correctly.
+No user is currently authenticated. This is expected before login.
 
 ---
 

--- a/skills/ios-mobile-sdk/SKILL.md
+++ b/skills/ios-mobile-sdk/SKILL.md
@@ -239,6 +239,8 @@ Also detect which dependency manager the project uses:
 - Project has a `Podfile` → use the CocoaPods path
 - Project has `.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/` → use the SPM path
 
+**Do NOT regenerate the Xcode project.** If the project already ships an `.xcodeproj`, edit the existing `Podfile` and source files in place. Do not run `xcodegen generate`, do not author a new `project.yml`, and do not recreate the existing `<AppName>.xcodeproj/` directory. Regenerating the project drops the existing target/scheme configuration and produces a project that compiles but cannot resolve CocoaPods-supplied modules.
+
 ### Step 1: Add the SDK Dependency
 
 #### Option A — CocoaPods (project has a `Podfile`)
@@ -264,6 +266,12 @@ post_install do |installer|
   end
 end
 ```
+
+**Verify before installing.** Re-read the Podfile after editing and confirm:
+- The line `pod 'SalesforceSDKCore'` is present inside the `target` block.
+- Both sources are declared: `cdn.cocoapods.org` AND `github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs`.
+
+If either is missing, your edit didn't land — `pod install` will succeed vacuously but the build will fail later with `Unable to find module dependency: 'SalesforceSDKCore'`.
 
 Then install:
 
@@ -692,9 +700,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 ### Step 3: Set Up Sync After Login in SceneDelegate.swift
 
-Add a `MobileSync` import and call `setupUserSyncsFromDefaultConfig()`, then trigger an initial sync.
+Add a `MobileSync` import and call `setupUserSyncsFromDefaultConfig()`, then run a registered sync.
 
-> **What `setupUserSyncsFromDefaultConfig()` actually does**: it reads `usersync.json` and **registers** the named sync configurations with the sync manager. It does **not** run them. To execute a registered sync, call `syncManager.reSync(named:onUpdate:)` after registration. The "Perform initial sync" example below shows the explicit, programmatic alternative — useful when you want a one-off sync that isn't declared in `usersync.json`.
+> **What `setupUserSyncsFromDefaultConfig()` actually does**: it reads `usersyncs.json` and **registers** the named sync configurations with the sync manager. It does **not** run them. To execute a registered sync, call `syncManager.reSync(named:onUpdate:)` after registration.
+
+> **The `onUpdate` block fires asynchronously** as the sync transitions through `.running` → `.done` / `.failed`. `reSync(named:onUpdate:)` returns the initial `SyncState` immediately, so any UI you build before the block fires will show pre-sync state. Reload your data source from SmartStore **inside** the `onUpdate` block when status reaches `.done`, otherwise your view stays empty even after the sync succeeds.
 
 **Before:**
 ```swift
@@ -712,7 +722,7 @@ func setupRootViewController() {
 **After:**
 ```swift
 import MobileSync
-import SalesforceSDKCore   // UserAccountManager lives in Core
+import SalesforceSDKCore
 
 // ...
 
@@ -720,49 +730,47 @@ func setupRootViewController() {
     MobileSyncSDKManager.shared.setupUserStoreFromDefaultConfig()
     MobileSyncSDKManager.shared.setupUserSyncsFromDefaultConfig()
 
-    // Trigger a sync registered in usersync.json by name.
+    // Build the post-login UI first; it will start empty.
+    let listVC = MyAccountsViewController()
+    window?.rootViewController = UINavigationController(rootViewController: listVC)
+
+    // Run the sync registered in usersyncs.json by name. The onUpdate
+    // block fires across .running → .done / .failed; reload the UI
+    // from SmartStore once the sync is .done.
     if let user = UserAccountManager.shared.currentUserAccount {
         let syncManager = SyncManager.sharedInstance(forUserAccount: user)
         try? syncManager.reSync(named: "<SyncName>") { sync in
-            print("Sync \(sync.syncName ?? "") status: \(sync.status)")
-        }
-
-        // Or run a one-off sync that isn't in usersync.json.
-        let target = SoqlSyncDownTarget.newSyncTarget("SELECT Id, Name FROM <SObjectType>")
-        let options = SyncOptions.newSyncOptions(forSyncDown: .overwrite)
-        syncManager.syncDown(target: target,
-                             options: options,
-                             soupName: "<SoupName>") { sync in
-            print("Initial sync status: \(sync.status)")
+            if sync.status == .done {
+                DispatchQueue.main.async {
+                    listVC.reloadFromStore()
+                }
+            } else if sync.status == .failed {
+                NSLog("Sync \(sync.syncName ?? "<unnamed>") failed")
+            }
         }
     }
-
-    let vc = UIViewController()
-    vc.view.backgroundColor = .systemBackground
-    let label = UILabel()
-    label.text = "SmartStore + MobileSync ready"
-    label.translatesAutoresizingMaskIntoConstraints = false
-    vc.view.addSubview(label)
-    NSLayoutConstraint.activate([
-        label.centerXAnchor.constraint(equalTo: vc.view.centerXAnchor),
-        label.centerYAnchor.constraint(equalTo: vc.view.centerYAnchor)
-    ])
-    window?.rootViewController = vc
 }
 ```
 
-Replace `<SObjectType>`, `<SoupName>`, and `<SyncName>` with actual values (e.g. `Contact`, `Item`, and a sync name from `usersync.json`).
+Replace `<SyncName>` with the `syncName` you declared in `usersyncs.json`. `MyAccountsViewController` stands in for whatever view you want to populate from SmartStore — its `reloadFromStore()` is your responsibility (typically a query against the soup followed by a `tableView.reloadData()` or equivalent).
 
-> **Swift name vs. Objective-C class**: the Mobile SDK is written in Objective-C and exposes Swift-native names via `NS_SWIFT_NAME` annotations. From Swift you write `SyncManager`, `SoqlSyncDownTarget`, `SyncOptions`, and `UserAccountManager`; the underlying ObjC classes are `SFMobileSyncSyncManager`, `SFSoqlSyncDownTarget`, `SFSyncOptions`, and `SFUserAccountManager`. They aren't deprecated — they're the same types under different names per language. See [API Reference](#api-reference) below.
+> **Swift name vs. Objective-C class**: the Mobile SDK is written in Objective-C and exposes Swift-native names via `NS_SWIFT_NAME` annotations. From Swift you write `UserAccountManager`, `SyncManager`, `SoqlSyncDownTarget`, and `SyncOptions`; the underlying ObjC classes are `SFUserAccountManager`, `SFMobileSyncSyncManager`, `SFSoqlSyncDownTarget`, and `SFSyncOptions`. They aren't deprecated — they're the same types under different names per language. A few specific gotchas:
+>
+> - `UserAccountManager.shared` is a **property**, not a method — write `UserAccountManager.shared.currentUserAccount`, not `UserAccountManager.shared().currentUser`. `currentUserAccount` is `Optional<UserAccount>`, so guard with `if let`.
+> - `SyncManager.sharedInstance` takes the label `forUserAccount:` from Swift (`NS_SWIFT_NAME(sharedInstance(forUserAccount:))`), not `for:`.
+> - `SoqlSyncDownTarget` has no Swift initializer; construct it via `SoqlSyncDownTarget.newSyncTarget(_:)`.
+>
+> See [API Reference](#api-reference) below for the full class mapping.
 
-### Step 4: Create usersync.json
+### Step 4: Create usersyncs.json
 
-Create `usersync.json` inside the app target's source folder:
+Create `usersyncs.json` inside the app target's source folder.
 
 ```json
 {
   "syncs": [
     {
+      "syncName": "<SyncName>",
       "syncType": "syncDown",
       "soupName": "<SoupName>",
       "target": {
@@ -772,18 +780,61 @@ Create `usersync.json` inside the app target's source folder:
       "options": {
         "mergeMode": "OVERWRITE"
       }
+    },
+    {
+      "syncName": "<SyncUpName>",
+      "syncType": "syncUp",
+      "soupName": "<SoupName>",
+      "target": {
+        "createFieldlist": ["Name"],
+        "updateFieldlist": ["Name"]
+      },
+      "options": {
+        "fieldlist": ["Name"],
+        "mergeMode": "OVERWRITE"
+      }
     }
   ]
 }
 ```
 
-Replace `<SoupName>` and `<SObjectType>` with actual values.
+Replace `<SyncName>`, `<SyncUpName>`, `<SoupName>`, and `<SObjectType>` with actual values, and tailor the field lists to the columns you want to push. The sync-up entry deliberately omits `target.type`; the SDK defaults to `"rest"` (`SFCollectionSyncUpTarget`), the standard sync-up target. Set `target.type` only if you ship a custom `SFSyncUpTarget` subclass (in which case use `"custom"` and add an `iOSImpl` key naming it).
 
-Add `usersync.json` to the Xcode target and verify it appears in **Copy Bundle Resources**.
+`syncName` is required on each entry — it's the identifier you pass to `syncManager.reSync(named:)` to run the sync.
 
-### Step 5: Build and Verify
+Add `usersyncs.json` to the Xcode target and verify it appears in **Copy Bundle Resources**.
 
-Build and run. After login, you should see **"SmartStore + MobileSync ready"** and data should begin syncing from Salesforce.
+### Step 5: Creating local rows from app code
+
+When the user creates a record in your app *before* it has been pushed to Salesforce, the row exists only in SmartStore and has no server `Id`. Flag it as locally created so sync-up will push it; the server `Id` is filled in on the next sync-up.
+
+```swift
+import MobileSync
+import SalesforceSDKCore
+
+func createLocalAccount(name: String, phone: String) {
+    guard let user = UserAccountManager.shared.currentUserAccount,
+          let store = SmartStore.shared(withName: SmartStore.defaultStoreName, forUserAccount: user)
+    else { return }
+
+    let entry: [String: Any] = [
+        "Name": name,
+        "Phone": phone,
+        "attributes": ["type": "Account"],
+        "__local__": true,
+        "__locally_created__": true,
+        "__locally_updated__": false,
+        "__locally_deleted__": false
+    ]
+    _ = store.upsert(entries: [entry], forSoupNamed: "<SoupName>")
+}
+```
+
+Use the two-arg `upsert(entries:forSoupNamed:)` overload for local creates — it keys on the soup's internal `_soupEntryId`. The three-arg `upsert(entries:forSoupNamed:withExternalIdPath:)` overload is for upsert-by-server-`Id` *after* a sync-down has populated the row; passing it for a brand-new local row throws because the external-id field is nil.
+
+### Step 6: Build and Verify
+
+Build and run. After login, you should see **"SmartStore + MobileSync ready"** and data should begin syncing from Salesforce. Confirm the launch log line `Setting up user syncs using config found in usersyncs.json` appears — if not, the file isn't in the bundle.
 
 ---
 
@@ -796,9 +847,7 @@ This section adds Face ID / Touch ID biometric authentication to an existing iOS
 
 **The app must already have the Mobile SDK wired up.** Check `AppDelegate.swift` for `SalesforceManager.initializeSDK()` (or one of its subclasses) and that `bootconfig.plist` exists. If not, complete the [Add Mobile SDK](#add-mobile-sdk) section first.
 
-Before starting, confirm:
-- **App target name** (e.g. `MyApp`)
-- **Biometric policy**: `deviceOwner` (Face ID / Touch ID / passcode fallback) or `deviceOwnerAuthenticationWithBiometrics` (biometric only, no passcode fallback)
+**The Connected App must already publish the biometric policy custom attributes.** This skill assumes that's done — if `BiometricAuthenticationManagerInternal.shared.enabled` returns `false` at runtime, talk to your Salesforce admin before debugging the client.
 
 ### Step 1: Update Info.plist for Biometric Permissions
 
@@ -809,55 +858,46 @@ Add the Face ID usage description to `Info.plist`:
 <string>This app uses Face ID to verify your identity before accessing Salesforce data.</string>
 ```
 
-### Step 2: Configure Biometric Authentication in AppDelegate.swift
+### Step 2: Prompt for Biometric Opt-In After Login
 
-Add biometric configuration after SDK initialization:
+In `SceneDelegate.swift`, present the SDK's opt-in dialog after successful login. Guard on `enabled` and `hasBiometricOptedIn()` so the dialog only appears once and only when the policy is in force for the current user.
 
 ```swift
-import UIKit
 import SalesforceSDKCore
 
-@UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow?
+func setupRootViewController() {
+    // ... build your post-login root view controller ...
 
-    override init() {
-        super.init()
-        SalesforceManager.initializeSDK()
-        
-        // Configure biometric authentication
-        BiometricAuthenticationManager.shared.biometricAuthenticationEnabled = true
-        BiometricAuthenticationManager.shared.biometricAuthenticationPolicy = .deviceOwner
+    let bioAuth = BiometricAuthenticationManagerInternal.shared
+    if bioAuth.enabled, !bioAuth.hasBiometricOptedIn(), let root = window?.rootViewController {
+        bioAuth.presentOptInDialog(viewController: root)
     }
-    
-    // ... rest of AppDelegate
 }
 ```
 
-Use `.deviceOwner` for Face ID / Touch ID with passcode fallback, or `.deviceOwnerAuthenticationWithBiometrics` for biometric-only (no passcode fallback).
+Notes on the API:
 
-### Step 3: Prompt for Biometric Enrollment After Login
+- `BiometricAuthenticationManagerInternal.shared` is the singleton; it conforms to the public `BiometricAuthenticationManager` protocol (`@objc(SFBiometricAuthenticationManager)`).
+- `enabled` is a **read-only** `Bool` derived from the Connected App policy stored at login. There is no client-side switch — biometric is enabled server-side via the Connected App, not from the app code.
+- `hasBiometricOptedIn()` lets you avoid re-prompting users who have already opted in or out.
 
-In `SceneDelegate.swift`, add biometric enrollment prompt after successful login:
+### Step 3: (Optional) Lock the App On Demand
+
+To lock immediately — for example, from an overflow menu's "Lock now" action — call `lock()`:
 
 ```swift
-func setupRootViewController() {
-    // Show biometric opt-in if not already configured
-    if !BiometricAuthenticationManager.shared.locked {
-        BiometricAuthenticationManager.shared.showBiometricEnrollment(presentingController: nil) { enrolled in
-            if enrolled {
-                print("User opted in to biometric authentication")
-            }
-        }
-    }
-    
-    // ... rest of setupRootViewController
-}
+BiometricAuthenticationManagerInternal.shared.lock()
 ```
+
+The SDK also relocks automatically when the app comes to the foreground after the policy's configured idle timeout has elapsed.
 
 ### Step 4: Build and Verify
 
-Build and run. After login, the app should prompt the user to enable Face ID / Touch ID. On subsequent launches, the user will need to authenticate biometrically before accessing the app.
+Build and run. After login on a user whose Connected App has the biometric policy in force:
+
+1. The opt-in dialog appears once. Tap **Enable**.
+2. Background the app and wait the configured timeout, or call `lock()`.
+3. Bring the app to the foreground — the SDK presents the Face ID / Touch ID unlock screen with a "Log In with Biometric" button.
 
 ---
 
@@ -893,7 +933,7 @@ The target is missing `supportedDestinations` (Xcode 16+ excludes the simulator 
 ### Biometric Issues
 
 **Biometric prompt does not appear**
-Verify `NSFaceIDUsageDescription` is in `Info.plist` and `BiometricAuthenticationManager.shared.biometricAuthenticationEnabled` is set to `true`.
+Verify `NSFaceIDUsageDescription` is in `Info.plist` and `BiometricAuthenticationManagerInternal.shared.enabled` returns `true` at runtime. If `enabled` is `false`, the Connected App's biometric policy isn't in force for this user — talk to your Salesforce admin.
 
 ---
 


### PR DESCRIPTION
## Summary

Syncs the `skills/` directory from [SalesforceMobileSDK-Skills-internal](https://git.soma.salesforce.com/SalesforceMobileSDK/SalesforceMobileSDK-Skills-internal) into this repository.

**Source commit:** `33bfdbdf44a8870ca57aa15e5a996627261d1e8a`
**Source date:** 2026-06-03

## Skills included

- `ios-mobile-sdk` — iOS Swift integration guide (create app, add SDK auth, SmartStore, MobileSync, biometric auth)
- `android-mobile-sdk` — Android Kotlin integration guide (same scenarios)

## How to install (end users)

```bash
npx skills add forcedotcom/SalesforceMobileSDK-Templates
```

## Review checklist

- [ ] Skills content looks correct
- [ ] No internal-only files (eval framework, `package.json`, `mcp-config.json`) were accidentally included