### PR TITLE
Wire OAuth redirect intent-filter into generated Android manifests (W-23294087)

### DIFF
--- a/AndroidIDPTemplate/app/src/main/AndroidManifest.xml
+++ b/AndroidIDPTemplate/app/src/main/AndroidManifest.xml
@@ -23,34 +23,34 @@
 
 		<!-- Login activity -->
 		<!--
-            To enable browser based authentication, uncomment the lines below and replace
-            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+            This activity delivers the browser callback Intent to the SDK LoginActivity
+            for browser based (advanced) authentication. The scheme, host and path below
+            are populated from your connected app's callback URL.
 
             For example, if the callback URL of your connected app is
             "testsfdc:///mobilesdk/detect/oauth/done",
-            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
-            'path' would be "/mobilesdk/detect/oauth/done".
+            'scheme' would be "testsfdc", 'host' would be empty ("") since it doesn't exist,
+            and 'path' would be "/mobilesdk/detect/oauth/done".
 
             If the callback URL is "sfdc://login.salesforce.com/oauth/done",
             'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
             and 'path' would be "/oauth/done".
         -->
-		<!--
-        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-            android:theme="@style/SalesforceSDK"
-            android:launchMode="singleTask"
-            android:exported="true">
-
-            <intent-filter>
-                <data android:scheme="testsfdc"
-                    android:host="*"
-                    android:path="/mobilesdk/detect/oauth/done" />
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-        </activity>
-        -->
+		<activity
+			android:name="com.salesforce.androidsdk.ui.LoginActivity"
+			android:exported="true"
+			android:launchMode="singleTask"
+			android:theme="@style/SalesforceSDK">
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<data
+					android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
+					android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
+					android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+			</intent-filter>
+		</activity>
 
 	</application>
 </manifest>

--- a/AndroidIDPTemplate/app/src/main/AndroidManifest.xml
+++ b/AndroidIDPTemplate/app/src/main/AndroidManifest.xml
@@ -48,7 +48,7 @@
 				<data
 					android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
 					android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
-					android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+					android:path="/__INSERT_CALLBACK_URL_PATH_HERE__" />
 			</intent-filter>
 		</activity>
 

--- a/AndroidIDPTemplate/template.js
+++ b/AndroidIDPTemplate/template.js
@@ -46,6 +46,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     var templateStringsXmlFile = path.join('app', 'src', 'main', 'res', 'values', 'strings.xml');
     var templateBootconfigFile = path.join('app', 'src', 'main', 'res', 'values', 'bootconfig.xml');
     var templateServersFile = path.join('app', 'src', 'main', 'res', 'xml', 'servers.xml');
+    var templateAndroidManifestFile = path.join('app', 'src', 'main', 'AndroidManifest.xml');
     var templateMainActivityFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'samples', 'salesforceandroididptemplateapp', 'MainActivity.kt');
     var templateMainApplicationFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'samples', 'salesforceandroididptemplateapp', 'MainApplication.kt');
 
@@ -67,6 +68,9 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // callback URL
     if (config.callbackurl && config.callbackurl !== '') {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
     }
 
     // login server

--- a/AndroidIDPTemplate/template.js
+++ b/AndroidIDPTemplate/template.js
@@ -70,7 +70,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
-        replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
+        replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
     }
 
     // login server

--- a/AndroidNativeKotlinTemplate/app/src/main/AndroidManifest.xml
+++ b/AndroidNativeKotlinTemplate/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
                 <data
                     android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
                     android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
-                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+                    android:path="/__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
     </application>

--- a/AndroidNativeKotlinTemplate/app/src/main/AndroidManifest.xml
+++ b/AndroidNativeKotlinTemplate/app/src/main/AndroidManifest.xml
@@ -34,23 +34,33 @@
 
         <!-- Login activity -->
         <!--
-            To enable browser based authentication, uncomment the lines below and replace
-            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+            This activity enables browser based authentication. The redirect intent-filter's
+            'scheme', 'host' and 'path' are populated from your connected app's callback URL.
 
             For example, if the callback URL of your connected app is
             "testsfdc:///mobilesdk/detect/oauth/done",
