### PR TITLE
W-21080629: Fix Info.plist path for cordova-ios 8.x (App/App-Info.plist)

### DIFF
--- a/HybridLocalTemplate/template.js
+++ b/HybridLocalTemplate/template.js
@@ -46,7 +46,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Key files
     var templateBootconfigFile = path.join('bootconfig.json');
     var templateServersFile = path.join('servers.xml'); // android only
-    var templateInfoFile = path.join('..', 'platforms', 'ios', config.appname, config.appname + '-Info.plist'); // ios only
+    var templateInfoFile = path.join('..', 'platforms', 'ios', 'App', 'App-Info.plist'); // ios only
 
     //
     // Replace in files

--- a/HybridRemoteTemplate/template.js
+++ b/HybridRemoteTemplate/template.js
@@ -49,7 +49,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Key files
     var templateBootconfigFile = path.join('bootconfig.json');
     var templateServersFile = path.join('servers.xml'); // android only
-    var templateInfoFile = path.join('..', 'platforms', 'ios', config.appname, config.appname + '-Info.plist'); // ios only
+    var templateInfoFile = path.join('..', 'platforms', 'ios', 'App', 'App-Info.plist'); // ios only
 
     //
     // Replace in files


### PR DESCRIPTION
## Summary

cordova-ios 8.x uses a fixed project directory name `App/` regardless of app name. The Info.plist path changed from `platforms/ios/<AppName>/<AppName>-Info.plist` to `platforms/ios/App/App-Info.plist`.

### Changes

- `HybridLocalTemplate/template.js` — update `templateInfoFile` path
- `HybridRemoteTemplate/template.js` — update `templateInfoFile` path

## Test plan

- [ ] `hybrid_local` template generates successfully with cordova-ios 8.1.0 — verified ✅
- [ ] `hybrid_remote` template generates successfully with cordova-ios 8.1.0 — verified ✅
- [ ] iOS login server is correctly written to `App-Info.plist` — verified ✅