### PR TITLE
[Templates][Android] presentOptInDialog call fails to compile — method removed from BiometricAuthenticationManager

### DIFF
--- a/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/MainActivity.kt
+++ b/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/MainActivity.kt
@@ -26,13 +26,9 @@
  */
 package com.salesforce.androidnativelogintemplate
 
-import androidx.biometric.BiometricManager
-import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
-import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import android.os.Bundle
-import android.service.autofill.Validators.or
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
@@ -104,20 +100,6 @@ class MainActivity : SalesforceActivity() {
 
         // Show everything
         findViewById<ViewGroup>(R.id.root).visibility = View.VISIBLE
-    }
-
-    override fun onPostResume() {
-        super.onPostResume()
-
-        // Check if we should prompt for biometric opt-in
-        val deviceHasBiometrics = BiometricManager.from(this).canAuthenticate(
-            /* authenticators = */ BIOMETRIC_STRONG or BIOMETRIC_WEAK
-        ) == BiometricManager.BIOMETRIC_SUCCESS
-        MobileSyncSDKManager.getInstance().biometricAuthenticationManager?.run {
-            if (enabled && deviceHasBiometrics && !hasBiometricOptedIn()) {
-                presentOptInDialog(supportFragmentManager)
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
## Summary

`AndroidNativeLoginTemplate` fails to compile because `BiometricAuthenticationManager.presentOptInDialog(FragmentManager)` was removed upstream in `SalesforceMobileSDK-Android` — the SDK now auto-presents the biometric opt-in dialog during login instead, so no replacement call is needed.

- Removed the `onPostResume()` override in `MainActivity.kt` that called it, plus its now-unused imports (including a stray `android.service.autofill.Validators.or` that was shadowing Kotlin's `Int.or`)
- Confirmed via repo-wide grep this is the only affected template; `NativeLogin.kt`'s biometric code uses the separate, unaffected `presentBiometricAuth` login/unlock API

**Note for reviewers:** a generated build of this template may still fail on an unrelated, separately-tracked `logout()` signature change in the same file — not a regression from this PR.

## Test plan

- [x] `./gradlew assembleDebug` succeeds locally against current `SalesforceMobileSDK-Android` `dev`
- [ ] Automatic opt-in dialog visually confirmed on a biometric-capable device (not available in this environment; confirmed via SDK source that the flow needs no app-side hook)

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*