-            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
-            'path' would be "/mobilesdk/detect/oauth/done".
+            'scheme' would be "testsfdc", 'host' would be empty since this callback URL has no
+            host component (never use "*"), and 'path' would be "/mobilesdk/detect/oauth/done".
 
             If the callback URL is "sfdc://login.salesforce.com/oauth/done",
             'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
             and 'path' would be "/oauth/done".
         -->
         <!-- Use `android:name="com.salesforce.androidnativekotlintemplate.QrCodeEnabledLoginActivity"` when enabling log in via Salesforce UI Bridge API generated QR codes -->
-<!--        <activity-->
-<!--            android:name="com.salesforce.androidsdk.ui.LoginActivity"-->
-<!--            android:exported="true"-->
-<!--            android:launchMode="singleTask"-->
-<!--            android:theme="@style/SalesforceSDK" />-->
+        <activity
+            android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/SalesforceSDK">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
+                    android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
+                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/AndroidNativeKotlinTemplate/template.js
+++ b/AndroidNativeKotlinTemplate/template.js
@@ -72,7 +72,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
-        replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
+        replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
     }
 
     // login server

--- a/AndroidNativeKotlinTemplate/template.js
+++ b/AndroidNativeKotlinTemplate/template.js
@@ -45,6 +45,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     var templateBuildGradleFile = path.join('app', 'build.gradle.kts');
     var templateStringsXmlFile = path.join('app', 'src', 'main', 'res', 'values', 'strings.xml');
     var templateBootconfigFile = path.join('app', 'src', 'main', 'res', 'values', 'bootconfig.xml');
+    var templateAndroidManifestFile = path.join('app', 'src', 'main', 'AndroidManifest.xml');
     var templateServersFile = path.join('app', 'src', 'main', 'res', 'xml', 'servers.xml');
     var templateMainActivityFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'MainActivity.kt');
     var templateMainApplicationFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativekotlintemplate', 'MainApplication.kt');
@@ -69,6 +70,9 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // callback URL
     if (config.callbackurl && config.callbackurl !== '') {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
     }
 
     // login server

--- a/AndroidNativeLoginTemplate/app/src/main/AndroidManifest.xml
+++ b/AndroidNativeLoginTemplate/app/src/main/AndroidManifest.xml
@@ -28,33 +28,32 @@
 
         <!-- Login activity -->
         <!--
-            To enable browser based authentication, uncomment the lines below and replace
-            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+            This activity handles browser based authentication. The 'scheme', 'host' and 'path'
+            below are derived from your connected app's callback URL.
 
             For example, if the callback URL of your connected app is
             "testsfdc:///mobilesdk/detect/oauth/done",
-            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
+            'scheme' would be "testsfdc", 'host' would be "" since the URL has no authority, and
             'path' would be "/mobilesdk/detect/oauth/done".
 
             If the callback URL is "sfdc://login.salesforce.com/oauth/done",
             'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
             and 'path' would be "/oauth/done".
         -->
-        <!--
-        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-            android:theme="@style/SalesforceSDK"
+        <activity
+            android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:exported="true"
             android:launchMode="singleTask"
-            android:exported="true">
-
+            android:theme="@style/SalesforceSDK">
             <intent-filter>
-                <data android:scheme="testsfdc"
-                    android:host="*"
-                    android:path="/mobilesdk/detect/oauth/done" />
                 <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
+                    android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
+                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
-        -->
 	</application>
 </manifest>

--- a/AndroidNativeLoginTemplate/app/src/main/AndroidManifest.xml
+++ b/AndroidNativeLoginTemplate/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
                 <data
                     android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
                     android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
-                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+                    android:path="/__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
 	</application>

--- a/AndroidNativeLoginTemplate/template.js
+++ b/AndroidNativeLoginTemplate/template.js
@@ -45,6 +45,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     var templateBuildGradleFile = path.join('app', 'build.gradle.kts');
     var templateStringsXmlFile = path.join('app', 'src', 'main', 'res', 'values', 'strings.xml');
     var templateBootconfigFile = path.join('app', 'src', 'main', 'res', 'values', 'bootconfig.xml');
