### PR TITLE
[MSDK Android Templates] AndroidNativeLoginTemplate: OTP/Registration/Reset-Password buttons never render due to reCAPTCHA client-init race

### DIFF
--- a/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/MainApplication.kt
+++ b/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/MainApplication.kt
@@ -27,6 +27,11 @@
 package com.salesforce.androidnativelogintemplate
 
 import android.app.Application
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.google.android.material.color.DynamicColors
 import com.google.android.recaptcha.Recaptcha
 import com.google.android.recaptcha.RecaptchaAction
@@ -112,10 +117,16 @@ class MainApplication : Application() {
         // region Google reCAPTCHA Integration
 
         /** The reCAPTCHA client used to obtain reCAPTCHA tokens when needed for Salesforce Headless Identity API requests. */
-        private var recaptchaClient: RecaptchaClient? = null
+        private var recaptchaClient: RecaptchaClient? by mutableStateOf(null)
 
-        /** Whether reCAPTCHA has been configured and is available for use. */
-        val isReCaptchaEnabled: Boolean get() = recaptchaClient != null
+        /**
+         * Whether reCAPTCHA has been configured and is available for use.
+         * Derived from Compose state so observers recompose once client
+         * initialization finishes asynchronously, rather than reading a
+         * one-time snapshot at first composition.
+         */
+        val isReCaptchaEnabledState: State<Boolean> =
+            derivedStateOf { recaptchaClient != null }
 
         /**
          * Initializes the Google reCAPTCHA client.

--- a/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/NativeLogin.kt
+++ b/AndroidNativeLoginTemplate/app/src/main/java/com/salesforce/androidnativelogintemplate/NativeLogin.kt
@@ -198,7 +198,7 @@ class NativeLogin : FragmentActivity() {
                             }
                         },
                         biometricAuthenticationUsername = bioUsername,
-                        reCaptchaEnabled = MainApplication.isReCaptchaEnabled,
+                        reCaptchaEnabled = MainApplication.isReCaptchaEnabledState.value,
                         onBiometricLogin = if (shouldShowBiometricPrompt) {
                             { nativeLoginManager.presentBiometricAuth(this@NativeLogin) }
                         } else null,


### PR DESCRIPTION
## Summary
`MainApplication.isReCaptchaEnabled` was a plain synchronous getter, read once by `NativeLogin.kt`'s Composable at first composition. The reCAPTCHA client populates asynchronously (unawaited coroutine, real network round trip), so the read loses the race on effectively every cold launch and the "Use One Time Password Instead," "Register," and "Reset Password" buttons never render, even though the client succeeds moments later.

## Fix
- `recaptchaClient` is now itself Compose-observable (`by mutableStateOf(null)`).
- `isReCaptchaEnabledState` is derived from it (`derivedStateOf { recaptchaClient != null }`) as a single, read-only source of truth — no separate flag to keep in sync.
- `NativeLogin.kt` reads `isReCaptchaEnabledState.value` instead of the old one-time snapshot, so Compose recomposes once the client finishes initializing.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` succeeds against a real `SalesforceMobileSDK-Android` source dependency
- [x] Local Android Studio review of the diff completed by the operator
- [x] End-to-end verification of button visibility against reCAPTCHA Enterprise on an emulator (separate session/orchestrator)

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*
