### PR TITLE
W-22857749: Fix header button look and feel in RN template apps on iOS 26

### DIFF
--- a/MobileSyncExplorerReactNative/js/ContactScreen.js
+++ b/MobileSyncExplorerReactNative/js/ContactScreen.js
@@ -60,7 +60,7 @@ class ContactScreen extends React.Component {
         
         this.props.navigation.setOptions({
             title: 'Contact',
-            headerLeft: () => (<NavImgButton icon='arrow-back' color='white' onPress={() => this.onBack()} />),
+            headerLeft: () => (<View style={styles.navButtonsGroupLeft}><NavImgButton icon='arrow-back' color='white' onPress={() => this.onBack()} /></View>),
             headerRight: () => (
                     <View style={styles.navButtonsGroup}>
                         <NavImgButton icon={deleteUndeleteIconName} iconType='material-community' onPress={() => this.onDeleteUndeleteContact()} />

--- a/MobileSyncExplorerReactNative/js/Styles.js
+++ b/MobileSyncExplorerReactNative/js/Styles.js
@@ -31,13 +31,20 @@ export default StyleSheet.create({
         backgroundColor: 'red',
     },
     navBarButton: {
-        paddingLeft: 6,
+        width: 44,
+        height: 44,
+        alignItems: 'center',
+        justifyContent: 'center',
     },
     navButtonsGroup: {
         flexDirection: 'row',
+        alignItems: 'center',
+        marginRight: 4,
     },
-    navBarButton: {
-        paddingLeft: 6,
+    navButtonsGroupLeft: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginLeft: 4,
     },
     navBarTitleText: {
         fontSize: 26,

--- a/ReactNativeDeferredTemplate/app.js
+++ b/ReactNativeDeferredTemplate/app.js
@@ -70,6 +70,7 @@ import {
     FlatList,
     ActivityIndicator,
     TouchableOpacity,
+    Platform,
 } from 'react-native';
 
 import { NavigationContainer } from '@react-navigation/native';
@@ -576,15 +577,25 @@ const styles = StyleSheet.create({
     },
 
     // Header button (Login/Logout in navigation bar)
-    headerButton: {
-        marginRight: 16,
-        paddingVertical: 6,
-        paddingHorizontal: 12,
-        backgroundColor: 'rgba(255, 255, 255, 0.2)',
-        borderRadius: 6,
-        borderWidth: 1,
-        borderColor: 'rgba(255, 255, 255, 0.4)',
-    },
+    // On iOS 26 the system adds a pill behind TouchableOpacity in headers — suppress our own pill there.
+    headerButton: Platform.select({
+        ios: {
+            height: 44,
+            marginRight: 4,
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: 8,
+        },
+        android: {
+            marginRight: 16,
+            paddingVertical: 6,
+            paddingHorizontal: 12,
+            backgroundColor: 'rgba(255, 255, 255, 0.2)',
+            borderRadius: 6,
+            borderWidth: 1,
+            borderColor: 'rgba(255, 255, 255, 0.4)',
+        },
+    }),
 
     // Header button text
     headerButtonText: {

--- a/ReactNativeTemplate/app.js
+++ b/ReactNativeTemplate/app.js
@@ -43,6 +43,7 @@ import {
     FlatList,
     ActivityIndicator,
     TouchableOpacity,
+    Platform,
 } from 'react-native';
 
 import { NavigationContainer } from '@react-navigation/native';
@@ -442,15 +443,25 @@ const styles = StyleSheet.create({
     },
 
     // Header button (Logout in navigation bar)
-    headerButton: {
-        marginRight: 16,
-        paddingVertical: 6,
-        paddingHorizontal: 12,
-        backgroundColor: 'rgba(255, 255, 255, 0.2)',
-        borderRadius: 6,
-        borderWidth: 1,
-        borderColor: 'rgba(255, 255, 255, 0.4)',
-    },
+    // On iOS 26 the system adds a pill behind TouchableOpacity in headers — suppress our own pill there.
+    headerButton: Platform.select({
+        ios: {
+            height: 44,
+            marginRight: 4,
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: 8,
+        },
+        android: {
+            marginRight: 16,
+            paddingVertical: 6,
+            paddingHorizontal: 12,
+            backgroundColor: 'rgba(255, 255, 255, 0.2)',
+            borderRadius: 6,
+            borderWidth: 1,
+            borderColor: 'rgba(255, 255, 255, 0.4)',
+        },
+    }),
 
     // Header button text
     headerButtonText: {

--- a/ReactNativeTypeScriptTemplate/app.tsx
+++ b/ReactNativeTypeScriptTemplate/app.tsx
@@ -43,6 +43,7 @@ import {
     FlatList,
     ActivityIndicator,
     TouchableOpacity,
+    Platform,
 } from 'react-native';
 
 import { NavigationContainer } from '@react-navigation/native';
@@ -479,15 +480,25 @@ const styles = StyleSheet.create({
     },
 
     // Header button (Logout in navigation bar)
-    headerButton: {
-        marginRight: 16,
-        paddingVertical: 6,
-        paddingHorizontal: 12,
-        backgroundColor: 'rgba(255, 255, 255, 0.2)',
-        borderRadius: 6,
-        borderWidth: 1,
-        borderColor: 'rgba(255, 255, 255, 0.4)',
-    },
+    // On iOS 26 the system adds a pill behind TouchableOpacity in headers — suppress our own pill there.
+    headerButton: Platform.select({
+        ios: {
+            height: 44,
+            marginRight: 4,
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: 8,
+        },
+        android: {
+            marginRight: 16,
+            paddingVertical: 6,
+            paddingHorizontal: 12,
+            backgroundColor: 'rgba(255, 255, 255, 0.2)',
+            borderRadius: 6,
+            borderWidth: 1,
+            borderColor: 'rgba(255, 255, 255, 0.4)',
+        },
+    }),
 
     // Header button text
     headerButtonText: {


### PR DESCRIPTION
## Summary

Fixes the iOS 26 \"Liquid Glass\" pill rendering issue on navigation header buttons in all 4 React Native templates. On iOS 26, the system automatically wraps `TouchableOpacity` elements in `headerRight`/`headerLeft` with a pill/capsule shape — causing double-pill appearance or misaligned icons.

## Changes

### ReactNativeTemplate / ReactNativeTypeScriptTemplate / ReactNativeDeferredTemplate

- Added `Platform` to `react-native` imports
- `headerButton` style now uses `Platform.select()`:
  - **iOS**: `height: 44`, centered, `paddingHorizontal: 8`, no background/border — lets the iOS 26 system pill render cleanly
  - **Android**: unchanged pill style (`backgroundColor`, `borderRadius`, `borderWidth`, `borderColor`, padding)

### MobileSyncExplorerReactNative

- `Styles.js`: Fixed `navBarButton` (44×44, `alignItems/justifyContent: center`), `navButtonsGroup` (added `alignItems: center`, `marginRight: 4`), added `navButtonsGroupLeft` for left-side buttons; removed duplicate `navBarButton` key
- `ContactScreen.js`: Wrapped `headerLeft` back button in `View` with `navButtonsGroupLeft` to suppress standalone circular pill on iOS 26

## Testing

Validated manually on iOS 26 simulator:
- ReactNativeTemplate: Logout button centered in system pill ✅
- MobileSyncExplorerReactNative: 3 icons (add/sync/logout) centered in pill ✅; back button and delete button on Contact screen centered ✅

Android UX unchanged (Platform.select keeps existing Android styles).

## ⚠️ Note

Changes are JS/TS only — no native code changes. No pod install or Gradle changes needed.