+    var templateAndroidManifestFile = path.join('app', 'src', 'main', 'AndroidManifest.xml');
     var templateServersFile = path.join('app', 'src', 'main', 'res', 'xml', 'servers.xml');
     var templateMainActivityFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativelogintemplate', 'MainActivity.kt');
     var templateMainApplicationFile = path.join('app', 'src', 'main', 'java', 'com', 'salesforce', 'androidnativelogintemplate', 'MainApplication.kt');
@@ -69,6 +70,9 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // callback URL
     if (config.callbackurl && config.callbackurl !== '') {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
     }
 
     // login server

--- a/AndroidNativeLoginTemplate/template.js
+++ b/AndroidNativeLoginTemplate/template.js
@@ -72,7 +72,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
-        replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
+        replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
     }
 
     // login server

--- a/HybridLocalTemplate/template.js
+++ b/HybridLocalTemplate/template.js
@@ -97,20 +97,24 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         }
         moveFile('servers.xml', serversNewPath);
 
-        // Advanced Auth (browser-based) redirect intent-filter on the SDK LoginActivity.
-        // Under forceAdvancedAuthentication (default ON) the first interactive login runs in a
-        // browser Custom Tab; the OS delivers the OAuth redirect to LoginActivity.onNewIntent
-        // (launchMode=singleTask), which requires a BROWSABLE <intent-filter> whose <data> matches
-        // the connected app's callback URL. The Cordova-generated manifest ships no such filter,
-        // so inject it here from the callback URL that Package parsed onto config
-        // (config.callbackUrlScheme/Host/Path). Scheme is load-bearing; host is empty for a
-        // hostless callback (never "*") and the SDK reads intent.data directly, ignoring host/path.
+        // Fill in the LoginActivity browser-redirect intent-filter. The CordovaPlugin post-install
+        // hook injects the block with placeholder tokens; substitute the real callback values here
+        // (like every other template type). If the block is missing (older plugin), inject it.
+        // Host is empty for a hostless callback (never "*").
         if (config.callbackurl && config.callbackurl !== '' && config.callbackUrlScheme) {
             var manifestFile = path.join('..', 'platforms', 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
             if (fs.existsSync(manifestFile)) {
                 var manifestContent = fs.readFileSync(manifestFile, 'utf8');
-                if (manifestContent.indexOf('com.salesforce.androidsdk.ui.LoginActivity') === -1) {
+                if (manifestContent.indexOf('com.salesforce.androidsdk.ui.LoginActivity') !== -1) {
+                    // Substitute placeholders in the hook-injected block. The leading slash lives
+                    // outside the path token; config.callbackUrlPath already carries its own.
+                    replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [manifestFile]);
+                    replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', (config.callbackUrlHost || ''), [manifestFile]);
+                    replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', (config.callbackUrlPath || ''), [manifestFile]);
+                } else {
+                    // Fallback: block absent (older plugin). Inject it with real values.
                     var loginActivityBlock =
+                        '        <!-- Salesforce Mobile SDK OAuth redirect (from --callbackurl). -->\n' +
                         '        <activity\n' +
                         '            android:name="com.salesforce.androidsdk.ui.LoginActivity"\n' +
                         '            android:exported="true"\n' +

--- a/HybridLocalTemplate/template.js
+++ b/HybridLocalTemplate/template.js
@@ -96,6 +96,41 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
             moveFile(msdkAndroidPath, msdkAndroidNewPath);
         }
         moveFile('servers.xml', serversNewPath);
+
+        // Advanced Auth (browser-based) redirect intent-filter on the SDK LoginActivity.
+        // Under forceAdvancedAuthentication (default ON) the first interactive login runs in a
+        // browser Custom Tab; the OS delivers the OAuth redirect to LoginActivity.onNewIntent
+        // (launchMode=singleTask), which requires a BROWSABLE <intent-filter> whose <data> matches
+        // the connected app's callback URL. The Cordova-generated manifest ships no such filter,
+        // so inject it here from the callback URL that Package parsed onto config
+        // (config.callbackUrlScheme/Host/Path). Scheme is load-bearing; host is empty for a
+        // hostless callback (never "*") and the SDK reads intent.data directly, ignoring host/path.
+        if (config.callbackurl && config.callbackurl !== '' && config.callbackUrlScheme) {
+            var manifestFile = path.join('..', 'platforms', 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
+            if (fs.existsSync(manifestFile)) {
+                var manifestContent = fs.readFileSync(manifestFile, 'utf8');
+                if (manifestContent.indexOf('com.salesforce.androidsdk.ui.LoginActivity') === -1) {
+                    var loginActivityBlock =
+                        '        <activity\n' +
+                        '            android:name="com.salesforce.androidsdk.ui.LoginActivity"\n' +
+                        '            android:exported="true"\n' +
+                        '            android:launchMode="singleTask"\n' +
+                        '            android:theme="@style/SalesforceSDK">\n' +
+                        '            <intent-filter>\n' +
+                        '                <action android:name="android.intent.action.VIEW" />\n' +
+                        '                <category android:name="android.intent.category.DEFAULT" />\n' +
+                        '                <category android:name="android.intent.category.BROWSABLE" />\n' +
+                        '                <data\n' +
+                        '                    android:scheme="' + config.callbackUrlScheme + '"\n' +
+                        '                    android:host="' + (config.callbackUrlHost || '') + '"\n' +
+                        '                    android:path="' + (config.callbackUrlPath || '') + '" />\n' +
+                        '            </intent-filter>\n' +
+                        '        </activity>\n';
+                    manifestContent = manifestContent.replace(/([ \t]*)<\/application>/, loginActivityBlock + '$1</application>');
+                    fs.writeFileSync(manifestFile, manifestContent, 'utf8');
+                }
+            }
+        }
     }
     removeFile('node_modules');
     removeFile('mobile_sdk');

--- a/HybridRemoteTemplate/template.js
+++ b/HybridRemoteTemplate/template.js
@@ -99,20 +99,24 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         }
         moveFile('servers.xml', serversNewPath);
 
-        // Advanced Auth (browser-based) redirect intent-filter on the SDK LoginActivity.
-        // Under forceAdvancedAuthentication (default ON) the first interactive login runs in a
-        // browser Custom Tab; the OS delivers the OAuth redirect to LoginActivity.onNewIntent
-        // (launchMode=singleTask), which requires a BROWSABLE <intent-filter> whose <data> matches
-        // the connected app's callback URL. The Cordova-generated manifest ships no such filter,
-        // so inject it here from the callback URL that Package parsed onto config
-        // (config.callbackUrlScheme/Host/Path). Scheme is load-bearing; host is empty for a
-        // hostless callback (never "*") and the SDK reads intent.data directly, ignoring host/path.
+        // Fill in the LoginActivity browser-redirect intent-filter. The CordovaPlugin post-install
+        // hook injects the block with placeholder tokens; substitute the real callback values here
+        // (like every other template type). If the block is missing (older plugin), inject it.
+        // Host is empty for a hostless callback (never "*").
         if (config.callbackurl && config.callbackurl !== '' && config.callbackUrlScheme) {
             var manifestFile = path.join('..', 'platforms', 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
             if (fs.existsSync(manifestFile)) {
                 var manifestContent = fs.readFileSync(manifestFile, 'utf8');
-                if (manifestContent.indexOf('com.salesforce.androidsdk.ui.LoginActivity') === -1) {
+                if (manifestContent.indexOf('com.salesforce.androidsdk.ui.LoginActivity') !== -1) {
+                    // Substitute placeholders in the hook-injected block. The leading slash lives
+                    // outside the path token; config.callbackUrlPath already carries its own.
+                    replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [manifestFile]);
+                    replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', (config.callbackUrlHost || ''), [manifestFile]);
+                    replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', (config.callbackUrlPath || ''), [manifestFile]);
+                } else {
+                    // Fallback: block absent (older plugin). Inject it with real values.
                     var loginActivityBlock =
+                        '        <!-- Salesforce Mobile SDK OAuth redirect (from --callbackurl). -->\n' +
                         '        <activity\n' +
                         '            android:name="com.salesforce.androidsdk.ui.LoginActivity"\n' +
                         '            android:exported="true"\n' +

--- a/HybridRemoteTemplate/template.js
+++ b/HybridRemoteTemplate/template.js
@@ -98,6 +98,41 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
             moveFile(msdkAndroidPath, msdkAndroidNewPath);
         }
         moveFile('servers.xml', serversNewPath);
+
+        // Advanced Auth (browser-based) redirect intent-filter on the SDK LoginActivity.
+        // Under forceAdvancedAuthentication (default ON) the first interactive login runs in a
+        // browser Custom Tab; the OS delivers the OAuth redirect to LoginActivity.onNewIntent
+        // (launchMode=singleTask), which requires a BROWSABLE <intent-filter> whose <data> matches
+        // the connected app's callback URL. The Cordova-generated manifest ships no such filter,
+        // so inject it here from the callback URL that Package parsed onto config
+        // (config.callbackUrlScheme/Host/Path). Scheme is load-bearing; host is empty for a
+        // hostless callback (never "*") and the SDK reads intent.data directly, ignoring host/path.
+        if (config.callbackurl && config.callbackurl !== '' && config.callbackUrlScheme) {
+            var manifestFile = path.join('..', 'platforms', 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
+            if (fs.existsSync(manifestFile)) {
+                var manifestContent = fs.readFileSync(manifestFile, 'utf8');
+                if (manifestContent.indexOf('com.salesforce.androidsdk.ui.LoginActivity') === -1) {
+                    var loginActivityBlock =
+                        '        <activity\n' +
+                        '            android:name="com.salesforce.androidsdk.ui.LoginActivity"\n' +
+                        '            android:exported="true"\n' +
+                        '            android:launchMode="singleTask"\n' +
+                        '            android:theme="@style/SalesforceSDK">\n' +
+                        '            <intent-filter>\n' +
+                        '                <action android:name="android.intent.action.VIEW" />\n' +
+                        '                <category android:name="android.intent.category.DEFAULT" />\n' +
+                        '                <category android:name="android.intent.category.BROWSABLE" />\n' +
+                        '                <data\n' +
+                        '                    android:scheme="' + config.callbackUrlScheme + '"\n' +
+                        '                    android:host="' + (config.callbackUrlHost || '') + '"\n' +
+                        '                    android:path="' + (config.callbackUrlPath || '') + '" />\n' +
+                        '            </intent-filter>\n' +
+                        '        </activity>\n';
+                    manifestContent = manifestContent.replace(/([ \t]*)<\/application>/, loginActivityBlock + '$1</application>');
+                    fs.writeFileSync(manifestFile, manifestContent, 'utf8');
+                }
+            }
+        }
     }
     removeFile('node_modules');
     removeFile('mobile_sdk');

--- a/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
+++ b/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
@@ -32,7 +32,7 @@
                 <data
                     android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
                     android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
-                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+                    android:path="/__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
     </application>

--- a/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
+++ b/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
@@ -24,7 +24,7 @@
             android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.SalesforceMobileSDKAndroid">
+            android:theme="@style/SalesforceSDK">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
+++ b/MobileSyncExplorerKotlinTemplate/app/AndroidManifest.xml
@@ -20,6 +20,21 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.SalesforceMobileSDKAndroid">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
+                    android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
+                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/MobileSyncExplorerKotlinTemplate/template.js
+++ b/MobileSyncExplorerKotlinTemplate/template.js
@@ -67,6 +67,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     const templateStringsXmlFile = path.join('app', 'src', 'main', 'res', 'values', 'strings.xml');
     const templateBootconfigFile = path.join('app', 'src', 'main', 'res', 'values', 'bootconfig.xml');
     const templateServersFile = path.join('app', 'src', 'main', 'res', 'xml', 'servers.xml');
+    const templateManifestFile = path.join('app', 'AndroidManifest.xml'); // NON-STANDARD PATH: app/AndroidManifest.xml, NOT app/src/main
     const javaDirPath = path.join('app', 'src', 'main', 'java');
     const ktFiles = listKtFiles(javaDirPath);
 
@@ -88,6 +89,9 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // callback URL
     if (config.callbackurl && config.callbackurl !== '') {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateManifestFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateManifestFile]);
+        replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateManifestFile]);
     }
 
     // login server

--- a/MobileSyncExplorerKotlinTemplate/template.js
+++ b/MobileSyncExplorerKotlinTemplate/template.js
@@ -91,7 +91,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateManifestFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateManifestFile]);
-        replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateManifestFile]);
+        replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateManifestFile]);
     }
 
     // login server

