### PR TITLE
Target API 37 in React Native templates

### DIFF
--- a/MobileSyncExplorerReactNative/android/build.gradle
+++ b/MobileSyncExplorerReactNative/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 31
-        compileSdkVersion = 36
-        targetSdkVersion = 36
+        compileSdkVersion = 37
+        targetSdkVersion = 37
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.3.20"
     }

--- a/ReactNativeDeferredTemplate/android/build.gradle
+++ b/ReactNativeDeferredTemplate/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 31
-        compileSdkVersion = 36
-        targetSdkVersion = 36
+        compileSdkVersion = 37
+        targetSdkVersion = 37
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.3.20"
     }

--- a/ReactNativeTemplate/android/build.gradle
+++ b/ReactNativeTemplate/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 31
-        compileSdkVersion = 36
-        targetSdkVersion = 36
+        compileSdkVersion = 37
+        targetSdkVersion = 37
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.3.20"
     }

--- a/ReactNativeTypeScriptTemplate/android/build.gradle
+++ b/ReactNativeTypeScriptTemplate/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 31
-        compileSdkVersion = 36
-        targetSdkVersion = 36
+        compileSdkVersion = 37
+        targetSdkVersion = 37
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.3.20"
     }


### PR DESCRIPTION
## Summary
- update the React Native, TypeScript, deferred-login, and MobileSync Explorer React Native templates to compile with API 37
- update the same templates to target API 37

## Testing
- ./test_template.sh --template ReactNativeTemplate --platform android
- ./test_template.sh --template ReactNativeTypeScriptTemplate --platform android
- ./test_template.sh --template ReactNativeDeferredTemplate --platform android
- ./test_template.sh --template MobileSyncExplorerReactNative --platform android