### PR TITLE
Restore opt-in push registration in React Native templates

### DIFF
--- a/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/AppDelegate.swift
+++ b/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Salesforce you will also need to implement the
     // application:didRegisterForRemoteNotificationsWithDeviceToken:
     // method below.
-    registerForRemotePushNotifications()
+    // registerForRemotePushNotifications()
     
     // Uncomment the code below to see how you can customize the color,
     // text color, font and font size of the navigation bar.
@@ -91,7 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   
   func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     // Uncomment the code below to register your device token with the push notification manager
-    didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
+    // didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
   }
   
   private func didRegisterForRemoteNotifications(withDeviceToken deviceToken:Data) {

--- a/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/AppDelegate.swift
+++ b/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Salesforce you will also need to implement the
     // application:didRegisterForRemoteNotificationsWithDeviceToken:
     // method below.
-    registerForRemotePushNotifications()
+    // registerForRemotePushNotifications()
     
     // Uncomment the code below to see how you can customize the color,
     // text color, font and font size of the navigation bar.
@@ -91,7 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   
   func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     // Uncomment the code below to register your device token with the push notification manager
-    didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
+    // didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
   }
   
   private func didRegisterForRemoteNotifications(withDeviceToken deviceToken:Data) {

--- a/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.swift
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Salesforce you will also need to implement the
     // application:didRegisterForRemoteNotificationsWithDeviceToken:
     // method below.
-    registerForRemotePushNotifications()
+    // registerForRemotePushNotifications()
     
     // Uncomment the code below to see how you can customize the color,
     // text color, font and font size of the navigation bar.
@@ -91,7 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   
   func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     // Uncomment the code below to register your device token with the push notification manager
-    didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
+    // didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
   }
   
   private func didRegisterForRemoteNotifications(withDeviceToken deviceToken:Data) {

--- a/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/AppDelegate.swift
+++ b/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Salesforce you will also need to implement the
     // application:didRegisterForRemoteNotificationsWithDeviceToken:
     // method below.
-    registerForRemotePushNotifications()
+    // registerForRemotePushNotifications()
     
     // Uncomment the code below to see how you can customize the color,
     // text color, font and font size of the navigation bar.
@@ -91,7 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   
   func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     // Uncomment the code below to register your device token with the push notification manager
-    didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
+    // didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
   }
   
   private func didRegisterForRemoteNotifications(withDeviceToken deviceToken:Data) {


### PR DESCRIPTION
## What

Restore remote-push registration and device-token forwarding to opt-in behavior in all four React Native iOS templates.

The Swift AppDelegate migration left these calls active even though the surrounding template guidance still instructs developers to uncomment them when enabling push notifications.

## Why

On a fresh iOS simulator, launch-time push registration presents the notification permission alert before Advanced Authentication can present its browser. The React Native UI test consequently times out waiting for the authentication WebView.

This follows [W-23294087](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eHs2PYAS/view) and the failure observed in the [SalesforceMobileSDK-UITests job](https://github.com/forcedotcom/SalesforceMobileSDK-UITests/actions/runs/29111694094/job/86425321445?pr=60).

## Validation

- `./test_template.sh --template MobileSyncExplorerReactNative --platform ios`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home ./test ios MobileSyncExplorerReactNative --ios 26 --templateBranch=brandonpage/fix-react-native-push-registration -p`
  - iOS 26.5, iPhone SE (3rd generation)
  - LoginTest: 1 passed, 0 failed