--- a/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
+++ b/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
@@ -56,7 +56,7 @@
                 <data
                     android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
                     android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
-                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+                    android:path="/__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
     </application>

--- a/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
+++ b/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
@@ -48,7 +48,7 @@
             android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+            android:theme="@style/SalesforceSDK">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
+++ b/MobileSyncExplorerReactNative/android/app/src/main/AndroidManifest.xml
@@ -30,36 +30,34 @@
 
         <!-- Login activity -->
         <!--
-            To enable browser based authentication, uncomment the lines below and replace
-            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+            This activity enables browser based authentication. Its intent-filter
+            delivers the OAuth callback Intent from the browser to the SDK LoginActivity.
+            The scheme, host and path below are populated from the connected app's
+            callback URL when the app is generated.
 
             For example, if the callback URL of your connected app is
             "testsfdc:///mobilesdk/detect/oauth/done",
-            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
-            'path' would be "/mobilesdk/detect/oauth/done".
+            'scheme' would be "testsfdc", 'host' would be "" since the URL has no
+            authority, and 'path' would be "/mobilesdk/detect/oauth/done".
 
             If the callback URL is "sfdc://login.salesforce.com/oauth/done",
             'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
             and 'path' would be "/oauth/done".
         -->
-        <!--
         <activity
             android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-
             <intent-filter>
