### PR TITLE
Use forcedotcom-ubuntu runner for Linux CI jobs

### DIFF
--- a/.github/workflows/android-reusable-workflow.yaml
+++ b/.github/workflows/android-reusable-workflow.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   generate-template-list:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     outputs:
       templates: ${{ steps.set-templates.outputs.templates }}
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   test-android:
     needs: generate-template-list
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ios-reusable-workflow.yaml
+++ b/.github/workflows/ios-reusable-workflow.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   generate-template-list:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     outputs:
       templates: ${{ steps.set-templates.outputs.templates }}
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/android-reusable-workflow.yaml
 
   nightly-summary:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     needs: [ios-nightly, android-nightly]
     if: always()
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   permission-check:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     steps:
       - name: Check Write Permission
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
@@ -53,7 +53,7 @@ jobs:
 
   detect-changed-templates:
     needs: permission-check
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     outputs:
       templates: ${{ steps.set-templates.outputs.templates }}
       has-changes: ${{ steps.set-templates.outputs.has-changes }}
@@ -177,7 +177,7 @@ jobs:
   pr-summary:
     needs: [detect-changed-templates, ios-pr, android-pr]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     steps:
       - name: PR Summary
         env:


### PR DESCRIPTION
## What
Switch all Linux GitHub Actions jobs from the public `ubuntu-latest` runner to the `forcedotcom-ubuntu` enterprise premium runner. macOS jobs are unchanged (there is no `forcedotcom-macos` runner).

## Why
`forcedotcom-ubuntu` supports much higher concurrency (~50 concurrent jobs) than the public pool, which our workflows have been hitting limits on as PR volume grew.

## Notes
- `forcedotcom-ubuntu` is scoped to the `forcedotcom` org — **personal forks cannot schedule it**. Each changed line carries an inline comment reminding fork contributors to swap back to `ubuntu-latest` for fork-based CI testing.
- Verified with a full nightly run on the org-scoped runner (in `SalesforceMobileSDK-UITests`): all Linux jobs picked up runners and ran concurrently, building apps and dispatching to Firebase Test Lab. Remaining test failures were pre-existing login/session flakes — present on the unchanged macOS jobs and the baseline `master` nightly too — and are unrelated to the runner change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
