### PR TITLE
Fix React Native template startup on iOS 27

### DIFF
--- a/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative.xcodeproj/project.pbxproj
+++ b/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		B77BD8B1211363F70036B284 /* bootconfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = B77BD8B0211363F70036B284 /* bootconfig.plist */; };
 		CE6BC3F620F12070009E4AAE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F3AFF441DC2C8C8006FF6B0 /* Images.xcassets */; };
 		D3349D372DFBCE49000F6F3D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3349D362DFBCE49000F6F3D /* AppDelegate.swift */; };
+		F5413AC12F61A00100E52D27 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5413AC02F61A00100E52D27 /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		B77BD8B0211363F70036B284 /* bootconfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = bootconfig.plist; path = MobileSyncExplorerReactNative/bootconfig.plist; sourceTree = "<group>"; };
 		CE46D5431E9C942C006E6537 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		D3349D362DFBCE49000F6F3D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = MobileSyncExplorerReactNative/AppDelegate.swift; sourceTree = "<group>"; };
+		F5413AC02F61A00100E52D27 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = MobileSyncExplorerReactNative/SceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +70,7 @@
 			isa = PBXGroup;
 			children = (
 				D3349D362DFBCE49000F6F3D /* AppDelegate.swift */,
+				F5413AC02F61A00100E52D27 /* SceneDelegate.swift */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -272,6 +275,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3349D372DFBCE49000F6F3D /* AppDelegate.swift in Sources */,
+				F5413AC12F61A00100E52D27 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/AppDelegate.swift
+++ b/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/AppDelegate.swift
@@ -10,7 +10,6 @@ import UserNotificationsUI
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  var window: UIWindow?
   
   var reactNativeDelegate: ReactNativeDelegate?
   var reactNativeFactory: RCTReactNativeFactory?
@@ -35,8 +34,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     reactNativeDelegate = delegate
     reactNativeFactory = factory
     
-    window = UIWindow(frame: UIScreen.main.bounds)
-    
     // If you wish to register for push notifications uncomment the line
     // below.  Note that if you want to receive push notifications from
     // Salesforce you will also need to implement the
@@ -48,15 +45,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // text color, font and font size of the navigation bar.
     customizeLoginView()
     
-    AuthHelper.loginIfRequired() {
+    return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+
+  func startReactNative(in window: UIWindow, scene: UIScene) {
+    guard let factory = reactNativeFactory else { return }
+    let launchOptions = launchOptions
+
+    AuthHelper.loginIfRequired(scene) {
       factory.startReactNative(
         withModuleName: "MobileSyncExplorerReactNative",
-        in: self.window,
+        in: window,
         launchOptions: launchOptions
       )
     }
-    
-    return true
   }
   
   private func registerForRemotePushNotifications() {

--- a/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/Info.plist
+++ b/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/Info.plist
@@ -39,6 +39,23 @@
 	<true/>
 	<key>SFDCOAuthLoginHost</key>
 	<string>__INSERT_DEFAULT_LOGIN_SERVER__</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>MaterialIcons.ttf</string>

--- a/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/SceneDelegate.swift
+++ b/MobileSyncExplorerReactNative/ios/MobileSyncExplorerReactNative/SceneDelegate.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else { return }
+
+    let window = UIWindow(windowScene: windowScene)
+    self.window = window
+
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+    appDelegate.startReactNative(in: window, scene: scene)
+  }
+}

--- a/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate.xcodeproj/project.pbxproj
+++ b/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C533827A9B18EA3D06F3253F /* Pods_ReactNativeDeferredTemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 117C4F7DD8AE72D6A18A2028 /* Pods_ReactNativeDeferredTemplate.framework */; };
 		CEA8CA061F071C3300448B51 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEA8CA051F071C3300448B51 /* Images.xcassets */; };
 		D3290F0F2DFB617F0095B81E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3290F0E2DFB617F0095B81E /* AppDelegate.swift */; };
+		F5413AA12F61A00100E52D27 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5413AA02F61A00100E52D27 /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +28,7 @@
 		B77BD8AE2113632C0036B284 /* bootconfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = bootconfig.plist; path = ReactNativeDeferredTemplate/bootconfig.plist; sourceTree = "<group>"; };
 		CEA8CA051F071C3300448B51 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../mobile_sdk/SalesforceMobileSDK-iOS/shared/resources/Images.xcassets"; sourceTree = "<group>"; };
 		D3290F0E2DFB617F0095B81E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = ReactNativeDeferredTemplate/AppDelegate.swift; sourceTree = "<group>"; };
+		F5413AA02F61A00100E52D27 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = ReactNativeDeferredTemplate/SceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +57,7 @@
 			isa = PBXGroup;
 			children = (
 				D3290F0E2DFB617F0095B81E /* AppDelegate.swift */,