-                <data
-                    android:host="*"
-                    android:path="/mobilesdk/detect/oauth/done"
-                    android:scheme="testsfdc" />
                 <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
+                    android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
+                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
-        -->
     </application>
 </manifest>

--- a/MobileSyncExplorerReactNative/template.js
+++ b/MobileSyncExplorerReactNative/template.js
@@ -164,7 +164,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
-            replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
+            replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
         }
 
         // login server

--- a/MobileSyncExplorerReactNative/template.js
+++ b/MobileSyncExplorerReactNative/template.js
@@ -162,6 +162,9 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         // callback URL
         if (config.callbackurl && config.callbackurl !== '') {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
         }
 
         // login server

--- a/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
@@ -30,36 +30,35 @@
 
         <!-- Login activity -->
         <!--
-            To enable browser based authentication, uncomment the lines below and replace
-            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+            This activity enables browser based authentication. The redirect intent-filter
+            below exists only to deliver the browser callback to the SDK's LoginActivity;
+            the SDK reads the callback data directly and does not match on host/path.
 
-            For example, if the callback URL of your connected app is
-            "testsfdc:///mobilesdk/detect/oauth/done",
-            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
-            'path' would be "/mobilesdk/detect/oauth/done".
+            The scheme, host and path below are populated from your connected app's
+            callback URL during app generation.
+
+            For example, if the callback URL is "testsfdc:///mobilesdk/detect/oauth/done",
+            'scheme' would be "testsfdc", 'host' would be empty ("") since it doesn't exist,
+            and 'path' would be "/mobilesdk/detect/oauth/done".
 
             If the callback URL is "sfdc://login.salesforce.com/oauth/done",
             'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
             and 'path' would be "/oauth/done".
         -->
