### PR TITLE
fix(security): validate Salesforce Record IDs before SOQL/SmartSQL queries in MobileSyncExplorerSwift (W-23604271)

### DIFF
--- a/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SObjects/SObjects.swift
+++ b/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SObjects/SObjects.swift
@@ -31,12 +31,18 @@ import SmartStore
 import MobileSync
 import Combine
 
-// Salesforce Record IDs are exactly 15 or 18 alphanumeric characters.
+// Salesforce Record IDs are exactly 15 or 18 ASCII alphanumeric characters.
 // Enforcing this blocks quote-based injection in SOQL/SmartSQL queries.
 func isValidSalesforceId(_ id: String) -> Bool {
     let len = id.count
     guard len == 15 || len == 18 else { return false }
-    return id.allSatisfy { $0.isLetter || $0.isNumber }
+    return id.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+}
+
+// Soup entry IDs are numeric row identifiers assigned by SmartStore (e.g. "1", "42").
+// Enforcing this blocks injection when a soup entry id is interpolated into SmartSQL.
+func isValidSoupEntryId(_ id: String) -> Bool {
+    return !id.isEmpty && id.allSatisfy { $0 >= "0" && $0 <= "9" }
 }
 
 enum SObjectConstants {
@@ -519,7 +525,7 @@ class SObjectDataManager: ObservableObject {
     }
     
     func localRecord(soupID: String) -> ContactSObjectData? {
-        guard let store = store else {
+        guard let store = store, isValidSoupEntryId(soupID) else {
             return nil
         }
         let queryResult = store.query("select {\(dataSpec.soupName):_soup} from {\(dataSpec.soupName)} where {\(dataSpec.soupName):_soupEntryId} = '\(soupID)'")

--- a/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SObjects/SObjects.swift
+++ b/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SObjects/SObjects.swift
@@ -31,6 +31,14 @@ import SmartStore
 import MobileSync
 import Combine
 
+// Salesforce Record IDs are exactly 15 or 18 alphanumeric characters.
+// Enforcing this blocks quote-based injection in SOQL/SmartSQL queries.
+func isValidSalesforceId(_ id: String) -> Bool {
+    let len = id.count
+    guard len == 15 || len == 18 else { return false }
+    return id.allSatisfy { $0.isLetter || $0.isNumber }
+}
+
 enum SObjectConstants {
     static let kSObjectIdField    = "Id"
 }
@@ -280,6 +288,11 @@ class SObjectDataManager: ObservableObject {
     }
 
     func fetchContact(id: String, completion: @escaping (ContactSObjectData?) -> ()) {
+        guard isValidSalesforceId(id) else {
+            MobileSyncLogger.e(SObjectDataManager.self, message: "fetchContact: invalid id rejected")
+            completion(nil)
+            return
+        }
         let request = RestClient.shared.request(forQuery: "SELECT Id, FirstName, LastName, Title, MobilePhone, Email, Department, HomePhone FROM Contact WHERE Id = '\(id)'", apiVersion: nil)
         RestClient.shared.publisher(for: request)
             .receive(on: RunLoop.main)
@@ -488,7 +501,7 @@ class SObjectDataManager: ObservableObject {
     }
 
     private func localRecord(id: String) -> [String: Any]? {
-        guard let store = store else {
+        guard let store = store, isValidSalesforceId(id) else {
             return nil
         }
         let queryResult = store.query("select {\(dataSpec.soupName):_soup} from {\(dataSpec.soupName)} where {\(dataSpec.soupName):Id} = '\(id)'")

--- a/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SceneDelegate.swift
+++ b/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SceneDelegate.swift
@@ -64,6 +64,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             self.window?.rootViewController = UIHostingController(rootView: ContactListView(sObjectManager: sObjectManager, newContact: true))
         } else if let contactRange = url.absoluteString.range(of: "contact/") {
             let id = String(url.absoluteString[contactRange.upperBound...])
+            guard isValidSalesforceId(id) else { return }
             self.window?.rootViewController = UIHostingController(rootView: NavigationStack {
                 ContactDetailView(localId: id, sObjectDataManager: sObjectManager)
             })
@@ -91,7 +92,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let sObjectManager = SObjectDataManager.sharedInstance(for: UserAccountManager.shared.currentUserAccount!)
 
         if let userActivity = userActivity, userActivity.title == openDetailPath,
-           let selectionId = userActivity.userInfo?[openDetailRecordIdKey] as? String {
+           let selectionId = userActivity.userInfo?[openDetailRecordIdKey] as? String,
+           isValidSalesforceId(selectionId) {
             self.window?.rootViewController = UIHostingController(rootView:  NavigationStack {
                 ContactDetailView(localId: selectionId, sObjectDataManager: sObjectManager)
             })

--- a/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SceneDelegate.swift
+++ b/MobileSyncExplorerSwift/MobileSyncExplorerSwift/SceneDelegate.swift
@@ -64,7 +64,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             self.window?.rootViewController = UIHostingController(rootView: ContactListView(sObjectManager: sObjectManager, newContact: true))
         } else if let contactRange = url.absoluteString.range(of: "contact/") {
             let id = String(url.absoluteString[contactRange.upperBound...])
-            guard isValidSalesforceId(id) else { return }
+            guard isValidSoupEntryId(id) else { return }
             self.window?.rootViewController = UIHostingController(rootView: NavigationStack {
                 ContactDetailView(localId: id, sObjectDataManager: sObjectManager)
             })
@@ -93,7 +93,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         if let userActivity = userActivity, userActivity.title == openDetailPath,
            let selectionId = userActivity.userInfo?[openDetailRecordIdKey] as? String,
-           isValidSalesforceId(selectionId) {
+           isValidSoupEntryId(selectionId) {
             self.window?.rootViewController = UIHostingController(rootView:  NavigationStack {
                 ContactDetailView(localId: selectionId, sObjectDataManager: sObjectManager)
             })

--- a/MobileSyncExplorerSwift/MobileSyncExplorerSwift/UI/Notifications/NotificationList.swift
+++ b/MobileSyncExplorerSwift/MobileSyncExplorerSwift/UI/Notifications/NotificationList.swift
@@ -54,7 +54,7 @@ struct ListView: View {
         List {
             ForEach(model.notifications, id: \.id) { notification in
                 VStack {
-                    if notification.targetId.starts(with: "003") { // Only contacts are tappable
+                    if notification.targetId.starts(with: "003") && isValidSalesforceId(notification.targetId) { // Only contacts are tappable
                         NavigationLink(destination: ContactDetailView(id: notification.targetId, sObjectDataManager: self.sObjectDataManager, onAppear: {
                             self.model.markNotificationRead(notificationId: notification.id)
                         })) {


### PR DESCRIPTION
## Summary

- Adds `isValidSalesforceId()` — enforces that IDs are exactly 15 or 18 alphanumeric characters before they reach any query
- Guards `fetchContact(id:)` and `localRecord(id:)` in `SObjects.swift` at the query layer (defense-in-depth)
- Guards all three external entry points: notification `targetId` (`NotificationList.swift`), URL scheme deep-link, and `NSUserActivity` handoff (`SceneDelegate.swift`)

Fixes SOQL/SmartSQL injection via unsanitized `targetId` from the Salesforce in-app notification API (W-23604271).

## Test plan

- [ ] Build succeeds with no errors
- [ ] Normal contact tap from notification list opens the contact detail view
- [ ] Normal contact deep-link via URL scheme opens the contact detail view
- [ ] Malformed `targetId` (e.g. containing quotes or SQL keywords) is silently rejected — notification cell rendered as non-tappable, deep-link ignored
- [ ] Locally-created contacts (no Salesforce ID yet) still load correctly via `localRecord(soupID:)` — unaffected by this change