+				F5413AA02F61A00100E52D27 /* SceneDelegate.swift */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -258,6 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3290F0F2DFB617F0095B81E /* AppDelegate.swift in Sources */,
+				F5413AA12F61A00100E52D27 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/AppDelegate.swift
+++ b/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/AppDelegate.swift
@@ -10,7 +10,6 @@ import UserNotificationsUI
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  var window: UIWindow?
   
   var reactNativeDelegate: ReactNativeDelegate?
   var reactNativeFactory: RCTReactNativeFactory?
@@ -35,8 +34,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     reactNativeDelegate = delegate
     reactNativeFactory = factory
     
-    window = UIWindow(frame: UIScreen.main.bounds)
-    
     // If you wish to register for push notifications uncomment the line
     // below.  Note that if you want to receive push notifications from
     // Salesforce you will also need to implement the
@@ -48,15 +45,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // text color, font and font size of the navigation bar.
     customizeLoginView()
     
-    AuthHelper.loginIfRequired() {
+    return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+
+  func startReactNative(in window: UIWindow, scene: UIScene) {
+    guard let factory = reactNativeFactory else { return }
+    let launchOptions = launchOptions
+
+    AuthHelper.loginIfRequired(scene) {
       factory.startReactNative(
         withModuleName: "ReactNativeDeferredTemplate",
-        in: self.window,
+        in: window,
         launchOptions: launchOptions
       )
     }
-    
-    return true
   }
   
   private func registerForRemotePushNotifications() {

--- a/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/Info.plist
+++ b/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/Info.plist
@@ -39,6 +39,23 @@
 	<true/>
 	<key>SFDCOAuthLoginHost</key>
 	<string>__INSERT_DEFAULT_LOGIN_SERVER__</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/SceneDelegate.swift
+++ b/ReactNativeDeferredTemplate/ios/ReactNativeDeferredTemplate/SceneDelegate.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else { return }
+
+    let window = UIWindow(windowScene: windowScene)
+    self.window = window
+
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+    appDelegate.startReactNative(in: window, scene: scene)
+  }
+}

--- a/ReactNativeTemplate/ios/ReactNativeTemplate.xcodeproj/project.pbxproj
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C955C9F2B54461750DCC56B1 /* Pods_ReactNativeTemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 070C882A5C716392B7B11A01 /* Pods_ReactNativeTemplate.framework */; };
 		CEA8CA061F071C3300448B51 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEA8CA051F071C3300448B51 /* Images.xcassets */; };
 		D32109E02DFA158700A206F1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32109DF2DFA158700A206F1 /* AppDelegate.swift */; };
+		F5413A912F61A00100E52D27 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5413A902F61A00100E52D27 /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +28,7 @@
 		B77BD8AE2113632C0036B284 /* bootconfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = bootconfig.plist; path = ReactNativeTemplate/bootconfig.plist; sourceTree = "<group>"; };
 		CEA8CA051F071C3300448B51 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../mobile_sdk/SalesforceMobileSDK-iOS/shared/resources/Images.xcassets"; sourceTree = "<group>"; };
 		D32109DF2DFA158700A206F1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = ReactNativeTemplate/AppDelegate.swift; sourceTree = "<group>"; };
+		F5413A902F61A00100E52D27 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = ReactNativeTemplate/SceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +57,7 @@
 			isa = PBXGroup;
 			children = (
 				D32109DF2DFA158700A206F1 /* AppDelegate.swift */,
+				F5413A902F61A00100E52D27 /* SceneDelegate.swift */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -258,6 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D32109E02DFA158700A206F1 /* AppDelegate.swift in Sources */,
+				F5413A912F61A00100E52D27 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.swift
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate/AppDelegate.swift
@@ -10,7 +10,6 @@ import UserNotificationsUI
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  var window: UIWindow?
   
   var reactNativeDelegate: ReactNativeDelegate?
   var reactNativeFactory: RCTReactNativeFactory?
@@ -35,8 +34,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     reactNativeDelegate = delegate
     reactNativeFactory = factory
     
-    window = UIWindow(frame: UIScreen.main.bounds)
-    
     // If you wish to register for push notifications uncomment the line
     // below.  Note that if you want to receive push notifications from
     // Salesforce you will also need to implement the
@@ -48,15 +45,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // text color, font and font size of the navigation bar.
     customizeLoginView()
     
-    AuthHelper.loginIfRequired() {
+    return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+
+  func startReactNative(in window: UIWindow, scene: UIScene) {
+    guard let factory = reactNativeFactory else { return }
+    let launchOptions = launchOptions
+
+    AuthHelper.loginIfRequired(scene) {
       factory.startReactNative(
         withModuleName: "ReactNativeTemplate",
-        in: self.window,
+        in: window,
         launchOptions: launchOptions
       )
     }
-    
-    return true
   }
   
   private func registerForRemotePushNotifications() {

--- a/ReactNativeTemplate/ios/ReactNativeTemplate/Info.plist
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate/Info.plist
@@ -39,6 +39,23 @@
 	<true/>
 	<key>SFDCOAuthLoginHost</key>
 	<string>__INSERT_DEFAULT_LOGIN_SERVER__</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ReactNativeTemplate/ios/ReactNativeTemplate/SceneDelegate.swift
+++ b/ReactNativeTemplate/ios/ReactNativeTemplate/SceneDelegate.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else { return }
+
+    let window = UIWindow(windowScene: windowScene)
+    self.window = window
+
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+    appDelegate.startReactNative(in: window, scene: scene)
+  }
+}