-        <!--
         <activity
             android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-
             <intent-filter>
-                <data
-                    android:host="*"
-                    android:path="/mobilesdk/detect/oauth/done"
-                    android:scheme="testsfdc" />
                 <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
+                    android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
+                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
-        -->
     </application>
 </manifest>

--- a/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
@@ -57,7 +57,7 @@
                 <data
                     android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
                     android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
-                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+                    android:path="/__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
     </application>

--- a/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeDeferredTemplate/android/app/src/main/AndroidManifest.xml
@@ -49,7 +49,7 @@
             android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+            android:theme="@style/SalesforceSDK">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/ReactNativeDeferredTemplate/template.js
+++ b/ReactNativeDeferredTemplate/template.js
@@ -164,7 +164,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
-            replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
+            replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
         }
 
         // login server

--- a/ReactNativeDeferredTemplate/template.js
+++ b/ReactNativeDeferredTemplate/template.js
@@ -162,6 +162,9 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         // callback URL
         if (config.callbackurl && config.callbackurl !== '') {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
         }
 
         // login server

--- a/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
@@ -30,36 +30,33 @@
 
         <!-- Login activity -->
         <!--
-            To enable browser based authentication, uncomment the lines below and replace
-            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+            This activity delivers the browser-based authentication callback Intent to the
+            SDK LoginActivity. The redirect <intent-filter> is populated from your connected
+            app's callback URL.
 
             For example, if the callback URL of your connected app is
             "testsfdc:///mobilesdk/detect/oauth/done",
