### PR TITLE
W-22974697: Remove deprecated adjustResize from Android template manifests

### DIFF
--- a/AndroidNativeLoginTemplate/app/src/main/AndroidManifest.xml
+++ b/AndroidNativeLoginTemplate/app/src/main/AndroidManifest.xml
@@ -24,7 +24,6 @@
 
 		<activity android:name=".NativeLogin"
 			android:theme="@style/NativeLoginTheme"
-			android:windowSoftInputMode="adjustResize"
 			android:exported="false" />
 
         <!-- Login activity -->

--- a/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
+++ b/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
@@ -21,8 +21,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-            android:windowSoftInputMode="adjustResize">
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
@@ -21,8 +21,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-            android:windowSoftInputMode="adjustResize">
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
@@ -21,8 +21,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-            android:windowSoftInputMode="adjustResize">
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
@@ -21,8 +21,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-            android:windowSoftInputMode="adjustResize">
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary

Remove `android:windowSoftInputMode="adjustResize"` from Android `AndroidManifest.xml` in the following templates:

- `AndroidNativeLoginTemplate`
- `ReactNativeTemplate`
- `ReactNativeTypeScriptTemplate`
- `ReactNativeDeferredTemplate`
- `MobileSyncExplorerReactNative`

`adjustResize` is deprecated on Android API 35+ in edge-to-edge windows and does not work correctly when the window is in edge-to-edge mode (mandatory on API 36 / Android 16).

## GUS

W-22974697

## Test plan

- [ ] Generate apps from affected templates and verify keyboard behavior in text input fields
- [ ] Test on API 35+ and API 31-34