### PR TITLE
[Templates][Android] Manifest intent-filter substituted with literal "undefined" when no OAuth flags provided

### DIFF
--- a/AndroidIDPTemplate/template.js
+++ b/AndroidIDPTemplate/template.js
@@ -68,6 +68,8 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // callback URL
     if (config.callbackurl && config.callbackurl !== '') {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+    }
+    if (config.callbackUrlScheme) {
         replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
         replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);

--- a/AndroidNativeKotlinTemplate/template.js
+++ b/AndroidNativeKotlinTemplate/template.js
@@ -70,6 +70,8 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // callback URL
     if (config.callbackurl && config.callbackurl !== '') {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+    }
+    if (config.callbackUrlScheme) {
         replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
         replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);

--- a/AndroidNativeLoginTemplate/template.js
+++ b/AndroidNativeLoginTemplate/template.js
@@ -70,6 +70,8 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // callback URL
     if (config.callbackurl && config.callbackurl !== '') {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+    }
+    if (config.callbackUrlScheme) {
         replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
         replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);

--- a/MobileSyncExplorerKotlinTemplate/template.js
+++ b/MobileSyncExplorerKotlinTemplate/template.js
@@ -89,6 +89,8 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // callback URL
     if (config.callbackurl && config.callbackurl !== '') {
         replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+    }
+    if (config.callbackUrlScheme) {
         replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateManifestFile]);
         replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateManifestFile]);
         replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateManifestFile]);

--- a/MobileSyncExplorerReactNative/template.js
+++ b/MobileSyncExplorerReactNative/template.js
@@ -162,6 +162,8 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         // callback URL
         if (config.callbackurl && config.callbackurl !== '') {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+        }
+        if (config.callbackUrlScheme) {
             replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
             replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);

--- a/ReactNativeDeferredTemplate/template.js
+++ b/ReactNativeDeferredTemplate/template.js
@@ -162,6 +162,8 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         // callback URL
         if (config.callbackurl && config.callbackurl !== '') {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+        }
+        if (config.callbackUrlScheme) {
             replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
             replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);

--- a/ReactNativeTemplate/template.js
+++ b/ReactNativeTemplate/template.js
@@ -162,6 +162,8 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         // callback URL
         if (config.callbackurl && config.callbackurl !== '') {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+        }
+        if (config.callbackUrlScheme) {
             replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
             replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);

--- a/ReactNativeTypeScriptTemplate/template.js
+++ b/ReactNativeTypeScriptTemplate/template.js
@@ -162,6 +162,8 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
         // callback URL
         if (config.callbackurl && config.callbackurl !== '') {
             replaceInFiles('__INSERT_CALLBACK_URL_HERE__', config.callbackurl, [templateBootconfigFile]);
+        }
+        if (config.callbackUrlScheme) {
             replaceInFiles('__INSERT_CALLBACK_URL_SCHEME_HERE__', config.callbackUrlScheme, [templateAndroidManifestFile]);
             replaceInFiles('__INSERT_CALLBACK_URL_HOST_HERE__', config.callbackUrlHost, [templateAndroidManifestFile]);
             replaceInFiles('/__INSERT_CALLBACK_URL_PATH_HERE__', config.callbackUrlPath, [templateAndroidManifestFile]);


### PR DESCRIPTION
## Summary

- When no `--consumerkey`/`--callbackurl` are supplied, the CLI's `createHelper.js` correctly leaves `config.callbackUrlScheme`/`Host`/`Path` as `undefined` (only its placeholder defaults are present). This repo's Android and React Native `template.js` files guarded the manifest scheme/host/path substitution on the broader `config.callbackurl && config.callbackurl !== ''` check, which stays true for the CLI's placeholder value — so `String.prototype.replace` coerced `undefined` into the literal text `"undefined"` in the generated `AndroidManifest.xml`, breaking AAPT builds.
- Splits the manifest substitution out from the bootconfig substitution in each of the 8 affected files, gating the manifest scheme/host/path replacements on `config.callbackUrlScheme` truthiness instead — matching the pattern `HybridLocalTemplate`/`HybridRemoteTemplate` already use. The bootconfig substitution keeps its original broader guard, unaffected by this change.
- Affected files: `AndroidNativeKotlinTemplate`, `AndroidNativeLoginTemplate`, `AndroidIDPTemplate`, `MobileSyncExplorerKotlinTemplate`, `ReactNativeTemplate`, `ReactNativeTypeScriptTemplate`, `ReactNativeDeferredTemplate`, `MobileSyncExplorerReactNative`.

## Test plan

- [x] `node -e "require('./<Template>/template.js')"` for all 8 edited files — loads without syntax errors
- [x] Simulated `AndroidNativeKotlinTemplate/template.js`'s `prepare()` with placeholder-only OAuth config (mirroring the CLI's no-flags-provided case) and a stubbed `replaceInFiles` — confirmed no call receives an `undefined` replacement value
- [ ] End-to-end app generation + AAPT/Gradle build verification across all 8 affected templates (to be run separately)

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*