-            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
+            'scheme' would be "testsfdc", 'host' would be "" since it doesn't exist, and
             'path' would be "/mobilesdk/detect/oauth/done".
 
             If the callback URL is "sfdc://login.salesforce.com/oauth/done",
             'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
             and 'path' would be "/oauth/done".
         -->
-        <!--
         <activity
             android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-
             <intent-filter>
-                <data
-                    android:host="*"
-                    android:path="/mobilesdk/detect/oauth/done"
-                    android:scheme="testsfdc" />
                 <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
+                    android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
+                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
-        -->
     </application>
 </manifest>

--- a/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
             android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+            android:theme="@style/SalesforceSDK">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTemplate/android/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
                 <data
                     android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
                     android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
-                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+                    android:path="/__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
     </application>

--- a/ReactNativeTemplate/template.js
+++ b/ReactNativeTemplate/template.js
@@ -164,7 +164,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
-            replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
+            replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
         }
 
         // login server

--- a/ReactNativeTemplate/template.js
+++ b/ReactNativeTemplate/template.js
@@ -162,6 +162,9 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         // callback URL
         if (config.callbackurl && config.callbackurl !== '') {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
         }
 
         // login server

--- a/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
@@ -30,36 +30,33 @@
 
         <!-- Login activity -->
         <!--
-            To enable browser based authentication, uncomment the lines below and replace
-            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+            This activity delivers the browser-based authentication callback Intent to the
+            SDK's LoginActivity. The <data> element is populated from your connected app's
+            callback URL scheme, host and path.
 
             For example, if the callback URL of your connected app is
             "testsfdc:///mobilesdk/detect/oauth/done",
-            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
-            'path' would be "/mobilesdk/detect/oauth/done".
+            'scheme' would be "testsfdc", 'host' would be empty ("") since the URL has no
+            authority, and 'path' would be "/mobilesdk/detect/oauth/done".
 
             If the callback URL is "sfdc://login.salesforce.com/oauth/done",
             'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
             and 'path' would be "/oauth/done".
         -->
-        <!--
         <activity
             android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-
             <intent-filter>
-                <data
-                    android:host="*"
-                    android:path="/mobilesdk/detect/oauth/done"
-                    android:scheme="testsfdc" />
                 <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
+                    android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
+                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
-        -->
     </application>
 </manifest>

--- a/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
             android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+            android:theme="@style/SalesforceSDK">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeTypeScriptTemplate/android/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
                 <data
                     android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"
                     android:host="__INSERT_CALLBACK_URL_HOST_HERE__"
-                    android:path="__INSERT_CALLBACK_URL_PATH_HERE__" />
+                    android:path="/__INSERT_CALLBACK_URL_PATH_HERE__" />
             </intent-filter>
         </activity>
     </application>

--- a/ReactNativeTypeScriptTemplate/template.js
+++ b/ReactNativeTypeScriptTemplate/template.js
@@ -164,7 +164,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
-            replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
+            replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
         }
 
         // login server