--- a/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate.xcodeproj/project.pbxproj
+++ b/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		BDDADCA1A0B90A26BAEB44DA /* Pods_ReactNativeTypeScriptTemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8770B5CCD5CCB2246FCA5CC5 /* Pods_ReactNativeTypeScriptTemplate.framework */; };
 		CEA8CA061F071C3300448B51 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEA8CA051F071C3300448B51 /* Images.xcassets */; };
 		D3290F0D2DFB60230095B81E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3290F0C2DFB60230095B81E /* AppDelegate.swift */; };
+		F5413AB12F61A00100E52D27 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5413AB02F61A00100E52D27 /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +28,7 @@
 		B77BD8AE2113632C0036B284 /* bootconfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = bootconfig.plist; path = ReactNativeTypeScriptTemplate/bootconfig.plist; sourceTree = "<group>"; };
 		CEA8CA051F071C3300448B51 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../mobile_sdk/SalesforceMobileSDK-iOS/shared/resources/Images.xcassets"; sourceTree = "<group>"; };
 		D3290F0C2DFB60230095B81E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = ReactNativeTypeScriptTemplate/AppDelegate.swift; sourceTree = "<group>"; };
+		F5413AB02F61A00100E52D27 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = ReactNativeTypeScriptTemplate/SceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +57,7 @@
 			isa = PBXGroup;
 			children = (
 				D3290F0C2DFB60230095B81E /* AppDelegate.swift */,
+				F5413AB02F61A00100E52D27 /* SceneDelegate.swift */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -258,6 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3290F0D2DFB60230095B81E /* AppDelegate.swift in Sources */,
+				F5413AB12F61A00100E52D27 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/AppDelegate.swift
+++ b/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/AppDelegate.swift
@@ -10,7 +10,6 @@ import UserNotificationsUI
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  var window: UIWindow?
   
   var reactNativeDelegate: ReactNativeDelegate?
   var reactNativeFactory: RCTReactNativeFactory?
@@ -35,8 +34,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     reactNativeDelegate = delegate
     reactNativeFactory = factory
     
-    window = UIWindow(frame: UIScreen.main.bounds)
-    
     // If you wish to register for push notifications uncomment the line
     // below.  Note that if you want to receive push notifications from
     // Salesforce you will also need to implement the
@@ -48,15 +45,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // text color, font and font size of the navigation bar.
     customizeLoginView()
     
-    AuthHelper.loginIfRequired() {
+    return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+
+  func startReactNative(in window: UIWindow, scene: UIScene) {
+    guard let factory = reactNativeFactory else { return }
+    let launchOptions = launchOptions
+
+    AuthHelper.loginIfRequired(scene) {
       factory.startReactNative(
         withModuleName: "ReactNativeTypeScriptTemplate",
-        in: self.window,
+        in: window,
         launchOptions: launchOptions
       )
     }
-    
-    return true
   }
   
   private func registerForRemotePushNotifications() {

--- a/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/Info.plist
+++ b/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/Info.plist
@@ -39,6 +39,23 @@
 	<true/>
 	<key>SFDCOAuthLoginHost</key>
 	<string>__INSERT_DEFAULT_LOGIN_SERVER__</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/SceneDelegate.swift
+++ b/ReactNativeTypeScriptTemplate/ios/ReactNativeTypeScriptTemplate/SceneDelegate.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else { return }
+
+    let window = UIWindow(windowScene: windowScene)
+    self.window = window
+
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+    appDelegate.startReactNative(in: window, scene: scene)
+  }
+}


### PR DESCRIPTION
## Summary

- adopt the UIKit scene lifecycle in all four React Native templates
- create each app window from its connected scene
- perform scene-aware Salesforce authentication before starting React Native
- keep process-level SDK initialization and notification callbacks in AppDelegate

## Testing

- `test_template.sh` passed for all four templates with Xcode 27.0 (27A5252f)
- all four generated workspaces built with Xcode 26.6 (17F113)
- `ReactNativeTemplate`, `ReactNativeTypeScriptTemplate`, and `MobileSyncExplorerReactNative` each launched successfully in the full matrix:
  - Xcode 26 build on iOS 26
  - Xcode 26 build on iOS 27
  - Xcode 27 build on iOS 26
  - Xcode 27 build on iOS 27
- every non-deferred launch stayed alive beyond the original crash window and displayed the configured Salesforce login page
- `ReactNativeDeferredTemplate` launched on iOS 27 with Metro running and displayed its expected RN guest screen; it builds with both Xcode versions
- no matching crash reports were produced
- `git diff --check` and plist/project lint passed