--- a/ReactNativeTypeScriptTemplate/template.js
+++ b/ReactNativeTypeScriptTemplate/template.js
@@ -162,6 +162,9 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         // callback URL
         if (config.callbackurl && config.callbackurl !== '') {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
+            replaceInFiles('__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);
         }
 
         // login server


### PR DESCRIPTION
## What

Wire the OAuth redirect URI into the generated **Android** app manifest so that, under forced Advanced (browser-based) Authentication (default-ON in Mobile SDK 14.0), the browser redirect is actually delivered back to the app.

Advanced Auth performs login in a Chrome Custom Tab and returns via the app's callback URL. For the OS to deliver that redirect to the app, the SDK `LoginActivity` must declare a redirect `<intent-filter>` whose `<data>` element **mirrors the callback URL** (scheme + host + path). Generated Android apps previously shipped without this filter, so a browser-based login could not complete.

## Changes

- **Native templates** (`AndroidNativeKotlinTemplate`, `AndroidNativeLoginTemplate`, `AndroidIDPTemplate`): activate the SDK `LoginActivity` declaration and add the parameterized redirect `<intent-filter>` with scheme/host/path placeholders. QR-code login guidance preserved.
- **React Native templates** (`ReactNativeTemplate`, `ReactNativeDeferredTemplate`, `ReactNativeTypeScriptTemplate`, `MobileSyncExplorerReactNative`): same manifest change. Also fixed a manifest-merger theme conflict — the SDK `LoginActivity` must use `@style/SalesforceSDK` (matching the SDK library declaration), not `@style/Theme.AppCompat...`, which hard-failed `:app:processDebugMainManifest`.
- **`MobileSyncExplorerKotlinTemplate`**: add the `LoginActivity` declaration (none existed) with the redirect filter.
- **Hybrid templates** (`HybridLocalTemplate`, `HybridRemoteTemplate`): no checked-in manifest, so inject the `LoginActivity` + redirect filter into the Cordova-generated `AndroidManifest.xml` from `template.js prepare()`, guarded on `config.callbackUrlScheme`, idempotent.
- Each `template.js` substitutes the scheme/host/path placeholders from the parsed callback URL.

### `android:path` placeholder ships slash-prefixed

The raw `<data>` line is `android:path="/__INSERT_CALLBACK_URL_PATH_HERE__"`. AAPT rejects any `android:path` that does not begin with `/`, so the **raw** checked-in template must already start with a slash to build (CI builds the template as-is — see Testing). The parsed path (`url.pathname`) already carries its own leading slash, so `template.js` matches the `/`-prefixed token and substitution yields a single-slash path (e.g. `/oauth/done`), never `//oauth/done`. Scheme/host placeholders need no prefix (AAPT accepts them raw).

### Intent-filter design (why mirror the URL, never `*`)

The `<data>` filter mirrors the full callback URL because Android intent-filter matching is a conjunctive subset test — the incoming URI must satisfy **every** attribute the filter declares, so declaring scheme+host+path narrows the filter to exactly this callback. For a **hostless** callback (`scheme:///path`) the host placeholder resolves to the empty string (`android:host=""`), which mirrors the empty authority. It is never `"*"`: `"*"` **is** an Android host wildcard (matches any host, over-broad), whereas `android:host=""` is the correctly-specific mirror.

## Dependency on the Package PR (generation-time, not CI-time)

The scheme/host/path values come from parsed callback-URL config fields (`config.callbackUrlScheme/Host/Path`) populated by the packager. That parsing is added in the companion **SalesforceMobileSDK-Package** PR:

**forcedotcom/SalesforceMobileSDK-Package#341**

**These must ship together** so that apps generated by the CLI get real values substituted into the manifest. Without the Package PR, an app generated by the released CLI would keep the literal placeholder tokens (the app still builds because the path is slash-prefixed — the developer just has to wire the redirect manually).

Note: this repo's CI does **not** exercise that substitution — `test_template.sh` builds the raw checked-in template (`node install.js` → `gradle assembleDebug`) and never runs the packager or `template.js` — so the Package PR is not required for CI here. The dependency is at app-generation time.

## Testing

- **This repo's CI** (`test_template.sh --platform android`) builds each raw checked-in template with `gradle assembleDebug`; the slash-prefixed `android:path` is what lets those raw builds pass AAPT.
- Hybrid generation + build to APK verified via the real CLI path (both hostless and host-bearing callbacks); `aapt2 dump xmltree` confirms the injected filter in the packaged manifest.
- E2E login (real Chrome Custom Tab → redirect returns to app → authenticated) verified via the UITests orchestrator for native_kotlin, hybrid_local, hybrid_remote, and react_native (host-bearing callback shape).

Work item: W-23294087

🤖 Generated with [Claude Code](https://claude.com/claude-code)
